### PR TITLE
Remove extraneous `NOT NULL` statement generation. Update README

### DIFF
--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -193,7 +193,6 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexBuild,
 		},
 	},
@@ -281,7 +280,6 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexBuild,
 		},
 	},
@@ -308,7 +306,6 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
 			diff.MigrationHazardTypeIndexBuild,
 		},
@@ -364,7 +361,6 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexBuild,
 		},
 	},
@@ -554,9 +550,9 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
 			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 		},
 		ddl: []string{
 			"ALTER INDEX \"some_idx\" RENAME TO \"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
@@ -569,15 +565,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
 			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
 			"ALTER TABLE ONLY \"public\".\"foobar\" ADD CONSTRAINT \"some_idx\" PRIMARY KEY (foo, id)",
-			"ALTER TABLE \"public\".\"foobar_1\" ALTER COLUMN \"id\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar_1\" ALTER COLUMN \"foo\" SET NOT NULL",
 			"CREATE UNIQUE INDEX CONCURRENTLY foobar_1_pkey ON public.foobar_1 USING btree (foo, id)",
 			"ALTER TABLE \"public\".\"foobar_1\" ADD CONSTRAINT \"foobar_1_pkey\" PRIMARY KEY USING INDEX \"foobar_1_pkey\"",
 			"ALTER INDEX \"some_idx\" ATTACH PARTITION \"foobar_1_pkey\"",
 			"CREATE INDEX CONCURRENTLY new_foobar_1_some_local_idx ON public.foobar_1 USING btree (foo, bar, id)",
 			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar_1 USING btree (foo, bar)",
-			"ALTER TABLE \"public\".\"foobar_2\" ALTER COLUMN \"id\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar_2\" ALTER COLUMN \"foo\" SET NOT NULL",
 			"CREATE UNIQUE INDEX CONCURRENTLY foobar_2_pkey ON public.foobar_2 USING btree (foo, id)",
 			"ALTER TABLE \"public\".\"foobar_2\" ADD CONSTRAINT \"foobar_2_pkey\" PRIMARY KEY USING INDEX \"foobar_2_pkey\"",
 			"ALTER INDEX \"some_idx\" ATTACH PARTITION \"foobar_2_pkey\"",

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -479,6 +479,7 @@ func (schemaSQLGenerator) Alter(diff schemaDiff) ([]Statement, error) {
 	tableGraphs, err := diff.tableDiffs.resolveToSQLGraph(&tableSQLVertexGenerator{
 		deletedTablesByName:     deletedTablesByName,
 		tablesInNewSchemaByName: tablesInNewSchemaByName,
+		tableDiffsByName:        buildDiffByNameMap[schema.Table, tableDiff](diff.tableDiffs.alters),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("resolving table sql graphs: %w", err)
@@ -614,6 +615,7 @@ func buildMap[K comparable, V any](v []V, getKey func(V) K) map[K]V {
 type tableSQLVertexGenerator struct {
 	deletedTablesByName     map[string]schema.Table
 	tablesInNewSchemaByName map[string]schema.Table
+	tableDiffsByName        map[string]tableDiff
 }
 
 var _ sqlVertexGenerator[schema.Table, tableDiff] = &tableSQLVertexGenerator{}
@@ -799,6 +801,11 @@ func (t *tableSQLVertexGenerator) alterPartition(diff tableDiff) ([]Statement, e
 		return nil, fmt.Errorf("check constraints on partitions: %w", ErrNotImplemented)
 	}
 
+	var alteredParentColumnsByName map[string]columnDiff
+	if parentDiff, ok := t.tableDiffsByName[diff.new.ParentTableName]; ok {
+		alteredParentColumnsByName = buildDiffByNameMap[schema.Column, columnDiff](parentDiff.columnsDiff.alters)
+	}
+
 	var stmts []Statement
 	// ColumnsDiff should only have nullability changes. Partitioned tables
 	// aren't concerned about old/new columns added
@@ -806,6 +813,16 @@ func (t *tableSQLVertexGenerator) alterPartition(diff tableDiff) ([]Statement, e
 		if colDiff.old.IsNullable == colDiff.new.IsNullable {
 			continue
 		}
+
+		if parentCol, ok := alteredParentColumnsByName[colDiff.new.Name]; ok {
+			if colDiff.new.IsNullable == parentCol.new.IsNullable && parentCol.new.IsNullable != parentCol.old.IsNullable {
+				// If the parent column nullability matches and we are altering the parent column nullability,
+				// then the column in the partition will just inherit the parent's via the DDL required to alter the
+				// parent's nullability
+				continue
+			}
+		}
+
 		alterColumnPrefix := fmt.Sprintf("%s ALTER COLUMN %s", alterTablePrefix(publicSchemaName(diff.new.Name)), schema.EscapeIdentifier(colDiff.new.Name))
 		if colDiff.new.IsNullable {
 			stmts = append(stmts, Statement{

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -816,9 +816,9 @@ func (t *tableSQLVertexGenerator) alterPartition(diff tableDiff) ([]Statement, e
 
 		if parentCol, ok := alteredParentColumnsByName[colDiff.new.Name]; ok {
 			if colDiff.new.IsNullable == parentCol.new.IsNullable && parentCol.new.IsNullable != parentCol.old.IsNullable {
-				// If the parent column nullability matches and we are altering the parent column nullability,
-				// then the column in the partition will just inherit the parent's via the DDL required to alter the
-				// parent's nullability
+				// If the parent column's new nullability matches the child column, and the parent column's nullability
+				// is being altered, then we don't need to alter the child column's nullability because the DDL required
+				// to alter the parent's nullability will alter the child's nullability as well.
 				continue
 			}
 		}


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Remove extraneous `NOT NULL` statement generation. If the parent table column is being altered from `NULL` -> `NOT NULL` (or vice versa), then we don't need to generate any SQL for the child table

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Simplify SQL generation. This also removes false positive ACCESS_EXCLUSIVE_LOCK migration hazards
https://github.com/stripe/pg-schema-diff/issues/88
### Testing
[//]: # (Describe how you tested these changes)
Acceptance tests