### PR TITLE
Fix whitespace in  PARTITION BY clause 

### DIFF
--- a/pkg/diff/schema_migration_plan_test.go
+++ b/pkg/diff/schema_migration_plan_test.go
@@ -396,6 +396,45 @@ var (
 			},
 		},
 		{
+			name:      "Create partitioned table",
+			oldSchema: schema.Schema{},
+			newSchema: schema.Schema{
+				Tables: []schema.Table{
+					{
+						Name: "foobar",
+						Columns: []schema.Column{
+							{Name: "id", Type: "integer"},
+							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
+						},
+						PartitionKeyDef: "LIST(foo)",
+					},
+					{
+						ParentTableName: "foobar",
+						Name:            "foobar_1",
+						Columns: []schema.Column{
+							{Name: "id", Type: "integer"},
+							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
+						},
+						ForValues: "FOR VALUES IN ('some_val')",
+					},
+				},
+			},
+			expectedStatements: []Statement{
+				{
+					DDL:     "CREATE TABLE \"foobar\" (\n\t\"id\" integer NOT NULL,\n\t\"foo\" character varying(255) COLLATE \"pg_catalog\".\"default\" NOT NULL DEFAULT ''::character varying\n) PARTITION BY LIST(foo)",
+					Timeout: statementTimeoutDefault,
+				},
+				{
+					DDL:     "CREATE TABLE \"foobar_1\" (\n\t\"id\" integer NOT NULL,\n\t\"foo\" character varying(255) COLLATE \"pg_catalog\".\"default\" NOT NULL DEFAULT ''::character varying\n)",
+					Timeout: statementTimeoutDefault,
+				},
+				{
+					DDL:     "ALTER TABLE \"foobar\" ATTACH PARTITION \"foobar_1\" FOR VALUES IN ('some_val')",
+					Timeout: statementTimeoutDefault,
+				},
+			},
+		},
+		{
 			name: "Index replacement on partitioned table",
 			oldSchema: schema.Schema{
 				Tables: []schema.Table{

--- a/pkg/diff/schema_migration_plan_test.go
+++ b/pkg/diff/schema_migration_plan_test.go
@@ -446,7 +446,7 @@ var (
 							{Name: "bar", Type: "timestamp without time zone", IsNullable: true, Default: "CURRENT_TIMESTAMP"},
 						},
 						CheckConstraints: nil,
-						PartitionKeyDef:  "PARTITION BY LIST(foo)",
+						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
 						ParentTableName: "foobar",
@@ -522,7 +522,7 @@ var (
 							{Name: "bar", Type: "timestamp without time zone", IsNullable: true, Default: "CURRENT_TIMESTAMP"},
 						},
 						CheckConstraints: nil,
-						PartitionKeyDef:  "PARTITION BY LIST(foo)",
+						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
 						ParentTableName: "foobar",
@@ -701,7 +701,7 @@ var (
 							{Name: "bar", Type: "timestamp without time zone", IsNullable: true, Default: "CURRENT_TIMESTAMP"},
 						},
 						CheckConstraints: nil,
-						PartitionKeyDef:  "PARTITION BY LIST(foo)",
+						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
 						ParentTableName: "foobar",
@@ -754,7 +754,7 @@ var (
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
 						},
 						CheckConstraints: nil,
-						PartitionKeyDef:  "PARTITION BY LIST(foo)",
+						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
 						ParentTableName: "foobar",
@@ -819,7 +819,7 @@ var (
 							{Name: "bar", Type: "timestamp without time zone", IsNullable: true, Default: "CURRENT_TIMESTAMP"},
 						},
 						CheckConstraints: nil,
-						PartitionKeyDef:  "PARTITION BY LIST(foo)",
+						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
 						ParentTableName: "foobar",
@@ -860,7 +860,7 @@ var (
 							{Name: "bar", Type: "timestamp without time zone", IsNullable: true, Default: "CURRENT_TIMESTAMP"},
 						},
 						CheckConstraints: nil,
-						PartitionKeyDef:  "PARTITION BY LIST(foo)",
+						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
 						ParentTableName: "foobar",

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -487,7 +487,7 @@ func (t *tableSQLVertexGenerator) Add(table schema.Table) ([]Statement, error) {
 		strings.Join(columnDefs, ",\n"),
 	))
 	if table.IsPartitioned() {
-		createTableSb.WriteString(fmt.Sprintf("PARTITION BY %s", table.PartitionKeyDef))
+		createTableSb.WriteString(fmt.Sprintf(" PARTITION BY %s", table.PartitionKeyDef))
 	}
 	stmts = append(stmts, Statement{
 		DDL:     createTableSb.String(),


### PR DESCRIPTION
### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Noticed that there's a space missing between a create table statement and its partition by clause. This was not an issue before because postgres considers the word after a closing paren to be a new token, even if there's no space. This fix is purely stylistic
```
CREATE TABLE(...)PARTITION BY ... -> CREATE TABLE(...) PARTITION BY ...
                                                      ^
                                                      |
```

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Saw this while generating a plan

### Testing
[//]: # (Describe how you tested these changes)
Added a plan unit test covering a raw table create with partition.

Before:
```
alexaub in ~/stripe/pg-schema-diff on alexaub/partition-whitespace ● λ pg-schema-diff plan --dsn "postgres://alexaub@localhost:5432/postgres" --schema-dir schema

################################ Generated plan ################################
1. CREATE TABLE "foobar" (
	"id" integer,
	"foo" character varying(255) COLLATE "pg_catalog"."default"
)PARTITION BY LIST (foo);
	-- Timeout: 3s
```

After:
```
alexaub in ~/stripe/pg-schema-diff on alexaub/partition-whitespace ● λ go run ./cmd/pg-schema-diff plan --dsn "postgres://alexaub@localhost:5432/postgres" --schema-dir schema

################################ Generated plan ################################
1. CREATE TABLE "foobar" (
	"id" integer,
	"foo" character varying(255) COLLATE "pg_catalog"."default"
) PARTITION BY LIST (foo);
	-- Timeout: 3s
```