### PR TITLE
Specify user in pgengine

### DIFF
--- a/internal/pgengine/engine.go
+++ b/internal/pgengine/engine.go
@@ -116,7 +116,7 @@ func StartEngineUsingPgDir(pgDir string) (_ *Engine, retErr error) {
 	return pgEngine, nil
 }
 
-func initDB(initDbPath, dbPath string, superuser string) error {
+func initDB(initDbPath, dbPath, superuser string) error {
 	cmd := exec.Command(initDbPath, []string{
 		"-U", superuser,
 		"-D", dbPath,


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Before, if `PGUSER` was set on a user's machine, local tests would break because we didn't specify user. Now, the user is specified in the pgengine. This also switches the super user from the current user to `postgres`

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Improved UX when running tests

### Testing
[//]: # (Describe how you tested these changes)
Unit tests