### PR TITLE
Allow root db to be something other than postgres in temp db factory

### DIFF
--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -225,7 +225,7 @@ func generatePlan(ctx context.Context, logger log.Logger, connConfig *pgx.ConnCo
 		copiedConfig := connConfig.Copy()
 		copiedConfig.Database = dbName
 		return openDbWithPgxConfig(copiedConfig)
-	})
+	}, tempdb.WithRootDatabase(connConfig.Database))
 	if err != nil {
 		return diff.Plan{}, err
 	}

--- a/pkg/tempdb/factory_test.go
+++ b/pkg/tempdb/factory_test.go
@@ -103,12 +103,21 @@ func (suite *onInstanceTempDbFactorySuite) TestCreate_CreateAndDropFlow() {
 		dbPrefix       = "some_prefix"
 		metadataSchema = "some metadata schema"
 		metadataTable  = "some metadata table"
+		rootDbName     = "some_root_db"
 	)
+
+	rootDb, err := suite.engine.CreateDatabaseWithName(rootDbName)
+	suite.Require().NoError(err)
+	defer func(rootDb *pgengine.DB) {
+		suite.Require().NoError(rootDb.DropDB())
+	}(rootDb)
+
 	factory := suite.mustBuildFactory(
 		WithDbPrefix(dbPrefix),
 		WithMetadataSchema(metadataSchema),
 		WithMetadataTable(metadataTable),
 		WithLogger(log.SimpleLogger()),
+		WithRootDatabase(rootDbName),
 	)
 	defer func(factory Factory) {
 		suite.Require().NoError(factory.Close())


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Bug fix

https://github.com/stripe/pg-schema-diff/issues/78
### Testing
[//]: # (Describe how you tested these changes)
- Unit tests
- Setup a local database that did not have a `postgres` database:
```
 go run ./cmd/pg-schema-diff apply  --dsn "host=localhost user=postgres password=postgres database=reldbbplunkett" --schema-dir ~/stripe/temp/examplesql --allow-hazards INDEX_BUILD
################################## Review plan ##################################
1. ALTER TABLE "public"."foobar" ADD CONSTRAINT "some_constraint" CHECK((id > 0)) NOT VALID;
        -- Statement Timeout: 3s

2. ALTER TABLE "public"."foobar" VALIDATE CONSTRAINT "some_constraint";
        -- Statement Timeout: 3s

3. CREATE INDEX CONCURRENTLY some_idx ON public.foobar USING btree (id);
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s
        -- Hazard INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.

✔ Yes
############################# Executing statement 1 #############################
ALTER TABLE "public"."foobar" ADD CONSTRAINT "some_constraint" CHECK((id > 0)) NOT VALID;
        -- Statement Timeout: 3s

Finished executing statement. Duration: 3.157042ms
############################# Executing statement 2 #############################
ALTER TABLE "public"."foobar" VALIDATE CONSTRAINT "some_constraint";
        -- Statement Timeout: 3s

Finished executing statement. Duration: 941µs
############################# Executing statement 3 #############################
CREATE INDEX CONCURRENTLY some_idx ON public.foobar USING btree (id);
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s
        -- Hazard INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.

Finished executing statement. Duration: 2.808ms
################################### Complete ###################################
Schema applied successfully
```
