### PR TITLE
[CLI] Add flag to disable plan validation

### DIFF
--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -85,7 +85,8 @@ type (
 
 		schemaFlags schemaFlags
 
-		dataPackNewTables bool
+		dataPackNewTables     bool
+		disablePlanValidation bool
 
 		statementTimeoutModifiers []string
 		lockTimeoutModifiers      []string
@@ -124,6 +125,8 @@ func createPlanFlags(cmd *cobra.Command) *planFlags {
 	schemaFlagsVar(cmd, &flags.schemaFlags)
 
 	cmd.Flags().BoolVar(&flags.dataPackNewTables, "data-pack-new-tables", true, "If set, will data pack new tables in the plan to minimize table size (re-arranges columns).")
+	cmd.Flags().BoolVar(&flags.disablePlanValidation, "disable-plan-validation", false, "If set, will disable plan validation. Plan validation runs the migration against a temporary"+
+		"database with an identical schema to the original, asserting that the generated plan actually migrates the schema to the desired target.")
 
 	timeoutModifierFlagVar(cmd, &flags.statementTimeoutModifiers, "statement", "t")
 	timeoutModifierFlagVar(cmd, &flags.lockTimeoutModifiers, "lock", "l")
@@ -177,6 +180,9 @@ func parsePlanConfig(p planFlags) (planConfig, error) {
 	opts := parseSchemaConfig(p.schemaFlags)
 	if p.dataPackNewTables {
 		opts = append(opts, diff.WithDataPackNewTables())
+	}
+	if p.disablePlanValidation {
+		opts = append(opts, diff.WithDoNotValidatePlan())
 	}
 
 	var statementTimeoutModifiers []timeoutModifier


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Optionally disable plan validation for CLI
### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
https://github.com/stripe/pg-schema-diff/issues/129
### Testing
[//]: # (Describe how you tested these changes)
Just showing the flag is parsed correctly:
```
 go run ./cmd/pg-schema-diff plan  --dsn "host=localhost database=postgres" --schema-dir ~/stripe/temp/examplesql  --disable-plan-validation --disable-plan-validation

################################ Generated plan ################################
01. CREATE SCHEMA "some_new_schema";
        -- Statement Timeout: 3s
```
