### PR TITLE
fixed buggy english

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ if err != nil {
 ```
 
 ## 2. Applying plan
-We leave plan application up to the user. For example, users might want to take out a session-level advisory lock if they are 
+We leave plan application up to the user. For example, a user might want to take out a session-level advisory lock if they are 
 concerned about concurrent migrations on their database. They might also want a second user to approve the plan
 before applying it.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ if err != nil {
 ```
 
 ## 2. Applying plan
-We leave plan application up to the user. For example, Users might want to take out a session-level advisory lock if they are 
+We leave plan application up to the user. For example, users might want to take out a session-level advisory lock if they are 
 concerned about concurrent migrations on their database. They might also want a second user to approve the plan
 before applying it.
 


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
This is fixing a word.

### Motivation
The incorrectly capitalized character was an eyesore in the readme, which is the first place users go to when viewing this repo.

### Testing
I have read the changed line like 20 times.
