### PR TITLE
New GeneratePlan interface

### DIFF
--- a/internal/migration_acceptance_tests/backwards_compat_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_test.go
@@ -1,0 +1,182 @@
+package migration_acceptance_tests
+
+import "github.com/stripe/pg-schema-diff/pkg/diff"
+
+var backCompatAcceptanceTestCases = []acceptanceTestCase{
+	{
+		name: "Drop partitioned table, Add partitioned table with local keys",
+		oldSchemaDDL: []string{
+			`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+			CREATE TABLE schema_filtered_1.foo();	
+
+			CREATE TABLE foobar(
+			    id INT,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+
+			CREATE TABLE fizz(
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE new_foobar(
+			    id INT,
+				bar TIMESTAMPTZ NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+
+			CREATE TABLE foobar_1 PARTITION of new_foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+
+			CREATE TABLE fizz(
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+		},
+		vanillaExpectations: expectations{
+			outputState: []string{`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+			CREATE TABLE schema_filtered_1.foo();	
+
+			CREATE TABLE new_foobar(
+			    id INT,
+				bar TIMESTAMPTZ NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+
+			CREATE TABLE foobar_1 PARTITION of new_foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+
+			CREATE TABLE fizz(
+			);
+			`},
+		},
+		dataPackingExpectations: expectations{
+			outputState: []string{
+				`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+			CREATE TABLE schema_filtered_1.foo();	
+
+			CREATE TABLE new_foobar(
+				bar TIMESTAMPTZ NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+
+			CREATE TABLE foobar_1 PARTITION of new_foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+
+			CREATE TABLE fizz(
+			);
+			`,
+			},
+		},
+
+		// Ensure that we're maintaining backwards compatibility with the old generate plan func
+		useOldGeneratePlan: true,
+	},
+}
+
+func (suite *acceptanceTestSuite) TestBackCompatAcceptanceTestCases() {
+	suite.runTestCases(backCompatAcceptanceTestCases)
+}

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -10,10 +10,6 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-            CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();
-
 			CREATE EXTENSION amcheck;
 
 			CREATE TABLE fizz(
@@ -146,147 +142,9 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		},
 		vanillaExpectations: expectations{
 			empty: true,
-			// Include the table that was filtered out because it is non-public
-			outputState: []string{`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-            CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();
-
-			CREATE EXTENSION amcheck;
-
-			CREATE TABLE fizz(
-			);
-
-			CREATE SEQUENCE foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
-
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + increment(a);
-
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
-
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
-
-			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-			`},
 		},
 		dataPackingExpectations: expectations{
 			empty: true,
-			// Include the table that was filtered out because it is non-public
-			outputState: []string{`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-            CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();
-
-			CREATE EXTENSION amcheck;
-
-			CREATE TABLE fizz(
-			);
-
-			CREATE SEQUENCE foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
-
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + increment(a);
-
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
-
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
-
-			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-			`},
 		},
 	},
 	{

--- a/pkg/diff/plan_generator.go
+++ b/pkg/diff/plan_generator.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/kr/pretty"
 	"github.com/stripe/pg-schema-diff/internal/schema"
@@ -21,6 +22,10 @@ const (
 	tempDbMaxConnections = 5
 )
 
+var (
+	errTempDbFactoryRequired = fmt.Errorf("tempDbFactory is required. include the option WithTempDbFactory")
+)
+
 type (
 	planOptions struct {
 		tempDbFactory           tempdb.Factory
@@ -28,7 +33,14 @@ type (
 		ignoreChangesToColOrder bool
 		logger                  log.Logger
 		validatePlan            bool
-		getSchemaOpts           []schema.GetSchemaOpt
+
+		getSchemaOpts []schema.GetSchemaOpt
+		// filteredSchemas is a map of schemas to filter out. We can deprecate this field once we can start allowing
+		// users to not specify the "public" schema. Users must currently specify the "public" schema because we
+		// do not support diffing non-public schemas
+		filteredSchemas map[string]bool
+		// allowCustomSchemaOpts is a temporary flag to allow acceptance tests to use custom schema opts.
+		allowCustomSchemaOpts bool
 	}
 
 	PlanOpt func(opts *planOptions)
@@ -71,7 +83,25 @@ func WithLogger(logger log.Logger) PlanOpt {
 	}
 }
 
-// GeneratePlan generates a migration plan to migrate the database to the target schema.
+func WithSchemas(schemas ...string) PlanOpt {
+	return func(opts *planOptions) {
+		for _, schema := range schemas {
+			opts.filteredSchemas[schema] = true
+		}
+		opts.getSchemaOpts = append(opts.getSchemaOpts, schema.WithSchemas(schemas...))
+	}
+}
+
+// WithBetaDoNotCallWithAllowCustomSchemaOpts is a temporary flag to allow acceptance tests to use custom schema opts.
+// Do not call this unless you know what you are doing.
+func WithBetaDoNotCallWithAllowCustomSchemaOpts() PlanOpt {
+	return func(opts *planOptions) {
+		opts.allowCustomSchemaOpts = true
+	}
+}
+
+// GeneratePlan generates a migration plan to migrate the database to the target schema. This function only
+// diffs the public schemas.
 //
 // Parameters:
 // queryable: 	The target database to generate the diff for. It is recommended to pass in *sql.DB of the db you
@@ -80,10 +110,13 @@ func WithLogger(logger log.Logger) PlanOpt {
 // migration plan. It is recommended to use tempdb.NewOnInstanceFactory, or you can provide your own.
 // newDDL:  		DDL encoding the new schema
 // opts:  			Additional options to configure the plan generation
-func GeneratePlan(ctx context.Context, fromDB sqldb.Queryable, targetSchema SchemaSource, opts ...PlanOpt) (Plan, error) {
-	return Generate(ctx, fromDB, targetSchema, opts...)
+func GeneratePlan(ctx context.Context, queryable sqldb.Queryable, tempdbFactory tempdb.Factory, newDDL []string, opts ...PlanOpt) (Plan, error) {
+	return Generate(ctx, queryable, DDLSchemaSource(newDDL), append(opts, WithTempDbFactory(tempdbFactory), WithSchemas("public"))...)
 }
 
+// Generate will become the new GeneratePlan function. It is currently _exported_ because we will want
+// to call this function from acceptance tests (separate package). It is not yet ready for public consumption.
+// Please use GeneratePlan instead.
 func Generate(
 	ctx context.Context,
 	fromDB sqldb.Queryable,
@@ -94,17 +127,30 @@ func Generate(
 		validatePlan:            true,
 		ignoreChangesToColOrder: true,
 		logger:                  log.SimpleLogger(),
-		getSchemaOpts:           []schema.GetSchemaOpt{schema.WithSchemas("public")},
+		filteredSchemas:         make(map[string]bool),
 	}
 	for _, opt := range opts {
 		opt(planOptions)
+	}
+
+	// A temporary shim to provide backwards compatibility with the old GeneratePlan function and allow folks
+	if !planOptions.allowCustomSchemaOpts {
+		if diff := cmp.Diff(map[string]bool{
+			"public": true,
+		}, planOptions.filteredSchemas); diff != "" {
+			return Plan{}, fmt.Errorf("only diffing the public schema is currently supported. You must specify WithSchemas(\"public\") if using Generate. diff=\n%s", diff)
+		}
 	}
 
 	currentSchema, err := schema.GetSchema(ctx, fromDB, planOptions.getSchemaOpts...)
 	if err != nil {
 		return Plan{}, fmt.Errorf("getting current schema: %w", err)
 	}
-	newSchema, err := deriveSchemaFromDDLOnTempDb(ctx, planOptions.logger, tempDbFactory, newDDL)
+	newSchema, err := targetSchema.GetSchema(ctx, schemaSourcePlanDeps{
+		tempDBFactory: planOptions.tempDbFactory,
+		logger:        planOptions.logger,
+		getSchemaOpts: planOptions.getSchemaOpts,
+	})
 	if err != nil {
 		return Plan{}, fmt.Errorf("getting new schema: %w", err)
 	}
@@ -125,7 +171,10 @@ func Generate(
 	}
 
 	if planOptions.validatePlan {
-		if err := assertValidPlan(ctx, tempDbFactory, currentSchema, newSchema, plan, planOptions); err != nil {
+		if planOptions.tempDbFactory == nil {
+			return Plan{}, fmt.Errorf("cannot validate plan without a tempDbFactory: %w", errTempDbFactoryRequired)
+		}
+		if err := assertValidPlan(ctx, planOptions.tempDbFactory, currentSchema, newSchema, plan, planOptions); err != nil {
 			return Plan{}, fmt.Errorf("validating migration plan: %w \n%# v", err, pretty.Formatter(plan))
 		}
 	}

--- a/pkg/diff/schema_source.go
+++ b/pkg/diff/schema_source.go
@@ -1,0 +1,51 @@
+package diff
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stripe/pg-schema-diff/internal/schema"
+	"github.com/stripe/pg-schema-diff/pkg/log"
+	"github.com/stripe/pg-schema-diff/pkg/tempdb"
+)
+
+type schemaSourcePlanDeps struct {
+	factory tempdb.Factory
+	logger  log.Logger
+}
+
+type SchemaSource interface {
+	GetSchema(ctx context.Context, deps schemaSourcePlanDeps) (schema.Schema, error)
+}
+
+type ddlSchemaSource struct {
+	ddl []string
+}
+
+func DDLSchemaSource(ddl []string) SchemaSource {
+	return ddlSchemaSource{ddl: ddl}
+}
+
+func (s ddlSchemaSource) GetSchema(ctx context.Context, deps schemaSourcePlanDeps) (schema.Schema, error) {
+	return deriveSchemaFromDDLOnTempDb(ctx, deps.logger, deps.factory, s.ddl)
+}
+
+func deriveSchemaFromDDLOnTempDb(ctx context.Context, logger log.Logger, tempDbFactory tempdb.Factory, ddl []string) (schema.Schema, error) {
+	tempDb, dropTempDb, err := tempDbFactory.Create(ctx)
+	if err != nil {
+		return schema.Schema{}, fmt.Errorf("creating temp database: %w", err)
+	}
+	defer func(drop tempdb.Dropper) {
+		if err := drop(ctx); err != nil {
+			logger.Errorf("an error occurred while dropping the temp database: %s", err)
+		}
+	}(dropTempDb)
+
+	for _, stmt := range ddl {
+		if _, err := tempDb.ExecContext(ctx, stmt); err != nil {
+			return schema.Schema{}, fmt.Errorf("running DDL: %w", err)
+		}
+	}
+
+	return schema.GetSchema(ctx, tempDb, schema.WithSchemas("public"))
+}

--- a/pkg/diff/schema_source.go
+++ b/pkg/diff/schema_source.go
@@ -10,8 +10,9 @@ import (
 )
 
 type schemaSourcePlanDeps struct {
-	factory tempdb.Factory
-	logger  log.Logger
+	tempDBFactory tempdb.Factory
+	logger        log.Logger
+	getSchemaOpts []schema.GetSchemaOpt
 }
 
 type SchemaSource interface {
@@ -23,29 +24,29 @@ type ddlSchemaSource struct {
 }
 
 func DDLSchemaSource(ddl []string) SchemaSource {
-	return ddlSchemaSource{ddl: ddl}
+	return &ddlSchemaSource{ddl: ddl}
 }
 
-func (s ddlSchemaSource) GetSchema(ctx context.Context, deps schemaSourcePlanDeps) (schema.Schema, error) {
-	return deriveSchemaFromDDLOnTempDb(ctx, deps.logger, deps.factory, s.ddl)
-}
+func (s *ddlSchemaSource) GetSchema(ctx context.Context, deps schemaSourcePlanDeps) (schema.Schema, error) {
+	if deps.tempDBFactory == nil {
+		return schema.Schema{}, errTempDbFactoryRequired
+	}
 
-func deriveSchemaFromDDLOnTempDb(ctx context.Context, logger log.Logger, tempDbFactory tempdb.Factory, ddl []string) (schema.Schema, error) {
-	tempDb, dropTempDb, err := tempDbFactory.Create(ctx)
+	tempDb, dropTempDb, err := deps.tempDBFactory.Create(ctx)
 	if err != nil {
 		return schema.Schema{}, fmt.Errorf("creating temp database: %w", err)
 	}
 	defer func(drop tempdb.Dropper) {
 		if err := drop(ctx); err != nil {
-			logger.Errorf("an error occurred while dropping the temp database: %s", err)
+			deps.logger.Errorf("an error occurred while dropping the temp database: %s", err)
 		}
 	}(dropTempDb)
 
-	for _, stmt := range ddl {
+	for _, stmt := range s.ddl {
 		if _, err := tempDb.ExecContext(ctx, stmt); err != nil {
 			return schema.Schema{}, fmt.Errorf("running DDL: %w", err)
 		}
 	}
 
-	return schema.GetSchema(ctx, tempDb, schema.WithSchemas("public"))
+	return schema.GetSchema(ctx, tempDb, deps.getSchemaOpts...)
 }


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
New generate plan interface
- Will enable us to support diffing two databases
- Does not filter to `public` schemas by default

This function has a new name to avoid conflicting with the old function. The old function will be deprecated soon.

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Support non-public schemas and diffing between two databases

### Testing
[//]: # (Describe how you tested these changes)
