### PR TITLE
Update CLI with multi-schema support and database schema source

### DIFF
--- a/cmd/pg-schema-diff/apply_cmd.go
+++ b/cmd/pg-schema-diff/apply_cmd.go
@@ -28,12 +28,12 @@ func buildApplyCmd() *cobra.Command {
 			" (example: --allowed-hazards DELETES_DATA,INDEX_BUILD)")
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		logger := log.SimpleLogger()
-		connConfig, err := connFlags.parseConnConfig(logger)
+		connConfig, err := parseConnConfig(*connFlags, logger)
 		if err != nil {
 			return err
 		}
 
-		planConfig, err := planFlags.parsePlanConfig()
+		planConfig, err := parsePlanConfig(*planFlags)
 		if err != nil {
 			return err
 		}

--- a/cmd/pg-schema-diff/flags.go
+++ b/cmd/pg-schema-diff/flags.go
@@ -7,28 +7,23 @@ import (
 )
 
 type connFlags struct {
-	dsn *string
+	dsn string
 }
 
-func createConnFlags(cmd *cobra.Command) connFlags {
-	dsn := cmd.Flags().String("dsn", "", "Connection string for the database (DB password can be specified through PGPASSWORD environment variable)")
+func createConnFlags(cmd *cobra.Command) *connFlags {
+	flags := &connFlags{}
+
+	cmd.Flags().StringVar(&flags.dsn, "dsn", "", "Connection string for the database (DB password can be specified through PGPASSWORD environment variable)")
 	// Don't mark dsn as a required flag.
 	// Allow users to use the "PGHOST" etc environment variables like `psql`.
-	return connFlags{
-		dsn: dsn,
-	}
+
+	return flags
 }
 
-func (c connFlags) parseConnConfig(logger log.Logger) (*pgx.ConnConfig, error) {
-	if c.dsn == nil || *c.dsn == "" {
+func parseConnConfig(c connFlags, logger log.Logger) (*pgx.ConnConfig, error) {
+	if c.dsn == "" {
 		logger.Warnf("DSN flag not set. Using libpq environment variables and default values.")
 	}
 
-	return pgx.ParseConfig(*c.dsn)
-}
-
-func mustMarkFlagAsRequired(cmd *cobra.Command, flagName string) {
-	if err := cmd.MarkFlagRequired(flagName); err != nil {
-		panic(err)
-	}
+	return pgx.ParseConfig(c.dsn)
 }

--- a/pkg/diff/plan_generator.go
+++ b/pkg/diff/plan_generator.go
@@ -75,7 +75,7 @@ func WithLogger(logger log.Logger) PlanOpt {
 	}
 }
 
-func WithSchemas(schemas ...string) PlanOpt {
+func WithIncludeSchemas(schemas ...string) PlanOpt {
 	return func(opts *planOptions) {
 		opts.getSchemaOpts = append(opts.getSchemaOpts, schema.WithIncludeSchemas(schemas...))
 	}
@@ -96,7 +96,7 @@ func WithGetSchemaOpts(getSchemaOpts ...externalschema.GetSchemaOpt) PlanOpt {
 // deprecated: GeneratePlan generates a migration plan to migrate the database to the target schema. This function only
 // diffs the public schemas.
 //
-// Use Generate instead with the DDLSchemaSource(newDDL) and WithSchemas("public") and WithTempDbFactory options.
+// Use Generate instead with the DDLSchemaSource(newDDL) and WithIncludeSchemas("public") and WithTempDbFactory options.
 //
 // Parameters:
 // queryable: 	The target database to generate the diff for. It is recommended to pass in *sql.DB of the db you
@@ -106,7 +106,7 @@ func WithGetSchemaOpts(getSchemaOpts ...externalschema.GetSchemaOpt) PlanOpt {
 // newDDL:  		DDL encoding the new schema
 // opts:  			Additional options to configure the plan generation
 func GeneratePlan(ctx context.Context, queryable sqldb.Queryable, tempdbFactory tempdb.Factory, newDDL []string, opts ...PlanOpt) (Plan, error) {
-	return Generate(ctx, queryable, DDLSchemaSource(newDDL), append(opts, WithTempDbFactory(tempdbFactory), WithSchemas("public"))...)
+	return Generate(ctx, queryable, DDLSchemaSource(newDDL), append(opts, WithTempDbFactory(tempdbFactory), WithIncludeSchemas("public"))...)
 }
 
 // Generate generates a migration plan to migrate the database to the target schema

--- a/pkg/diff/plan_generator_test.go
+++ b/pkg/diff/plan_generator_test.go
@@ -175,7 +175,7 @@ func (suite *planGeneratorTestSuite) TestGenerate_CannotBuildMigrationFromDDLWit
 	pool := suite.mustGetTestDBPool()
 	defer pool.Close()
 	_, err := Generate(context.Background(), pool, DDLSchemaSource([]string{``}),
-		WithSchemas("public"),
+		WithIncludeSchemas("public"),
 		WithDoNotValidatePlan(),
 	)
 	suite.ErrorContains(err, "tempDbFactory is required")
@@ -185,7 +185,7 @@ func (suite *planGeneratorTestSuite) TestGenerate_CannotValidateWithoutTempDbFac
 	pool := suite.mustGetTestDBPool()
 	defer pool.Close()
 	_, err := Generate(context.Background(), pool, DDLSchemaSource([]string{``}),
-		WithSchemas("public"),
+		WithIncludeSchemas("public"),
 		WithDoNotValidatePlan(),
 	)
 	suite.ErrorContains(err, "tempDbFactory is required")


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
- Add multi-schema support to CLI
- Add support for a database schema source to the CLI

In a follow-up PR, I'm going to update the statement modifiers to follow logfmt. The current way they are specified is awful.

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
https://github.com/stripe/pg-schema-diff/issues/105

### Testing
[//]: # (Describe how you tested these changes)

Normal (notice the some_schema related operations):
```
 ~/stripe/pg-schema-diff │ bplunkett/up…hema-support  go run ./cmd/pg-schema-diff plan  --dsn "host=localhost user=postgres password=postgres database=somedb" --schema-dir ~/stripe/temp/examplesql

################################ Generated plan ################################
1. CREATE TABLE "public"."foobar" (
        "id" integer,
        "some_other_column" character varying(255) COLLATE "pg_catalog"."default",
        "fizz" character varying(255) COLLATE "pg_catalog"."default"
);
        -- Statement Timeout: 3s

2. ALTER TABLE "public"."foobar" ADD CONSTRAINT "some_constraint" CHECK((id > 0));
        -- Statement Timeout: 3s

3. ALTER TABLE "public"."foobar" REPLICA IDENTITY FULL;
        -- Statement Timeout: 3s

4. CREATE INDEX CONCURRENTLY some_idx ON public.foobar USING btree (id);
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s

5. DROP TABLE "some_schema"."foobar";
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s
        -- Hazard DELETES_DATA: Deletes all rows in the table (and the table itself)

6. DROP SCHEMA "some_schema";
        -- Statement Timeout: 3s
```

Include schemas (public only):
```
 ~/stripe/pg-schema-diff │ bplunkett/up…hema-support  go run ./cmd/pg-schema-diff plan  --dsn "host=localhost user=postgres password=postgres database=somedb" --schema-dir ~/stripe/temp/examplesql --include-schema public

################################ Generated plan ################################
1. CREATE TABLE "public"."foobar" (
        "id" integer,
        "some_other_column" character varying(255) COLLATE "pg_catalog"."default",
        "fizz" character varying(255) COLLATE "pg_catalog"."default"
);
        -- Statement Timeout: 3s

2. ALTER TABLE "public"."foobar" ADD CONSTRAINT "some_constraint" CHECK((id > 0));
        -- Statement Timeout: 3s

3. ALTER TABLE "public"."foobar" REPLICA IDENTITY FULL;
        -- Statement Timeout: 3s

4. CREATE INDEX CONCURRENTLY some_idx ON public.foobar USING btree (id);
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s
```


Exclude schemas (public only):
```
go run ./cmd/pg-schema-diff plan  --dsn "host=localhost user=postgres password=postgres database=somedb" --schema-dir ~/stripe/temp/examplesql --exclude-schema some_schema

################################ Generated plan ################################
1. CREATE TABLE "public"."foobar" (
        "id" integer,
        "some_other_column" character varying(255) COLLATE "pg_catalog"."default",
        "fizz" character varying(255) COLLATE "pg_catalog"."default"
);
        -- Statement Timeout: 3s

2. ALTER TABLE "public"."foobar" ADD CONSTRAINT "some_constraint" CHECK((id > 0));
        -- Statement Timeout: 3s

3. ALTER TABLE "public"."foobar" REPLICA IDENTITY FULL;
        -- Statement Timeout: 3s

4. CREATE INDEX CONCURRENTLY some_idx ON public.foobar USING btree (id);
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s
```

Comparing two databases:
```
go run ./cmd/pg-schema-diff plan  --dsn "host=localhost user=postgres password=postgres database=somedb"  --include-schema public  --schema-source-dsn "host=localhost user=postgres password=postgres database=postgres"

################################ Generated plan ################################
1. CREATE TABLE "public"."foobar" (

);
        -- Statement Timeout: 3s
```

No source specified:
```
 ~/stripe/pg-schema-diff │ bplunkett/up…hema-support  go run ./cmd/pg-schema-diff plan  --dsn "host=localhost user=postgres password=postgres database=somedb"                          INT х │ 15:17:22
Error: either --schema-dir or --schema-source-dsn must be set
Usage:
  pg-schema-diff plan [flags]
```
