### PR TITLE
cmd: make dsn a non-mandatory flag to allow use of Postgres environment variables

### DIFF
--- a/cmd/pg-schema-diff/apply_cmd.go
+++ b/cmd/pg-schema-diff/apply_cmd.go
@@ -28,7 +28,8 @@ func buildApplyCmd() *cobra.Command {
 			" (example: --allowed-hazards DELETES_DATA,INDEX_BUILD)")
 	lockTimeout := cmd.Flags().Duration("lock-timeout", 30*time.Second, "the max time to wait to acquire a lock. 0 implies no timeout")
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		connConfig, err := connFlags.parseConnConfig()
+		logger := log.SimpleLogger()
+		connConfig, err := connFlags.parseConnConfig(logger)
 		if err != nil {
 			return err
 		}
@@ -44,7 +45,7 @@ func buildApplyCmd() *cobra.Command {
 
 		cmd.SilenceUsage = true
 
-		plan, err := generatePlan(context.Background(), log.SimpleLogger(), connConfig, planConfig)
+		plan, err := generatePlan(context.Background(), logger, connConfig, planConfig)
 		if err != nil {
 			return err
 		} else if len(plan.Statements) == 0 {

--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -46,7 +46,8 @@ func buildPlanCmd() *cobra.Command {
 	connFlags := createConnFlags(cmd)
 	planFlags := createPlanFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		connConfig, err := connFlags.parseConnConfig()
+		logger := log.SimpleLogger()
+		connConfig, err := connFlags.parseConnConfig(logger)
 		if err != nil {
 			return err
 		}
@@ -58,7 +59,7 @@ func buildPlanCmd() *cobra.Command {
 
 		cmd.SilenceUsage = true
 
-		plan, err := generatePlan(context.Background(), log.SimpleLogger(), connConfig, planConfig)
+		plan, err := generatePlan(context.Background(), logger, connConfig, planConfig)
 		if err != nil {
 			return err
 		} else if len(plan.Statements) == 0 {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -8,6 +8,7 @@ import (
 type (
 	Logger interface {
 		Errorf(msg string, args ...any)
+		Warnf(msg string, args ...any)
 	}
 
 	simpleLogger struct{}
@@ -20,5 +21,10 @@ func SimpleLogger() Logger {
 
 func (*simpleLogger) Errorf(msg string, args ...any) {
 	formattedMessage := fmt.Sprintf(msg, args...)
-	log.Println(fmt.Sprintf("[ERROR] %s", formattedMessage))
+	log.Printf("[ERROR] %s", formattedMessage)
+}
+
+func (*simpleLogger) Warnf(msg string, args ...any) {
+	formattedMessage := fmt.Sprintf(msg, args...)
+	log.Printf("[WARNING] %s", formattedMessage)
 }


### PR DESCRIPTION
### Description

`psql` and programs using `libpq` allows users to use the environment variables `PGHOST` and friends to specify the connection information. This PR implements the same behavior for `pg-schema-diff` by making the DSN flag non-mandatory.

### Motivation

- We already set the Postgres environment variables in our development and deployment environments.
- The Javascript and Golang libraries we use honor the variables.
- This change makes `pg-schema-diff` "just work" in our workflow.

### Implementation

-  pg-schema-diff's `(connFlags).parseConnConfig()` calls  `pgx.ParseConfig()`, which calls `pgconn.ParseConfigWithOptions()`

- `pgconn.ParseConfigWithOptions` already reads the Postgres environment variables.

### Testing

- I've tested the change manually on the command line and it works as expected