### PR TITLE
Exclude schemas owned by extensions

### DIFF
--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -4,7 +4,16 @@ FROM pg_catalog.pg_namespace
 WHERE
     nspname NOT IN ('pg_catalog', 'information_schema')
     AND nspname !~ '^pg_toast'
-    AND nspname !~ '^pg_temp';
+    AND nspname !~ '^pg_temp'
+    -- Exclude schemas owned by extensions
+    AND NOT EXISTS (
+        SELECT depend.objid
+        FROM pg_catalog.pg_depend AS depend
+        WHERE
+            depend.classid = 'pg_namespace'::REGCLASS
+            AND depend.objid = pg_namespace.oid
+            AND depend.deptype = 'e'
+    );
 
 -- name: GetTables :many
 SELECT

--- a/internal/queries/queries.sql.go
+++ b/internal/queries/queries.sql.go
@@ -596,6 +596,15 @@ WHERE
     nspname NOT IN ('pg_catalog', 'information_schema')
     AND nspname !~ '^pg_toast'
     AND nspname !~ '^pg_temp'
+    -- Exclude schemas owned by extensions
+    AND NOT EXISTS (
+        SELECT depend.objid
+        FROM pg_catalog.pg_depend AS depend
+        WHERE
+            depend.classid = 'pg_namespace'::REGCLASS
+            AND depend.objid = pg_namespace.oid
+            AND depend.deptype = 'e'
+    )
 `
 
 func (q *Queries) GetSchemas(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Exclude schemas owned by extensions.

#### Example: 
pg_repack creates a schema called pg_repack. Let's say the user's `model.sql` removes the `CREATE EXTENSION pg_repack` line. This will generate two statements:
1. Drop extension pg_repack
2. Drop schema pg_repack

The first line drops the pg_repack schema as well because it is owned by the extension, causing the second line to fail. As a result, we should stop generating statements for schemas owned by extensions, just like we do with other schema objects.

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Bug fix

### Testing
[//]: # (Describe how you tested these changes)
There are few extensions that actually create extensions. One is pg_repack but it doesn't come with the default set of extensions in postgres-contrib. As a result, I just tested locally by creating `pg_repack` an
