### PR TITLE
Set max connections for plan cmd

### DIFF
--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -242,6 +242,8 @@ func generatePlan(ctx context.Context, logger log.Logger, connConfig *pgx.ConnCo
 	}
 	defer connPool.Close()
 
+	connPool.SetMaxOpenConns(5)
+
 	plan, err := diff.GeneratePlan(ctx, connPool, tempDbFactory, ddl,
 		diff.WithDataPackNewTables(),
 	)

--- a/pkg/diff/plan_generator.go
+++ b/pkg/diff/plan_generator.go
@@ -62,7 +62,7 @@ func WithLogger(logger log.Logger) PlanOpt {
 //
 // Parameters:
 // queryable: 	The target database to generate the diff for. It is recommended to pass in *sql.DB of the db you
-// wish to migrate.
+// wish to migrate. If using a connection pool, it is RECOMMENDED to set a maximum number of connections.
 // tempDbFactory:  	used to create a temporary database instance to extract the schema from the new DDL and validate the
 // migration plan. It is recommended to use tempdb.NewOnInstanceFactory, or you can provide your own.
 // newDDL:  		DDL encoding the new schema


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Now that we fetch schemas in parallel, we should set a maximum number of connections on the connection pool for planning.

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Follow best practices

### Testing
[//]: # (Describe how you tested these changes)
```
 go run ./cmd/pg-schema-diff apply  --dsn "host=localhost user=postgres password=postgres database=somedb" --schema-dir ~/stripe/temp/examplesql
################################## Review plan ##################################
1. ALTER TABLE "public"."foobar" DROP CONSTRAINT "some_other_constraint";
        -- Statement Timeout: 3s

✔ Yes
############################# Executing statement 1 #############################
ALTER TABLE "public"."foobar" DROP CONSTRAINT "some_other_constraint";
        -- Statement Timeout: 3s

Finished executing statement. Duration: 6.794458ms
################################### Complete ###################################
Schema applied successfully

```