### PR TITLE
Cleanup lint

### DIFF
--- a/build/Dockerfile.lint
+++ b/build/Dockerfile.lint
@@ -9,8 +9,8 @@ RUN apk update && \
 # Install golang-ci-lint
 RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.53.3
 # Install sqlfluff
-RUN pip install wheel
-RUN pip install wheel "Cython<3.0" pyyaml --no-build-isolation # Fix for https://github.com/yaml/pyyaml/issues/601
+RUN pip install wheel # It complains if we attempt to install this in the same command as Cython
+RUN pip install "Cython<3.0" pyyaml --no-build-isolation # Fix for https://github.com/yaml/pyyaml/issues/601
 RUN pip install "sqlfluff==2.1.2"
 
 WORKDIR /pg-schema-diff


### PR DESCRIPTION
### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Just realized this in my urgency to get CI passing again. The reason it was working previously is we installed "wheel", and it saw "wheel" was installed in the same line. This cleans up the install process by getting rid of the redundant install
### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)

### Testing
[//]: # (Describe how you tested these changes)
