### PR TITLE
Add support for fetching non-public schemas.

### DIFF
--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -146,9 +146,147 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		},
 		vanillaExpectations: expectations{
 			empty: true,
+			// Include the table that was filtered out because it is non-public
+			outputState: []string{`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+			CREATE TABLE schema_filtered_1.foo();
+
+			CREATE EXTENSION amcheck;
+
+			CREATE TABLE fizz(
+			);
+
+			CREATE SEQUENCE foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
+
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + increment(a);
+
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    bar SERIAL NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo DESC, bar);
+			CREATE INDEX foobar_hash_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+
+			CREATE table bar(
+			    id  INT PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			ALTER TABLE bar REPLICA IDENTITY FULL;
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+			`},
 		},
 		dataPackingExpectations: expectations{
 			empty: true,
+			// Include the table that was filtered out because it is non-public
+			outputState: []string{`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+			CREATE TABLE schema_filtered_1.foo();
+
+			CREATE EXTENSION amcheck;
+
+			CREATE TABLE fizz(
+			);
+
+			CREATE SEQUENCE foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
+
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + increment(a);
+
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    bar SERIAL NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo DESC, bar);
+			CREATE INDEX foobar_hash_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+
+			CREATE table bar(
+			    id  INT PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			ALTER TABLE bar REPLICA IDENTITY FULL;
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+			`},
 		},
 	},
 	{

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -10,6 +10,10 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+			CREATE TABLE schema_filtered_1.foo();
+
 			CREATE EXTENSION amcheck;
 
 			CREATE TABLE fizz(

--- a/internal/queries/queries.sql.go
+++ b/internal/queries/queries.sql.go
@@ -25,6 +25,7 @@ SELECT
             AND NOT a.attisdropped
     )::TEXT [] AS column_names,
     pg_class.relname::TEXT AS table_name,
+    table_namespace.nspname::TEXT AS table_schema_name,
     pg_constraint.convalidated AS is_valid,
     pg_constraint.connoinherit AS is_not_inheritable,
     pg_catalog.pg_get_expr(
@@ -32,9 +33,12 @@ SELECT
     ) AS constraint_expression
 FROM pg_catalog.pg_constraint
 INNER JOIN pg_catalog.pg_class ON pg_constraint.conrelid = pg_class.oid
+INNER JOIN
+    pg_catalog.pg_namespace AS table_namespace
+    ON pg_class.relnamespace = table_namespace.oid
 WHERE
-    pg_class.relnamespace
-    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    table_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND table_namespace.nspname !~ '^pg_toast'
     AND pg_constraint.contype = 'c'
     AND pg_constraint.conislocal
 `
@@ -44,6 +48,7 @@ type GetCheckConstraintsRow struct {
 	ConstraintName       string
 	ColumnNames          []string
 	TableName            string
+	TableSchemaName      string
 	IsValid              bool
 	IsNotInheritable     bool
 	ConstraintExpression string
@@ -63,6 +68,7 @@ func (q *Queries) GetCheckConstraints(ctx context.Context) ([]GetCheckConstraint
 			&i.ConstraintName,
 			pq.Array(&i.ColumnNames),
 			&i.TableName,
+			&i.TableSchemaName,
 			&i.IsValid,
 			&i.IsNotInheritable,
 			&i.ConstraintExpression,
@@ -244,7 +250,9 @@ FROM pg_catalog.pg_namespace AS extension_namespace
 INNER JOIN
     pg_catalog.pg_extension AS ext
     ON ext.extnamespace = extension_namespace.oid
-WHERE extension_namespace.nspname = 'public'
+WHERE
+    extension_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND extension_namespace.nspname !~ '^pg_toast'
 `
 
 type GetExtensionsRow struct {
@@ -304,7 +312,8 @@ INNER JOIN pg_catalog.pg_namespace AS foreign_table_namespace
     ON
         foreign_table_c.relnamespace = foreign_table_namespace.oid
 WHERE
-    constraint_namespace.nspname = 'public'
+    constraint_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND constraint_namespace.nspname !~ '^pg_toast'
     AND pg_constraint.contype = 'f'
     AND pg_constraint.conislocal
 `
@@ -368,7 +377,8 @@ INNER JOIN
     pg_catalog.pg_language AS proc_lang
     ON proc_lang.oid = pg_proc.prolang
 WHERE
-    proc_namespace.nspname = 'public'
+    proc_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND proc_namespace.nspname !~ '^pg_toast'
     AND pg_proc.prokind = 'f'
     -- Exclude functions belonging to extensions
     AND NOT EXISTS (
@@ -425,6 +435,7 @@ SELECT
     c.oid AS oid,
     c.relname::TEXT AS index_name,
     table_c.relname::TEXT AS table_name,
+    table_namespace.nspname::TEXT AS table_schema_name,
     pg_catalog.pg_get_indexdef(c.oid)::TEXT AS def_stmt,
     COALESCE(con.conname, '')::TEXT AS constraint_name,
     COALESCE(con.contype, '')::TEXT AS constraint_type,
@@ -440,6 +451,8 @@ SELECT
 FROM pg_catalog.pg_class AS c
 INNER JOIN pg_catalog.pg_index AS i ON (i.indexrelid = c.oid)
 INNER JOIN pg_catalog.pg_class AS table_c ON (table_c.oid = i.indrelid)
+INNER JOIN pg_catalog.pg_namespace AS table_namespace
+    ON table_c.relnamespace = table_namespace.oid
 LEFT JOIN
     pg_catalog.pg_constraint AS con
     ON (con.conindid = c.oid AND con.contype IN ('p', 'u', null))
@@ -453,8 +466,8 @@ LEFT JOIN
     pg_catalog.pg_namespace AS parent_namespace
     ON parent_c.relnamespace = parent_namespace.oid
 WHERE
-    c.relnamespace
-    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    table_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND table_namespace.nspname !~ '^pg_toast'
     AND (c.relkind = 'i' OR c.relkind = 'I')
 `
 
@@ -462,6 +475,7 @@ type GetIndexesRow struct {
 	Oid                   interface{}
 	IndexName             string
 	TableName             string
+	TableSchemaName       string
 	DefStmt               string
 	ConstraintName        string
 	ConstraintType        string
@@ -487,6 +501,7 @@ func (q *Queries) GetIndexes(ctx context.Context) ([]GetIndexesRow, error) {
 			&i.Oid,
 			&i.IndexName,
 			&i.TableName,
+			&i.TableSchemaName,
 			&i.DefStmt,
 			&i.ConstraintName,
 			&i.ConstraintType,
@@ -542,15 +557,18 @@ LEFT JOIN pg_catalog.pg_class AS owner_c ON depend.refobjid = owner_c.oid
 LEFT JOIN
     pg_catalog.pg_namespace AS owner_ns
     ON owner_c.relnamespace = owner_ns.oid
-WHERE seq_ns.nspname = 'public'
-AND NOT EXISTS (
-    SELECT ext_depend.objid
-    FROM pg_catalog.pg_depend AS ext_depend
-    WHERE
-        ext_depend.classid = 'pg_class'::REGCLASS
-        AND ext_depend.objid = pg_seq.seqrelid
-        AND ext_depend.deptype = 'e'
-)
+WHERE
+    seq_ns.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND seq_ns.nspname !~ '^pg_toast'
+    -- It doesn't belong to an extension
+    AND NOT EXISTS (
+        SELECT ext_depend.objid
+        FROM pg_catalog.pg_depend AS ext_depend
+        WHERE
+            ext_depend.classid = 'pg_class'::REGCLASS
+            AND ext_depend.objid = pg_seq.seqrelid
+            AND ext_depend.deptype = 'e'
+    )
 `
 
 type GetSequencesRow struct {
@@ -568,7 +586,6 @@ type GetSequencesRow struct {
 	DataType           string
 }
 
-// It doesn't belong to an extension
 func (q *Queries) GetSequences(ctx context.Context) ([]GetSequencesRow, error) {
 	rows, err := q.db.QueryContext(ctx, getSequences)
 	if err != nil {
@@ -609,6 +626,7 @@ const getTables = `-- name: GetTables :many
 SELECT
     c.oid AS oid,
     c.relname::TEXT AS table_name,
+    table_namespace.nspname::TEXT AS table_schema_name,
     c.relreplident::TEXT AS replica_identity,
     COALESCE(parent_c.relname, '')::TEXT AS parent_table_name,
     COALESCE(parent_namespace.nspname, '')::TEXT AS parent_table_schema_name,
@@ -622,6 +640,9 @@ SELECT
         ELSE ''
     END)::TEXT AS partition_for_values
 FROM pg_catalog.pg_class AS c
+INNER JOIN
+    pg_catalog.pg_namespace AS table_namespace
+    ON c.relnamespace = table_namespace.oid
 LEFT JOIN
     pg_catalog.pg_inherits AS table_inherits
     ON table_inherits.inhrelid = c.oid
@@ -632,14 +653,15 @@ LEFT JOIN
     pg_catalog.pg_namespace AS parent_namespace
     ON parent_c.relnamespace = parent_namespace.oid
 WHERE
-    c.relnamespace
-    = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public')
+    table_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND table_namespace.nspname !~ '^pg_toast'
     AND (c.relkind = 'r' OR c.relkind = 'p')
 `
 
 type GetTablesRow struct {
 	Oid                   interface{}
 	TableName             string
+	TableSchemaName       string
 	ReplicaIdentity       string
 	ParentTableName       string
 	ParentTableSchemaName string
@@ -659,6 +681,7 @@ func (q *Queries) GetTables(ctx context.Context) ([]GetTablesRow, error) {
 		if err := rows.Scan(
 			&i.Oid,
 			&i.TableName,
+			&i.TableSchemaName,
 			&i.ReplicaIdentity,
 			&i.ParentTableName,
 			&i.ParentTableSchemaName,
@@ -699,8 +722,8 @@ INNER JOIN
     pg_catalog.pg_namespace AS proc_namespace
     ON pg_proc.pronamespace = proc_namespace.oid
 WHERE
-    proc_namespace.nspname = 'public'
-    AND owning_c_namespace.nspname = 'public'
+    owning_c_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND owning_c_namespace.nspname !~ '^pg_toast'
     AND trig.tgparentid = 0
     AND NOT trig.tgisinternal
 `

--- a/internal/schema/filters.go
+++ b/internal/schema/filters.go
@@ -1,0 +1,32 @@
+package schema
+
+// nameFilter is one of the most generic of filters. We can use it to filter objects by their schema name or name.
+// In the future, it might be expanded to include a "type" field, e.g., to filter down to specific tables.
+type nameFilter func(name SchemaQualifiedName) bool
+
+func schemaNameFilter(schema string) nameFilter {
+	return func(obj SchemaQualifiedName) bool {
+		return obj.SchemaName == schema
+	}
+}
+
+func orNameFilter(filters ...nameFilter) nameFilter {
+	return func(obj SchemaQualifiedName) bool {
+		for _, filter := range filters {
+			if filter(obj) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func filterSliceByName[T any](objs []T, getNameFn func(T) SchemaQualifiedName, filter nameFilter) []T {
+	var filteredObjs []T
+	for _, obj := range objs {
+		if filter(getNameFn(obj)) {
+			filteredObjs = append(filteredObjs, obj)
+		}
+	}
+	return filteredObjs
+}

--- a/internal/schema/filters_test.go
+++ b/internal/schema/filters_test.go
@@ -1,0 +1,95 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type (
+	fakeNameFilterMock struct {
+		expectedInput SchemaQualifiedName
+		returnValue   bool
+	}
+	fakeNameFilter struct {
+		t    *testing.T
+		mock fakeNameFilterMock
+	}
+)
+
+func newFakeNameFilter(t *testing.T, mock fakeNameFilterMock) fakeNameFilter {
+	return fakeNameFilter{
+		t:    t,
+		mock: mock,
+	}
+}
+
+func (f fakeNameFilter) filter(input SchemaQualifiedName) bool {
+	assert.Equal(f.t, f.mock.expectedInput, input)
+	return f.mock.returnValue
+}
+
+func TestOrNameFilters(t *testing.T) {
+	someName1 := SchemaQualifiedName{
+		SchemaName:  "some_schema",
+		EscapedName: "some_name",
+	}
+	for _, tc := range []struct {
+		name        string
+		input       SchemaQualifiedName
+		filters     []fakeNameFilterMock
+		expectedOut bool
+	}{
+		{
+			name:        "empty",
+			input:       someName1,
+			expectedOut: false,
+		},
+		{
+			name:  "one filter (true)",
+			input: someName1,
+			filters: []fakeNameFilterMock{
+				{
+					expectedInput: someName1,
+					returnValue:   true,
+				},
+			},
+			expectedOut: true,
+		},
+		{
+			name:  "one filter (false)",
+			input: someName1,
+			filters: []fakeNameFilterMock{
+				{expectedInput: someName1, returnValue: false},
+			},
+			expectedOut: false,
+		},
+		{
+			name:  "two filters (false, true)",
+			input: someName1,
+			filters: []fakeNameFilterMock{
+				{expectedInput: someName1, returnValue: false},
+				{expectedInput: someName1, returnValue: true},
+			},
+			expectedOut: true,
+		},
+		{
+			name:  "two filters (false, false)",
+			input: someName1,
+			filters: []fakeNameFilterMock{
+				{expectedInput: someName1, returnValue: false},
+				{expectedInput: someName1, returnValue: false},
+			},
+			expectedOut: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var filters []nameFilter
+			for _, filter := range tc.filters {
+				filters = append(filters, newFakeNameFilter(t, filter).filter)
+			}
+			assert.Equal(t, tc.expectedOut, orNameFilter(filters...)(tc.input))
+		})
+	}
+
+}

--- a/pkg/diff/schema_migration_plan_test.go
+++ b/pkg/diff/schema_migration_plan_test.go
@@ -43,7 +43,8 @@ var (
 			oldSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -55,8 +56,9 @@ var (
 				},
 				Indexes: []schema.Index{
 					{
-						TableName: "foobar",
-						Name:      "some_idx", Columns: []string{"foo", "bar"},
+						TableName:   "foobar",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:        "some_idx", Columns: []string{"foo", "bar"},
 						GetIndexDefStmt: "CREATE INDEX some_idx ON public.foobar USING btree (foo, bar)",
 						IsUnique:        true, IsInvalid: true,
 					},
@@ -65,7 +67,8 @@ var (
 			newSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -78,8 +81,9 @@ var (
 				Indexes: []schema.Index{
 
 					{
-						TableName: "foobar",
-						Name:      "some_idx", Columns: []string{"foo", "bar"},
+						TableName:   "foobar",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:        "some_idx", Columns: []string{"foo", "bar"},
 						GetIndexDefStmt: "CREATE INDEX some_idx ON public.foobar USING btree (foo, bar)",
 						IsUnique:        true,
 					},
@@ -110,7 +114,8 @@ var (
 			oldSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -121,8 +126,10 @@ var (
 						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
-						ParentTableName: "foobar",
-						Name:            "foobar_1",
+						ParentTableName:     "foobar",
+						ParentTable:         &schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:                "foobar_1",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -136,15 +143,17 @@ var (
 				Indexes: []schema.Index{
 					// foobar indexes
 					{
-						TableName: "foobar",
-						Name:      "some_idx", Columns: []string{"foo, bar"},
+						TableName:   "foobar",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:        "some_idx", Columns: []string{"foo, bar"},
 						GetIndexDefStmt: "CREATE INDEX some_idx ON ONLY public.foobar USING btree (foo, bar)",
 						IsInvalid:       true,
 					},
 					// foobar_1 indexes
 					{
-						TableName: "foobar_1",
-						Name:      "foobar_1_some_idx", Columns: []string{"foo", "bar"},
+						TableName:   "foobar_1",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
+						Name:        "foobar_1_some_idx", Columns: []string{"foo", "bar"},
 						GetIndexDefStmt: "CREATE INDEX foobar_1_some_idx ON public.foobar_1 USING btree (foo, bar)",
 						IsInvalid:       true,
 					},
@@ -153,7 +162,8 @@ var (
 			newSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -164,8 +174,10 @@ var (
 						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
-						ParentTableName: "foobar",
-						Name:            "foobar_1",
+						ParentTableName:     "foobar",
+						ParentTable:         &schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:                "foobar_1",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -179,14 +191,16 @@ var (
 				Indexes: []schema.Index{
 					// foobar indexes
 					{
-						TableName: "foobar",
-						Name:      "some_idx", Columns: []string{"foo, bar"},
+						TableName:   "foobar",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:        "some_idx", Columns: []string{"foo, bar"},
 						GetIndexDefStmt: "CREATE INDEX some_idx ON ONLY public.foobar USING btree (foo, bar)",
 					},
 					// foobar_1 indexes
 					{
-						TableName: "foobar_1",
-						Name:      "foobar_1_some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "some_idx",
+						TableName:   "foobar_1",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
+						Name:        "foobar_1_some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "some_idx",
 						GetIndexDefStmt: "CREATE INDEX foobar_1_some_idx ON public.foobar_1 USING btree (foo, bar)",
 					},
 				},
@@ -225,7 +239,8 @@ var (
 			oldSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "id", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -238,7 +253,8 @@ var (
 			newSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "something", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -256,7 +272,8 @@ var (
 			oldSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -267,8 +284,10 @@ var (
 						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
-						ParentTableName: "foobar",
-						Name:            "foobar_1",
+						ParentTableName:     "foobar",
+						ParentTable:         &schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:                "foobar_1",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -282,15 +301,17 @@ var (
 				Indexes: []schema.Index{
 					// foobar indexes
 					{
-						TableName: "foobar",
+						TableName:   "foobar",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						// This index points to its child, which is wrong, but induces a loop
 						Name: "some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "foobar_1_some_idx",
 						GetIndexDefStmt: "CREATE INDEX some_idx ON ONLY public.foobar USING btree (foo, bar)",
 					},
 					// foobar_1 indexes
 					{
-						TableName: "foobar_1",
-						Name:      "foobar_1_some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "some_idx",
+						TableName:   "foobar_1",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
+						Name:        "foobar_1_some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "some_idx",
 						GetIndexDefStmt: "CREATE INDEX foobar_1_some_idx ON public.foobar_1 USING btree (foo, bar)",
 					},
 				},
@@ -298,7 +319,8 @@ var (
 			newSchema: schema.Schema{
 				Tables: []schema.Table{
 					{
-						Name: "foobar",
+						Name:                "foobar",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -309,8 +331,10 @@ var (
 						PartitionKeyDef:  "LIST(foo)",
 					},
 					{
-						ParentTableName: "foobar",
-						Name:            "foobar_1",
+						ParentTableName:     "foobar",
+						ParentTable:         &schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
+						Name:                "foobar_1",
+						SchemaQualifiedName: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
 						Columns: []schema.Column{
 							{Name: "id", Type: "integer"},
 							{Name: "foo", Type: "character varying(255)", Default: "''::character varying", Collation: defaultCollation},
@@ -324,15 +348,17 @@ var (
 				Indexes: []schema.Index{
 					// foobar indexes
 					{
-						TableName: "foobar",
+						TableName:   "foobar",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar\""},
 						// This index points to its child, which is wrong, but induces a loop
 						Name: "some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "foobar_1_some_idx",
 						GetIndexDefStmt: "CREATE INDEX some_idx ON ONLY public.foobar USING btree (foo, bar)",
 					},
 					// foobar_1 indexes
 					{
-						TableName: "foobar_1",
-						Name:      "foobar_1_some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "some_idx",
+						TableName:   "foobar_1",
+						OwningTable: schema.SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foobar_1\""},
+						Name:        "foobar_1_some_idx", Columns: []string{"foo", "bar"}, ParentIdxName: "some_idx",
 						GetIndexDefStmt: "CREATE INDEX foobar_1_some_idx ON public.foobar_1 USING btree (foo, bar)",
 					},
 				},

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -12,7 +12,7 @@ import (
 // plan to determine if the plan is still valid
 // We do not expose the Schema struct yet because it is subject to change, and we do not want folks depending on its API
 func GetPublicSchemaHash(ctx context.Context, queryable sqldb.Queryable) (string, error) {
-	schema, err := internalschema.GetPublicSchema(ctx, queryable)
+	schema, err := internalschema.GetSchema(ctx, queryable, internalschema.WithSchemas("public"))
 	if err != nil {
 		return "", fmt.Errorf("getting public schema: %w", err)
 	}


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
This only adds support for fetching non-public schemas. This does actually allow generating migration plans for non-public schemas because we will need plumb several into the sql generation code to account for schemas.

I opted to do the filtering in-memory because it is way more flexible to do the filtering in-memory rather than in the queries. We can easily support things like regex and complex nested operations in the future (unions of intersections, etc). I don't expect the filters to significantly reduce the number of schema objects being fetched, so the performance impact of doing it in-memory is minimal.

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
https://github.com/stripe/pg-schema-diff/issues/94

### Testing
[//]: # (Describe how you tested these changes)
Tested via unit tests
