### PR TITLE
SQL linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,8 @@ jobs:
         run: docker build -t pg-schema-diff-lint-runner -f ./build/Dockerfile.lint .
       - name: Run lint
         run: docker run pg-schema-diff-lint-runner
-  # The "lint" job will lint go (and SQL), but the "go_lint" job will also highlight specific go errors in the PR
+  # The "lint" job will lint go (and SQL). The "go_lint" job will also lint go but adds comments to the PR on the lines
+  # containing the linting errors
   go_lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t pg-schema-diff-lint-runner -f ./build/Dockerfile.lint .
+      - name: Run lint
+        run: docker run pg-schema-diff-lint-runner
+  # The "lint" job will lint go (and SQL), but the "go_lint" job will also highlight specific go errors in the PR
+  go_lint:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
@@ -19,3 +28,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52.2
+

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,9 @@
+[sqlfluff]
+dialect = postgres
+templater = placeholder
+
+[sqlfluff:templater:placeholder]
+param_regex = sqlc.arg\(.*\)
+# Dummy values that are substituted in for the sqlc variables to allow the formatter to parse the SQL
+1 = 'pg_proc'
+2 = '1'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,13 @@ This project is in its early stages. We appreciate all the feature/bug requests 
 to review direct code contributions at this time. We will try and respond to any bug reports, feature requests, and 
 questions within one week.
 
+## Set-up
+1. Install Docker
+2. [Setup GPG key signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account)
+3. *(Optional)* Install Postgres locally
+4. *(Optional)* Install [golangci-lint (go linting)](https://github.com/golangci/golangci-lint)
+5. *(Optional)* Install [sqlfluff (sql linting)](https://github.com/sqlfluff/sqlfluff)
+
 If you want to make changes yourself, follow these steps:
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository and [clone](https://help.github.com/articles/cloning-a-repository/) it locally.

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,28 @@
-.PHONY: code_gen format go_mod_tidy lint test vendor sqlc
-
-format:
-	goimports -w .
-
-lint:
-	golangci-lint run
+.PHONY: code_gen format go_lint go_lint_fix go_mod_tidy lint sqlc sql_lint sql_lint_fix vendor
 
 code_gen: go_mod_tidy sqlc
+
+go_lint:
+	golangci-lint run
+
+go_lint_fix:
+	golangci-lint run --fix
 
 go_mod_tidy:
 	go mod tidy
 
+lint: go_lint sql_lint
+
+lint_fix: go_lint_fix sql_lint_fix
+
 sqlc:
 	cd internal/queries && sqlc generate
+
+sql_lint:
+	sqlfluff lint
+
+sql_lint_fix:
+	sqlfluff fix
 
 vendor:
 	go mod vendor

--- a/build/Dockerfile.lint
+++ b/build/Dockerfile.lint
@@ -1,0 +1,18 @@
+# Use a newer version of go to appease #golangci-lint
+FROM golang:1.20.6-alpine3.18
+
+RUN apk update && \
+    apk add --no-cache  \
+      make \
+      python3 \
+      py3-pip
+# Install golang-ci-lint
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.53.3
+# Install sqlfluff
+RUN pip install sqlfluff
+
+WORKDIR /pg-schema-diff
+COPY . .
+
+CMD ["lint"]
+ENTRYPOINT ["make"]

--- a/cmd/pg-schema-diff/cli.go
+++ b/cmd/pg-schema-diff/cli.go
@@ -9,7 +9,7 @@ import (
 )
 
 func header(header string) string {
-const headerTargetWidth = 80
+	const headerTargetWidth = 80
 
 	if len(header) > headerTargetWidth {
 		return header

--- a/cmd/pg-schema-diff/cli.go
+++ b/cmd/pg-schema-diff/cli.go
@@ -9,7 +9,7 @@ import (
 )
 
 func header(header string) string {
-	const headerTargetWidth = 80
+const headerTargetWidth = 80
 
 	if len(header) > headerTargetWidth {
 		return header

--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -128,7 +128,7 @@ INNER JOIN
     ON proc_lang.oid = pg_proc.prolang
 WHERE
     proc_namespace.nspname = 'public'
-    AND pg_proc.prokind = 'f'
+AND pg_proc.prokind = 'f'
     -- Exclude functions belonging to extensions
     AND NOT EXISTS (
         SELECT depend.objid

--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -1,165 +1,228 @@
 -- name: GetTables :many
-SELECT c.oid                                        AS oid,
-       c.relname::TEXT                              AS table_name,
-       COALESCE(parent_c.relname, '')::TEXT         AS parent_table_name,
-       COALESCE(parent_namespace.nspname, '')::TEXT AS parent_table_schema_name,
-       (CASE
-            WHEN c.relkind = 'p' THEN pg_catalog.pg_get_partkeydef(c.oid)
-            ELSE ''
-           END)::text
-                                                    AS partition_key_def,
-       (CASE
-            WHEN c.relispartition THEN pg_catalog.pg_get_expr(c.relpartbound, c.oid)
-            ELSE ''
-           END)::text                               AS partition_for_values
-FROM pg_catalog.pg_class c
-         LEFT JOIN pg_catalog.pg_inherits inherits ON inherits.inhrelid = c.oid
-         LEFT JOIN pg_catalog.pg_class parent_c ON inherits.inhparent = parent_c.oid
-         LEFT JOIN pg_catalog.pg_namespace as parent_namespace ON parent_c.relnamespace = parent_namespace.oid
-WHERE c.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
-  AND (c.relkind = 'r' OR c.relkind = 'p');
+SELECT
+    c.oid AS oid,
+    c.relname::TEXT AS table_name,
+    COALESCE(parent_c.relname, '')::TEXT AS parent_table_name,
+    COALESCE(parent_namespace.nspname, '')::TEXT AS parent_table_schema_name,
+    (CASE
+        WHEN c.relkind = 'p' THEN pg_catalog.pg_get_partkeydef(c.oid)
+        ELSE ''
+    END)::TEXT
+    AS partition_key_def,
+    (CASE
+        WHEN c.relispartition THEN pg_catalog.pg_get_expr(c.relpartbound, c.oid)
+        ELSE ''
+    END)::TEXT AS partition_for_values
+FROM pg_catalog.pg_class AS c
+LEFT JOIN
+    pg_catalog.pg_inherits AS table_inherits
+    ON table_inherits.inhrelid = c.oid
+LEFT JOIN
+    pg_catalog.pg_class AS parent_c
+    ON table_inherits.inhparent = parent_c.oid
+LEFT JOIN
+    pg_catalog.pg_namespace AS parent_namespace
+    ON parent_c.relnamespace = parent_namespace.oid
+WHERE
+    c.relnamespace
+    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    AND (c.relkind = 'r' OR c.relkind = 'p');
 
 -- name: GetColumnsForTable :many
-SELECT a.attname::TEXT                                                AS column_name,
-       pg_catalog.format_type(a.atttypid, a.atttypmod)                AS column_type,
-       COALESCE(coll.collname, '')::TEXT                              AS collation_name,
-       COALESCE(collation_namespace.nspname, '')::TEXT                AS collation_schema_name,
-       COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')::TEXT AS default_value,
-       a.attnotnull                                                   AS is_not_null,
-       a.attlen                                                       AS column_size
-FROM pg_catalog.pg_attribute a
-         LEFT JOIN pg_catalog.pg_attrdef d ON (d.adrelid = a.attrelid AND d.adnum = a.attnum)
-         LEFT JOIN pg_catalog.pg_collation coll ON coll.oid = a.attcollation
-         LEFT JOIN pg_catalog.pg_namespace collation_namespace ON collation_namespace.oid = coll.collnamespace
-WHERE a.attrelid = $1
-  AND a.attnum > 0
-  AND NOT a.attisdropped
+SELECT
+    a.attname::TEXT AS column_name,
+    COALESCE(coll.collname, '')::TEXT AS collation_name,
+    COALESCE(collation_namespace.nspname, '')::TEXT AS collation_schema_name,
+    COALESCE(
+        pg_catalog.pg_get_expr(d.adbin, d.adrelid), ''
+    )::TEXT AS default_value,
+    a.attnotnull AS is_not_null,
+    a.attlen AS column_size,
+    pg_catalog.format_type(a.atttypid, a.atttypmod) AS column_type
+FROM pg_catalog.pg_attribute AS a
+LEFT JOIN
+    pg_catalog.pg_attrdef AS d
+    ON (d.adrelid = a.attrelid AND d.adnum = a.attnum)
+LEFT JOIN pg_catalog.pg_collation AS coll ON coll.oid = a.attcollation
+LEFT JOIN
+    pg_catalog.pg_namespace AS collation_namespace
+    ON collation_namespace.oid = coll.collnamespace
+WHERE
+    a.attrelid = $1
+    AND a.attnum > 0
+    AND NOT a.attisdropped
 ORDER BY a.attnum;
 
 -- name: GetIndexes :many
-SELECT c.oid                                        AS oid,
-       c.relname::TEXT                              as index_name,
-       table_c.relname::TEXT                        as table_name,
-       pg_catalog.pg_get_indexdef(c.oid)::TEXT      as def_stmt,
-       COALESCE(con.conname, '')::TEXT              as constraint_name,
-       i.indisvalid                                 as index_is_valid,
-       i.indisprimary                               as index_is_pk,
-       i.indisunique                                AS index_is_unique,
-       COALESCE(parent_c.relname, '')::TEXT         as parent_index_name,
-       COALESCE(parent_namespace.nspname, '')::TEXT as parent_index_schema_name
-FROM pg_catalog.pg_class c
-         INNER JOIN pg_catalog.pg_index i ON (i.indexrelid = c.oid)
-         INNER JOIN pg_catalog.pg_class table_c ON (table_c.oid = i.indrelid)
-         LEFT JOIN pg_catalog.pg_constraint con ON (con.conindid = c.oid)
-         LEFT JOIN pg_catalog.pg_inherits inherits ON (c.oid = inherits.inhrelid)
-         LEFT JOIN pg_catalog.pg_class parent_c ON (inherits.inhparent = parent_c.oid)
-         LEFT JOIN pg_catalog.pg_namespace as parent_namespace ON parent_c.relnamespace = parent_namespace.oid
-WHERE c.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
-  AND (c.relkind = 'i' OR c.relkind = 'I');
+SELECT
+    c.oid AS oid,
+    c.relname::TEXT AS index_name,
+    table_c.relname::TEXT AS table_name,
+    pg_catalog.pg_get_indexdef(c.oid)::TEXT AS def_stmt,
+    COALESCE(con.conname, '')::TEXT AS constraint_name,
+    i.indisvalid AS index_is_valid,
+    i.indisprimary AS index_is_pk,
+    i.indisunique AS index_is_unique,
+    COALESCE(parent_c.relname, '')::TEXT AS parent_index_name,
+    COALESCE(parent_namespace.nspname, '')::TEXT AS parent_index_schema_name
+FROM pg_catalog.pg_class AS c
+INNER JOIN pg_catalog.pg_index AS i ON (i.indexrelid = c.oid)
+INNER JOIN pg_catalog.pg_class AS table_c ON (table_c.oid = i.indrelid)
+LEFT JOIN pg_catalog.pg_constraint AS con ON (con.conindid = c.oid)
+LEFT JOIN
+    pg_catalog.pg_inherits AS idx_inherits
+    ON (c.oid = idx_inherits.inhrelid)
+LEFT JOIN
+    pg_catalog.pg_class AS parent_c
+    ON (idx_inherits.inhparent = parent_c.oid)
+LEFT JOIN
+    pg_catalog.pg_namespace AS parent_namespace
+    ON parent_c.relnamespace = parent_namespace.oid
+WHERE
+    c.relnamespace
+    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    AND (c.relkind = 'i' OR c.relkind = 'I');
 
 -- name: GetColumnsForIndex :many
 SELECT a.attname::TEXT AS column_name
-FROM pg_catalog.pg_attribute a
-WHERE a.attrelid = $1
-  AND a.attnum > 0
+FROM pg_catalog.pg_attribute AS a
+WHERE
+    a.attrelid = $1
+    AND a.attnum > 0
 ORDER BY a.attnum;
 
 -- name: GetCheckConstraints :many
-SELECT pg_constraint.oid,
-       conname::TEXT                            as name,
-       pg_class.relname::TEXT                   as table_name,
-       pg_catalog.pg_get_expr(conbin, conrelid) as expression,
-       convalidated                             as is_valid,
-       connoinherit                             as is_not_inheritable
+SELECT
+    pg_constraint.oid,
+    pg_constraint.conname::TEXT AS constraint_name,
+    pg_class.relname::TEXT AS table_name,
+    pg_constraint.convalidated AS is_valid,
+    pg_constraint.connoinherit AS is_not_inheritable,
+    pg_catalog.pg_get_expr(
+        pg_constraint.conbin, pg_constraint.conrelid
+    ) AS constraint_expression
 FROM pg_catalog.pg_constraint
-         JOIN pg_catalog.pg_class ON pg_constraint.conrelid = pg_class.oid
-WHERE pg_class.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
-  AND contype = 'c'
-  AND pg_constraint.conislocal;
+INNER JOIN pg_catalog.pg_class ON pg_constraint.conrelid = pg_class.oid
+WHERE
+    pg_class.relnamespace
+    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    AND pg_constraint.contype = 'c'
+    AND pg_constraint.conislocal;
 
 -- name: GetFunctions :many
-SELECT proc.oid,
-       proname::TEXT                                           as func_name,
-       pg_catalog.pg_get_function_identity_arguments(proc.oid) as func_identity_arguments,
-       proc_namespace.nspname::TEXT                            as func_schema_name,
-       pg_catalog.pg_get_functiondef(proc.oid)                 as func_def,
-       proc_lang.lanname::TEXT                                 as func_lang
-FROM pg_catalog.pg_proc proc
-         JOIN pg_catalog.pg_namespace proc_namespace ON proc.pronamespace = proc_namespace.oid
-         JOIN pg_catalog.pg_language proc_lang ON proc_lang.oid = proc.prolang
-WHERE proc_namespace.nspname = 'public'
-  AND proc.prokind = 'f'
-  -- Exclude functions belonging to extensions
-  AND NOT EXISTS(
+SELECT
+    pg_proc.oid,
+    pg_proc.proname::TEXT AS func_name,
+    proc_namespace.nspname::TEXT AS func_schema_name,
+    proc_lang.lanname::TEXT AS func_lang,
+    pg_catalog.pg_get_function_identity_arguments(
+        pg_proc.oid
+    ) AS func_identity_arguments,
+    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def
+FROM pg_catalog.pg_proc
+INNER JOIN
+    pg_catalog.pg_namespace AS proc_namespace
+    ON pg_proc.pronamespace = proc_namespace.oid
+INNER JOIN
+    pg_catalog.pg_language AS proc_lang
+    ON proc_lang.oid = pg_proc.prolang
+WHERE
+    proc_namespace.nspname = 'public'
+    AND pg_proc.prokind = 'f'
+    -- Exclude functions belonging to extensions
+    AND NOT EXISTS (
         SELECT depend.objid
-        FROM pg_catalog.pg_depend depend
-        WHERE depend.classid = 'pg_proc'::regclass
-          AND depend.objid = proc.oid
-          AND depend.deptype = 'e'
+        FROM pg_catalog.pg_depend AS depend
+        WHERE
+            depend.classid = 'pg_proc'::REGCLASS
+            AND depend.objid = pg_proc.oid
+            AND depend.deptype = 'e'
     );
 
 -- name: GetDependsOnFunctions :many
-SELECT proc.proname::TEXT                                      as func_name,
-       pg_catalog.pg_get_function_identity_arguments(proc.oid) as func_identity_arguments,
-       proc_namespace.nspname::TEXT                            as func_schema_name
-FROM pg_catalog.pg_depend depend
-         JOIN pg_catalog.pg_proc proc
-              ON depend.refclassid = 'pg_proc'::regclass
-                  AND depend.refobjid = proc.oid
-         JOIN pg_catalog.pg_namespace proc_namespace ON proc.pronamespace = proc_namespace.oid
-WHERE depend.classid = sqlc.arg(system_catalog)::regclass
-  AND depend.objid = sqlc.arg(object_id)
-  AND depend.deptype = 'n';
+SELECT
+    pg_proc.proname::TEXT AS func_name,
+    proc_namespace.nspname::TEXT AS func_schema_name,
+    pg_catalog.pg_get_function_identity_arguments(
+        pg_proc.oid
+    ) AS func_identity_arguments
+FROM pg_catalog.pg_depend AS depend
+INNER JOIN pg_catalog.pg_proc AS pg_proc
+    ON
+        depend.refclassid = 'pg_proc'::REGCLASS
+        AND depend.refobjid = pg_proc.oid
+INNER JOIN
+    pg_catalog.pg_namespace AS proc_namespace
+    ON pg_proc.pronamespace = proc_namespace.oid
+WHERE
+    depend.classid = sqlc.arg(system_catalog)::REGCLASS
+    AND depend.objid = sqlc.arg(object_id)
+    AND depend.deptype = 'n';
 
 -- name: GetTriggers :many
-SELECT trig.tgname::TEXT                                       as trigger_name,
-       owning_c.relname::TEXT                                  as owning_table_name,
-       owning_c_namespace.nspname::TEXT                        as owning_table_schema_name,
-       proc.proname::TEXT                                      as func_name,
-       pg_catalog.pg_get_function_identity_arguments(proc.oid) as func_identity_arguments,
-       proc_namespace.nspname::TEXT                            as func_schema_name,
-       pg_catalog.pg_get_triggerdef(trig.oid)                  as trigger_def
-FROM pg_catalog.pg_trigger trig
-         JOIN pg_catalog.pg_class owning_c ON trig.tgrelid = owning_c.oid
-         JOIN pg_catalog.pg_namespace owning_c_namespace ON owning_c.relnamespace = owning_c_namespace.oid
-         JOIN pg_catalog.pg_proc proc ON trig.tgfoid = proc.oid
-         JOIN pg_catalog.pg_namespace proc_namespace ON proc.pronamespace = proc_namespace.oid
-WHERE proc_namespace.nspname = 'public'
-  AND owning_c_namespace.nspname = 'public'
-  AND trig.tgparentid = 0
-  AND NOT trig.tgisinternal;
+SELECT
+    trig.tgname::TEXT AS trigger_name,
+    owning_c.relname::TEXT AS owning_table_name,
+    owning_c_namespace.nspname::TEXT AS owning_table_schema_name,
+    pg_proc.proname::TEXT AS func_name,
+    proc_namespace.nspname::TEXT AS func_schema_name,
+    pg_catalog.pg_get_function_identity_arguments(
+        pg_proc.oid
+    ) AS func_identity_arguments,
+    pg_catalog.pg_get_triggerdef(trig.oid) AS trigger_def
+FROM pg_catalog.pg_trigger AS trig
+INNER JOIN pg_catalog.pg_class AS owning_c ON trig.tgrelid = owning_c.oid
+INNER JOIN
+    pg_catalog.pg_namespace AS owning_c_namespace
+    ON owning_c.relnamespace = owning_c_namespace.oid
+INNER JOIN pg_catalog.pg_proc AS pg_proc ON trig.tgfoid = pg_proc.oid
+INNER JOIN
+    pg_catalog.pg_namespace AS proc_namespace
+    ON pg_proc.pronamespace = proc_namespace.oid
+WHERE
+    proc_namespace.nspname = 'public'
+    AND owning_c_namespace.nspname = 'public'
+    AND trig.tgparentid = 0
+    AND NOT trig.tgisinternal;
 
 -- name: GetSequences :many
-SELECT seq_c.relname::TEXT                    as sequence_name,
-       seq_ns.nspname::TEXT                   as sequence_schema_name,
-       COALESCE(owner_attr.attname, '')::TEXT as owner_column_name,
-       COALESCE(owner_ns.nspname, '')::TEXt   as owner_schema_name,
-       COALESCE(owner_c.relname, '')::TEXT    as owner_table_name,
-       format_type(seq.seqtypid, NULL)        as type,
-       seq.seqstart                           as start_value,
-       seq.seqincrement                       as increment,
-       seq.seqmax                             as max_value,
-       seq.seqmin                             as min_value,
-       seq.seqcache                           as cache_size,
-       seq.seqcycle                           as cycle
-FROM pg_catalog.pg_sequence seq
-         JOIN pg_catalog.pg_class seq_c ON seq.seqrelid = seq_c.oid
-         JOIN pg_catalog.pg_namespace seq_ns ON seq_c.relnamespace = seq_ns.oid
-         LEFT JOIN pg_catalog.pg_depend depend
-                   ON depend.classid = 'pg_class'::regclass
-                       AND seq.seqrelid = depend.objid
-                       AND depend.refclassid = 'pg_class'::regclass
-                       AND depend.deptype = 'a'
-         LEFT JOIN pg_catalog.pg_attribute owner_attr
-                   ON depend.refobjid = owner_attr.attrelid AND depend.refobjsubid = owner_attr.attnum
-         LEFT JOIN pg_catalog.pg_class owner_c ON depend.refobjid = owner_c.oid
-         LEFT JOIN pg_catalog.pg_namespace owner_ns ON owner_c.relnamespace = owner_ns.oid
+SELECT
+    seq_c.relname::TEXT AS sequence_name,
+    seq_ns.nspname::TEXT AS sequence_schema_name,
+    COALESCE(owner_attr.attname, '')::TEXT AS owner_column_name,
+    COALESCE(owner_ns.nspname, '')::TEXT AS owner_schema_name,
+    COALESCE(owner_c.relname, '')::TEXT AS owner_table_name,
+    pg_seq.seqstart AS start_value,
+    pg_seq.seqincrement AS increment_value,
+    pg_seq.seqmax AS max_value,
+    pg_seq.seqmin AS min_value,
+    pg_seq.seqcache AS cache_size,
+    pg_seq.seqcycle AS is_cycle,
+    FORMAT_TYPE(pg_seq.seqtypid, NULL) AS data_type
+FROM pg_catalog.pg_sequence AS pg_seq
+INNER JOIN pg_catalog.pg_class AS seq_c ON pg_seq.seqrelid = seq_c.oid
+INNER JOIN pg_catalog.pg_namespace AS seq_ns ON seq_c.relnamespace = seq_ns.oid
+LEFT JOIN pg_catalog.pg_depend AS depend
+    ON
+        depend.classid = 'pg_class'::REGCLASS
+        AND pg_seq.seqrelid = depend.objid
+        AND depend.refclassid = 'pg_class'::REGCLASS
+        AND depend.deptype = 'a'
+LEFT JOIN pg_catalog.pg_attribute AS owner_attr
+    ON
+        depend.refobjid = owner_attr.attrelid
+        AND depend.refobjsubid = owner_attr.attnum
+LEFT JOIN pg_catalog.pg_class AS owner_c ON depend.refobjid = owner_c.oid
+LEFT JOIN
+    pg_catalog.pg_namespace AS owner_ns
+    ON owner_c.relnamespace = owner_ns.oid
 WHERE seq_ns.nspname = 'public'
-  -- It doesn't belong to an extension
-  AND NOT EXISTS(
-        SELECT objid
-        FROM pg_catalog.pg_depend ext_depend
-        WHERE ext_depend.classid = 'pg_class'::regclass
-          AND ext_depend.objid = seq.seqrelid
-          AND ext_depend.deptype = 'e'
-    );
+-- It doesn't belong to an extension
+AND NOT EXISTS (
+    SELECT ext_depend.objid
+    FROM pg_catalog.pg_depend AS ext_depend
+    WHERE
+        ext_depend.classid = 'pg_class'::REGCLASS
+        AND ext_depend.objid = pg_seq.seqrelid
+        AND ext_depend.deptype = 'e'
+);

--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -128,7 +128,7 @@ INNER JOIN
     ON proc_lang.oid = pg_proc.prolang
 WHERE
     proc_namespace.nspname = 'public'
-AND pg_proc.prokind = 'f'
+    AND pg_proc.prokind = 'f'
     -- Exclude functions belonging to extensions
     AND NOT EXISTS (
         SELECT depend.objid

--- a/internal/queries/queries.sql.go
+++ b/internal/queries/queries.sql.go
@@ -10,26 +10,31 @@ import (
 )
 
 const getCheckConstraints = `-- name: GetCheckConstraints :many
-SELECT pg_constraint.oid,
-       conname::TEXT                            as name,
-       pg_class.relname::TEXT                   as table_name,
-       pg_catalog.pg_get_expr(conbin, conrelid) as expression,
-       convalidated                             as is_valid,
-       connoinherit                             as is_not_inheritable
+SELECT
+    pg_constraint.oid,
+    pg_constraint.conname::TEXT AS constraint_name,
+    pg_class.relname::TEXT AS table_name,
+    pg_constraint.convalidated AS is_valid,
+    pg_constraint.connoinherit AS is_not_inheritable,
+    pg_catalog.pg_get_expr(
+        pg_constraint.conbin, pg_constraint.conrelid
+    ) AS constraint_expression
 FROM pg_catalog.pg_constraint
-         JOIN pg_catalog.pg_class ON pg_constraint.conrelid = pg_class.oid
-WHERE pg_class.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
-  AND contype = 'c'
-  AND pg_constraint.conislocal
+INNER JOIN pg_catalog.pg_class ON pg_constraint.conrelid = pg_class.oid
+WHERE
+    pg_class.relnamespace
+    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    AND pg_constraint.contype = 'c'
+    AND pg_constraint.conislocal
 `
 
 type GetCheckConstraintsRow struct {
-	Oid              interface{}
-	Name             string
-	TableName        string
-	Expression       string
-	IsValid          bool
-	IsNotInheritable bool
+	Oid                  interface{}
+	ConstraintName       string
+	TableName            string
+	IsValid              bool
+	IsNotInheritable     bool
+	ConstraintExpression string
 }
 
 func (q *Queries) GetCheckConstraints(ctx context.Context) ([]GetCheckConstraintsRow, error) {
@@ -43,11 +48,11 @@ func (q *Queries) GetCheckConstraints(ctx context.Context) ([]GetCheckConstraint
 		var i GetCheckConstraintsRow
 		if err := rows.Scan(
 			&i.Oid,
-			&i.Name,
+			&i.ConstraintName,
 			&i.TableName,
-			&i.Expression,
 			&i.IsValid,
 			&i.IsNotInheritable,
+			&i.ConstraintExpression,
 		); err != nil {
 			return nil, err
 		}
@@ -64,9 +69,10 @@ func (q *Queries) GetCheckConstraints(ctx context.Context) ([]GetCheckConstraint
 
 const getColumnsForIndex = `-- name: GetColumnsForIndex :many
 SELECT a.attname::TEXT AS column_name
-FROM pg_catalog.pg_attribute a
-WHERE a.attrelid = $1
-  AND a.attnum > 0
+FROM pg_catalog.pg_attribute AS a
+WHERE
+    a.attrelid = $1
+    AND a.attnum > 0
 ORDER BY a.attnum
 `
 
@@ -94,31 +100,39 @@ func (q *Queries) GetColumnsForIndex(ctx context.Context, attrelid interface{}) 
 }
 
 const getColumnsForTable = `-- name: GetColumnsForTable :many
-SELECT a.attname::TEXT                                                AS column_name,
-       pg_catalog.format_type(a.atttypid, a.atttypmod)                AS column_type,
-       COALESCE(coll.collname, '')::TEXT                              AS collation_name,
-       COALESCE(collation_namespace.nspname, '')::TEXT                AS collation_schema_name,
-       COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')::TEXT AS default_value,
-       a.attnotnull                                                   AS is_not_null,
-       a.attlen                                                       AS column_size
-FROM pg_catalog.pg_attribute a
-         LEFT JOIN pg_catalog.pg_attrdef d ON (d.adrelid = a.attrelid AND d.adnum = a.attnum)
-         LEFT JOIN pg_catalog.pg_collation coll ON coll.oid = a.attcollation
-         LEFT JOIN pg_catalog.pg_namespace collation_namespace ON collation_namespace.oid = coll.collnamespace
-WHERE a.attrelid = $1
-  AND a.attnum > 0
-  AND NOT a.attisdropped
+SELECT
+    a.attname::TEXT AS column_name,
+    COALESCE(coll.collname, '')::TEXT AS collation_name,
+    COALESCE(collation_namespace.nspname, '')::TEXT AS collation_schema_name,
+    COALESCE(
+        pg_catalog.pg_get_expr(d.adbin, d.adrelid), ''
+    )::TEXT AS default_value,
+    a.attnotnull AS is_not_null,
+    a.attlen AS column_size,
+    pg_catalog.format_type(a.atttypid, a.atttypmod) AS column_type
+FROM pg_catalog.pg_attribute AS a
+LEFT JOIN
+    pg_catalog.pg_attrdef AS d
+    ON (d.adrelid = a.attrelid AND d.adnum = a.attnum)
+LEFT JOIN pg_catalog.pg_collation AS coll ON coll.oid = a.attcollation
+LEFT JOIN
+    pg_catalog.pg_namespace AS collation_namespace
+    ON collation_namespace.oid = coll.collnamespace
+WHERE
+    a.attrelid = $1
+    AND a.attnum > 0
+    AND NOT a.attisdropped
 ORDER BY a.attnum
 `
 
 type GetColumnsForTableRow struct {
 	ColumnName          string
-	ColumnType          string
 	CollationName       string
 	CollationSchemaName string
 	DefaultValue        string
 	IsNotNull           bool
 	ColumnSize          int16
+	ColumnType          string
 }
 
 func (q *Queries) GetColumnsForTable(ctx context.Context, attrelid interface{}) ([]GetColumnsForTableRow, error) {
@@ -132,12 +146,12 @@ func (q *Queries) GetColumnsForTable(ctx context.Context, attrelid interface{}) 
 		var i GetColumnsForTableRow
 		if err := rows.Scan(
 			&i.ColumnName,
-			&i.ColumnType,
 			&i.CollationName,
 			&i.CollationSchemaName,
 			&i.DefaultValue,
 			&i.IsNotNull,
 			&i.ColumnSize,
+			&i.ColumnType,
 		); err != nil {
 			return nil, err
 		}
@@ -153,17 +167,24 @@ func (q *Queries) GetColumnsForTable(ctx context.Context, attrelid interface{}) 
 }
 
 const getDependsOnFunctions = `-- name: GetDependsOnFunctions :many
-SELECT proc.proname::TEXT                                      as func_name,
-       pg_catalog.pg_get_function_identity_arguments(proc.oid) as func_identity_arguments,
-       proc_namespace.nspname::TEXT                            as func_schema_name
-FROM pg_catalog.pg_depend depend
-         JOIN pg_catalog.pg_proc proc
-              ON depend.refclassid = 'pg_proc'::regclass
-                  AND depend.refobjid = proc.oid
-         JOIN pg_catalog.pg_namespace proc_namespace ON proc.pronamespace = proc_namespace.oid
-WHERE depend.classid = $1::regclass
-  AND depend.objid = $2
-  AND depend.deptype = 'n'
+SELECT
+    pg_proc.proname::TEXT AS func_name,
+    proc_namespace.nspname::TEXT AS func_schema_name,
+    pg_catalog.pg_get_function_identity_arguments(
+        pg_proc.oid
+    ) AS func_identity_arguments
+FROM pg_catalog.pg_depend AS depend
+INNER JOIN pg_catalog.pg_proc AS pg_proc
+    ON
+        depend.refclassid = 'pg_proc'::REGCLASS
+        AND depend.refobjid = pg_proc.oid
+INNER JOIN
+    pg_catalog.pg_namespace AS proc_namespace
+    ON pg_proc.pronamespace = proc_namespace.oid
+WHERE
+    depend.classid = $1::REGCLASS
+    AND depend.objid = $2
+    AND depend.deptype = 'n'
 `
 
 type GetDependsOnFunctionsParams struct {
@@ -173,8 +194,8 @@ type GetDependsOnFunctionsParams struct {
 
 type GetDependsOnFunctionsRow struct {
 	FuncName              string
-	FuncIdentityArguments string
 	FuncSchemaName        string
+	FuncIdentityArguments string
 }
 
 func (q *Queries) GetDependsOnFunctions(ctx context.Context, arg GetDependsOnFunctionsParams) ([]GetDependsOnFunctionsRow, error) {
@@ -186,7 +207,7 @@ func (q *Queries) GetDependsOnFunctions(ctx context.Context, arg GetDependsOnFun
 	var items []GetDependsOnFunctionsRow
 	for rows.Next() {
 		var i GetDependsOnFunctionsRow
-		if err := rows.Scan(&i.FuncName, &i.FuncIdentityArguments, &i.FuncSchemaName); err != nil {
+		if err := rows.Scan(&i.FuncName, &i.FuncSchemaName, &i.FuncIdentityArguments); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -201,34 +222,43 @@ func (q *Queries) GetDependsOnFunctions(ctx context.Context, arg GetDependsOnFun
 }
 
 const getFunctions = `-- name: GetFunctions :many
-SELECT proc.oid,
-       proname::TEXT                                           as func_name,
-       pg_catalog.pg_get_function_identity_arguments(proc.oid) as func_identity_arguments,
-       proc_namespace.nspname::TEXT                            as func_schema_name,
-       pg_catalog.pg_get_functiondef(proc.oid)                 as func_def,
-       proc_lang.lanname::TEXT                                 as func_lang
-FROM pg_catalog.pg_proc proc
-         JOIN pg_catalog.pg_namespace proc_namespace ON proc.pronamespace = proc_namespace.oid
-         JOIN pg_catalog.pg_language proc_lang ON proc_lang.oid = proc.prolang
-WHERE proc_namespace.nspname = 'public'
-  AND proc.prokind = 'f'
-  -- Exclude functions belonging to extensions
-  AND NOT EXISTS(
+SELECT
+    pg_proc.oid,
+    pg_proc.proname::TEXT AS func_name,
+    proc_namespace.nspname::TEXT AS func_schema_name,
+    proc_lang.lanname::TEXT AS func_lang,
+    pg_catalog.pg_get_function_identity_arguments(
+        pg_proc.oid
+    ) AS func_identity_arguments,
+    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def
+FROM pg_catalog.pg_proc
+INNER JOIN
+    pg_catalog.pg_namespace AS proc_namespace
+    ON pg_proc.pronamespace = proc_namespace.oid
+INNER JOIN
+    pg_catalog.pg_language AS proc_lang
+    ON proc_lang.oid = pg_proc.prolang
+WHERE
+    proc_namespace.nspname = 'public'
+    AND pg_proc.prokind = 'f'
+    -- Exclude functions belonging to extensions
+    AND NOT EXISTS (
         SELECT depend.objid
-        FROM pg_catalog.pg_depend depend
-        WHERE depend.classid = 'pg_proc'::regclass
-          AND depend.objid = proc.oid
-          AND depend.deptype = 'e'
+        FROM pg_catalog.pg_depend AS depend
+        WHERE
+            depend.classid = 'pg_proc'::REGCLASS
+            AND depend.objid = pg_proc.oid
+            AND depend.deptype = 'e'
     )
 `
 
 type GetFunctionsRow struct {
 	Oid                   interface{}
 	FuncName              string
-	FuncIdentityArguments string
 	FuncSchemaName        string
-	FuncDef               string
 	FuncLang              string
+	FuncIdentityArguments string
+	FuncDef               string
 }
 
 func (q *Queries) GetFunctions(ctx context.Context) ([]GetFunctionsRow, error) {
@@ -243,10 +273,10 @@ func (q *Queries) GetFunctions(ctx context.Context) ([]GetFunctionsRow, error) {
 		if err := rows.Scan(
 			&i.Oid,
 			&i.FuncName,
-			&i.FuncIdentityArguments,
 			&i.FuncSchemaName,
-			&i.FuncDef,
 			&i.FuncLang,
+			&i.FuncIdentityArguments,
+			&i.FuncDef,
 		); err != nil {
 			return nil, err
 		}
@@ -262,25 +292,34 @@ func (q *Queries) GetFunctions(ctx context.Context) ([]GetFunctionsRow, error) {
 }
 
 const getIndexes = `-- name: GetIndexes :many
-SELECT c.oid                                        AS oid,
-       c.relname::TEXT                              as index_name,
-       table_c.relname::TEXT                        as table_name,
-       pg_catalog.pg_get_indexdef(c.oid)::TEXT      as def_stmt,
-       COALESCE(con.conname, '')::TEXT              as constraint_name,
-       i.indisvalid                                 as index_is_valid,
-       i.indisprimary                               as index_is_pk,
-       i.indisunique                                AS index_is_unique,
-       COALESCE(parent_c.relname, '')::TEXT         as parent_index_name,
-       COALESCE(parent_namespace.nspname, '')::TEXT as parent_index_schema_name
-FROM pg_catalog.pg_class c
-         INNER JOIN pg_catalog.pg_index i ON (i.indexrelid = c.oid)
-         INNER JOIN pg_catalog.pg_class table_c ON (table_c.oid = i.indrelid)
-         LEFT JOIN pg_catalog.pg_constraint con ON (con.conindid = c.oid)
-         LEFT JOIN pg_catalog.pg_inherits inherits ON (c.oid = inherits.inhrelid)
-         LEFT JOIN pg_catalog.pg_class parent_c ON (inherits.inhparent = parent_c.oid)
-         LEFT JOIN pg_catalog.pg_namespace as parent_namespace ON parent_c.relnamespace = parent_namespace.oid
-WHERE c.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
-  AND (c.relkind = 'i' OR c.relkind = 'I')
+SELECT
+    c.oid AS oid,
+    c.relname::TEXT AS index_name,
+    table_c.relname::TEXT AS table_name,
+    pg_catalog.pg_get_indexdef(c.oid)::TEXT AS def_stmt,
+    COALESCE(con.conname, '')::TEXT AS constraint_name,
+    i.indisvalid AS index_is_valid,
+    i.indisprimary AS index_is_pk,
+    i.indisunique AS index_is_unique,
+    COALESCE(parent_c.relname, '')::TEXT AS parent_index_name,
+    COALESCE(parent_namespace.nspname, '')::TEXT AS parent_index_schema_name
+FROM pg_catalog.pg_class AS c
+INNER JOIN pg_catalog.pg_index AS i ON (i.indexrelid = c.oid)
+INNER JOIN pg_catalog.pg_class AS table_c ON (table_c.oid = i.indrelid)
+LEFT JOIN pg_catalog.pg_constraint AS con ON (con.conindid = c.oid)
+LEFT JOIN
+    pg_catalog.pg_inherits AS idx_inherits
+    ON (c.oid = idx_inherits.inhrelid)
+LEFT JOIN
+    pg_catalog.pg_class AS parent_c
+    ON (idx_inherits.inhparent = parent_c.oid)
+LEFT JOIN
+    pg_catalog.pg_namespace AS parent_namespace
+    ON parent_c.relnamespace = parent_namespace.oid
+WHERE
+    c.relnamespace
+    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    AND (c.relkind = 'i' OR c.relkind = 'I')
 `
 
 type GetIndexesRow struct {
@@ -331,39 +370,45 @@ func (q *Queries) GetIndexes(ctx context.Context) ([]GetIndexesRow, error) {
 }
 
 const getSequences = `-- name: GetSequences :many
-SELECT seq_c.relname::TEXT                    as sequence_name,
-       seq_ns.nspname::TEXT                   as sequence_schema_name,
-       COALESCE(owner_attr.attname, '')::TEXT as owner_column_name,
-       COALESCE(owner_ns.nspname, '')::TEXt   as owner_schema_name,
-       COALESCE(owner_c.relname, '')::TEXT    as owner_table_name,
-       format_type(seq.seqtypid, NULL)        as type,
-       seq.seqstart                           as start_value,
-       seq.seqincrement                       as increment,
-       seq.seqmax                             as max_value,
-       seq.seqmin                             as min_value,
-       seq.seqcache                           as cache_size,
-       seq.seqcycle                           as cycle
-FROM pg_catalog.pg_sequence seq
-         JOIN pg_catalog.pg_class seq_c ON seq.seqrelid = seq_c.oid
-         JOIN pg_catalog.pg_namespace seq_ns ON seq_c.relnamespace = seq_ns.oid
-         LEFT JOIN pg_catalog.pg_depend depend
-                   ON depend.classid = 'pg_class'::regclass
-                       AND seq.seqrelid = depend.objid
-                       AND depend.refclassid = 'pg_class'::regclass
-                       AND depend.deptype = 'a'
-         LEFT JOIN pg_catalog.pg_attribute owner_attr
-                   ON depend.refobjid = owner_attr.attrelid AND depend.refobjsubid = owner_attr.attnum
-         LEFT JOIN pg_catalog.pg_class owner_c ON depend.refobjid = owner_c.oid
-         LEFT JOIN pg_catalog.pg_namespace owner_ns ON owner_c.relnamespace = owner_ns.oid
+SELECT
+    seq_c.relname::TEXT AS sequence_name,
+    seq_ns.nspname::TEXT AS sequence_schema_name,
+    COALESCE(owner_attr.attname, '')::TEXT AS owner_column_name,
+    COALESCE(owner_ns.nspname, '')::TEXT AS owner_schema_name,
+    COALESCE(owner_c.relname, '')::TEXT AS owner_table_name,
+    pg_seq.seqstart AS start_value,
+    pg_seq.seqincrement AS increment_value,
+    pg_seq.seqmax AS max_value,
+    pg_seq.seqmin AS min_value,
+    pg_seq.seqcache AS cache_size,
+    pg_seq.seqcycle AS is_cycle,
+    FORMAT_TYPE(pg_seq.seqtypid, NULL) AS data_type
+FROM pg_catalog.pg_sequence AS pg_seq
+INNER JOIN pg_catalog.pg_class AS seq_c ON pg_seq.seqrelid = seq_c.oid
+INNER JOIN pg_catalog.pg_namespace AS seq_ns ON seq_c.relnamespace = seq_ns.oid
+LEFT JOIN pg_catalog.pg_depend AS depend
+    ON
+        depend.classid = 'pg_class'::REGCLASS
+        AND pg_seq.seqrelid = depend.objid
+        AND depend.refclassid = 'pg_class'::REGCLASS
+        AND depend.deptype = 'a'
+LEFT JOIN pg_catalog.pg_attribute AS owner_attr
+    ON
+        depend.refobjid = owner_attr.attrelid
+        AND depend.refobjsubid = owner_attr.attnum
+LEFT JOIN pg_catalog.pg_class AS owner_c ON depend.refobjid = owner_c.oid
+LEFT JOIN
+    pg_catalog.pg_namespace AS owner_ns
+    ON owner_c.relnamespace = owner_ns.oid
 WHERE seq_ns.nspname = 'public'
-  -- It doesn't belong to an extension
-  AND NOT EXISTS(
-        SELECT objid
-        FROM pg_catalog.pg_depend ext_depend
-        WHERE ext_depend.classid = 'pg_class'::regclass
-          AND ext_depend.objid = seq.seqrelid
-          AND ext_depend.deptype = 'e'
-    )
+AND NOT EXISTS (
+    SELECT ext_depend.objid
+    FROM pg_catalog.pg_depend AS ext_depend
+    WHERE
+        ext_depend.classid = 'pg_class'::REGCLASS
+        AND ext_depend.objid = pg_seq.seqrelid
+        AND ext_depend.deptype = 'e'
+)
 `
 
 type GetSequencesRow struct {
@@ -372,15 +417,16 @@ type GetSequencesRow struct {
 	OwnerColumnName    string
 	OwnerSchemaName    string
 	OwnerTableName     string
-	Type               string
 	StartValue         int64
-	Increment          int64
+	IncrementValue     int64
 	MaxValue           int64
 	MinValue           int64
 	CacheSize          int64
-	Cycle              bool
+	IsCycle            bool
+	DataType           string
 }
 
+// It doesn't belong to an extension
 func (q *Queries) GetSequences(ctx context.Context) ([]GetSequencesRow, error) {
 	rows, err := q.db.QueryContext(ctx, getSequences)
 	if err != nil {
@@ -396,13 +442,13 @@ func (q *Queries) GetSequences(ctx context.Context) ([]GetSequencesRow, error) {
 			&i.OwnerColumnName,
 			&i.OwnerSchemaName,
 			&i.OwnerTableName,
-			&i.Type,
 			&i.StartValue,
-			&i.Increment,
+			&i.IncrementValue,
 			&i.MaxValue,
 			&i.MinValue,
 			&i.CacheSize,
-			&i.Cycle,
+			&i.IsCycle,
+			&i.DataType,
 		); err != nil {
 			return nil, err
 		}
@@ -418,25 +464,34 @@ func (q *Queries) GetSequences(ctx context.Context) ([]GetSequencesRow, error) {
 }
 
 const getTables = `-- name: GetTables :many
-SELECT c.oid                                        AS oid,
-       c.relname::TEXT                              AS table_name,
-       COALESCE(parent_c.relname, '')::TEXT         AS parent_table_name,
-       COALESCE(parent_namespace.nspname, '')::TEXT AS parent_table_schema_name,
-       (CASE
-            WHEN c.relkind = 'p' THEN pg_catalog.pg_get_partkeydef(c.oid)
-            ELSE ''
-           END)::text
-                                                    AS partition_key_def,
-       (CASE
-            WHEN c.relispartition THEN pg_catalog.pg_get_expr(c.relpartbound, c.oid)
-            ELSE ''
-           END)::text                               AS partition_for_values
-FROM pg_catalog.pg_class c
-         LEFT JOIN pg_catalog.pg_inherits inherits ON inherits.inhrelid = c.oid
-         LEFT JOIN pg_catalog.pg_class parent_c ON inherits.inhparent = parent_c.oid
-         LEFT JOIN pg_catalog.pg_namespace as parent_namespace ON parent_c.relnamespace = parent_namespace.oid
-WHERE c.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
-  AND (c.relkind = 'r' OR c.relkind = 'p')
+SELECT
+    c.oid AS oid,
+    c.relname::TEXT AS table_name,
+    COALESCE(parent_c.relname, '')::TEXT AS parent_table_name,
+    COALESCE(parent_namespace.nspname, '')::TEXT AS parent_table_schema_name,
+    (CASE
+        WHEN c.relkind = 'p' THEN pg_catalog.pg_get_partkeydef(c.oid)
+        ELSE ''
+    END)::TEXT
+    AS partition_key_def,
+    (CASE
+        WHEN c.relispartition THEN pg_catalog.pg_get_expr(c.relpartbound, c.oid)
+        ELSE ''
+    END)::TEXT AS partition_for_values
+FROM pg_catalog.pg_class AS c
+LEFT JOIN
+    pg_catalog.pg_inherits AS table_inherits
+    ON table_inherits.inhrelid = c.oid
+LEFT JOIN
+    pg_catalog.pg_class AS parent_c
+    ON table_inherits.inhparent = parent_c.oid
+LEFT JOIN
+    pg_catalog.pg_namespace AS parent_namespace
+    ON parent_c.relnamespace = parent_namespace.oid
+WHERE
+    c.relnamespace
+    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    AND (c.relkind = 'r' OR c.relkind = 'p')
 `
 
 type GetTablesRow struct {
@@ -479,22 +534,30 @@ func (q *Queries) GetTables(ctx context.Context) ([]GetTablesRow, error) {
 }
 
 const getTriggers = `-- name: GetTriggers :many
-SELECT trig.tgname::TEXT                                       as trigger_name,
-       owning_c.relname::TEXT                                  as owning_table_name,
-       owning_c_namespace.nspname::TEXT                        as owning_table_schema_name,
-       proc.proname::TEXT                                      as func_name,
-       pg_catalog.pg_get_function_identity_arguments(proc.oid) as func_identity_arguments,
-       proc_namespace.nspname::TEXT                            as func_schema_name,
-       pg_catalog.pg_get_triggerdef(trig.oid)                  as trigger_def
-FROM pg_catalog.pg_trigger trig
-         JOIN pg_catalog.pg_class owning_c ON trig.tgrelid = owning_c.oid
-         JOIN pg_catalog.pg_namespace owning_c_namespace ON owning_c.relnamespace = owning_c_namespace.oid
-         JOIN pg_catalog.pg_proc proc ON trig.tgfoid = proc.oid
-         JOIN pg_catalog.pg_namespace proc_namespace ON proc.pronamespace = proc_namespace.oid
-WHERE proc_namespace.nspname = 'public'
-  AND owning_c_namespace.nspname = 'public'
-  AND trig.tgparentid = 0
-  AND NOT trig.tgisinternal
+SELECT
+    trig.tgname::TEXT AS trigger_name,
+    owning_c.relname::TEXT AS owning_table_name,
+    owning_c_namespace.nspname::TEXT AS owning_table_schema_name,
+    pg_proc.proname::TEXT AS func_name,
+    proc_namespace.nspname::TEXT AS func_schema_name,
+    pg_catalog.pg_get_function_identity_arguments(
+        pg_proc.oid
+    ) AS func_identity_arguments,
+    pg_catalog.pg_get_triggerdef(trig.oid) AS trigger_def
+FROM pg_catalog.pg_trigger AS trig
+INNER JOIN pg_catalog.pg_class AS owning_c ON trig.tgrelid = owning_c.oid
+INNER JOIN
+    pg_catalog.pg_namespace AS owning_c_namespace
+    ON owning_c.relnamespace = owning_c_namespace.oid
+INNER JOIN pg_catalog.pg_proc AS pg_proc ON trig.tgfoid = pg_proc.oid
+INNER JOIN
+    pg_catalog.pg_namespace AS proc_namespace
+    ON pg_proc.pronamespace = proc_namespace.oid
+WHERE
+    proc_namespace.nspname = 'public'
+    AND owning_c_namespace.nspname = 'public'
+    AND trig.tgparentid = 0
+    AND NOT trig.tgisinternal
 `
 
 type GetTriggersRow struct {
@@ -502,8 +565,8 @@ type GetTriggersRow struct {
 	OwningTableName       string
 	OwningTableSchemaName string
 	FuncName              string
-	FuncIdentityArguments string
 	FuncSchemaName        string
+	FuncIdentityArguments string
 	TriggerDef            string
 }
 
@@ -521,8 +584,8 @@ func (q *Queries) GetTriggers(ctx context.Context) ([]GetTriggersRow, error) {
 			&i.OwningTableName,
 			&i.OwningTableSchemaName,
 			&i.FuncName,
-			&i.FuncIdentityArguments,
 			&i.FuncSchemaName,
+			&i.FuncIdentityArguments,
 			&i.TriggerDef,
 		); err != nil {
 			return nil, err

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -402,8 +402,8 @@ func fetchCheckConsAndBuildTableToCheckConsMap(ctx context.Context, q *queries.Q
 		}
 
 		checkCon := CheckConstraint{
-			Name:               cc.Name,
-			Expression:         cc.Expression,
+			Name:               cc.ConstraintName,
+			Expression:         cc.ConstraintExpression,
 			IsValid:            cc.IsValid,
 			IsInheritable:      !cc.IsNotInheritable,
 			DependsOnFunctions: dependsOnFunctions,
@@ -470,13 +470,13 @@ func fetchSequences(ctx context.Context, q *queries.Queries) ([]Sequence, error)
 				EscapedName: EscapeIdentifier(rawSeq.SequenceName),
 			},
 			Owner:      owner,
-			Type:       rawSeq.Type,
+			Type:       rawSeq.DataType,
 			StartValue: rawSeq.StartValue,
-			Increment:  rawSeq.Increment,
+			Increment:  rawSeq.IncrementValue,
 			MaxValue:   rawSeq.MaxValue,
 			MinValue:   rawSeq.MinValue,
 			CacheSize:  rawSeq.CacheSize,
-			Cycle:      rawSeq.Cycle,
+			Cycle:      rawSeq.IsCycle,
 		})
 	}
 	return seqs, nil


### PR DESCRIPTION
### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Uses SQLfluff for linting. This linter requires folks to have python installed or use docker. There aren't any super great-looking go SQL linters, and most folks have Python installed on their machines, so it should be fine.

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Enforce a consistent style in SQL

### Testing
[//]: # (Describe how you tested these changes)
Tested locally and in CI