### PR TITLE
Show postgres in run_tests job name

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [14, 15]
+        pg_package: ["postgresql14", "postgresql15"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build Docker image
-        run: docker build -t pg-schema-diff-test-runner -f ./build/Dockerfile.test --build-arg POSTGRES_PACKAGE=postgresql${{ matrix.pg_version }} .
+        run: docker build -t pg-schema-diff-test-runner -f ./build/Dockerfile.test --build-arg POSTGRES_PACKAGE=${{ matrix.pg_package }} .
       - name: Run tests
         run: docker run pg-schema-diff-test-runner


### PR DESCRIPTION
### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Makes it a bit clearer in views what the different run_tests jobs are by including postgresql in the version. Feel free to push back if you think this harms brevity.

Old:
<img width="360" alt="image" src="https://github.com/stripe/pg-schema-diff/assets/130488060/678b78a8-6986-4e23-88c1-5da8d88d2acd">
New:
<img width="422" alt="image" src="https://github.com/stripe/pg-schema-diff/assets/130488060/9672d290-5ab9-445b-9f85-7ba812292380">

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Didn't know what run_tests (14) and run_tests (15) were in a PR

### Testing
[//]: # (Describe how you tested these changes)
CI