### PR TITLE
Update Acceptance Tests - Flatten specs

### DIFF
--- a/internal/migration_acceptance_tests/acceptance_test.go
+++ b/internal/migration_acceptance_tests/acceptance_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,9 +13,9 @@ import (
 	"github.com/stripe/pg-schema-diff/internal/pgdump"
 	"github.com/stripe/pg-schema-diff/internal/pgengine"
 	"github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/log"
 	"github.com/stripe/pg-schema-diff/pkg/sqldb"
 
-	"github.com/stripe/pg-schema-diff/pkg/log"
 	"github.com/stripe/pg-schema-diff/pkg/tempdb"
 )
 
@@ -44,10 +43,18 @@ type (
 
 	acceptanceTestCase struct {
 		name string
+
+		// planOpts is a list of options that should be passed to the plan generator
+		planOpts []diff.PlanOpt
+
 		// roles is a list of roles that should be created before the DDL is applied
 		roles        []string
 		oldSchemaDDL []string
 		newSchemaDDL []string
+
+		// planFactory is used to generate the actual plan. This is useful for testing different plan generation paths
+		// outside of the normal path. If not specified, a plan will be generated using a default.
+		planFactory planFactory
 
 		// ddl is used to assert the exact DDL (of the statements) that  generated. This is useful when asserting
 		// exactly how a migration is performed
@@ -57,15 +64,8 @@ type (
 		// generated plan
 		expectedHazardTypes []diff.MigrationHazardType
 
-		// vanillaExpectations refers to the expectations of the migration if no additional opts are used
-		vanillaExpectations expectations
-		// dataPackingExpectations refers to the expectations of the migration if table packing is used. We should
-		// aim to deprecate this and just split out a separate set of individual tests for data packing.
-		dataPackingExpectations expectations
-
-		// planFactory is used to generate the actual plan. This is useful for testing different plan generation paths
-		// outside of the normal path. If not specified, a plan will be generated using a default.
-		planFactory planFactory
+		// expectations refers to the expectations of the migration if no additional opts are used
+		expectations expectations
 	}
 
 	acceptanceTestSuite struct {
@@ -88,29 +88,26 @@ func (suite *acceptanceTestSuite) TearDownSuite() {
 func (suite *acceptanceTestSuite) runTestCases(acceptanceTestCases []acceptanceTestCase) {
 	for _, tc := range acceptanceTestCases {
 		suite.Run(tc.name, func() {
-			suite.Run("vanilla", func() {
-				suite.runSubtest(tc, tc.vanillaExpectations, nil)
-			})
-			// Only run the data packing test if there are expectations for it. We should strip out the embedded
-			// data packing tests and make them their own tests to simplify the test suite.
-			if !reflect.DeepEqual(tc.dataPackingExpectations, expectations{}) {
-				suite.Run("with data packing (and ignoring column order)", func() {
-					suite.runSubtest(tc, tc.dataPackingExpectations, []diff.PlanOpt{
-						diff.WithDataPackNewTables(),
-						diff.WithLogger(log.SimpleLogger()),
-					})
-				})
-			}
+			suite.runTest(tc)
 		})
 	}
 }
 
-func (suite *acceptanceTestSuite) runSubtest(tc acceptanceTestCase, expects expectations, planOpts []diff.PlanOpt) {
+func (suite *acceptanceTestSuite) runTest(tc acceptanceTestCase) {
 	uuid.SetRand(&deterministicRandReader{})
 
-	// normalize the subtest
-	if expects.outputState == nil {
-		expects.outputState = tc.newSchemaDDL
+	// Normalize the subtest
+	tc.planOpts = append(tc.planOpts, diff.WithLogger(log.SimpleLogger()))
+	if tc.expectations.outputState == nil {
+		tc.expectations.outputState = tc.newSchemaDDL
+	}
+	if tc.planFactory == nil {
+		tc.planFactory = func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error) {
+			return diff.Generate(ctx, connPool, diff.DDLSchemaSource(newSchemaDDL),
+				append(tc.planOpts,
+					diff.WithTempDbFactory(tempDbFactory),
+				)...)
+		}
 	}
 
 	// Create roles since they are global
@@ -148,30 +145,20 @@ func (suite *acceptanceTestSuite) runSubtest(tc acceptanceTestCase, expects expe
 		suite.Require().NoError(tempDbFactory.Close())
 	}(tempDbFactory)
 
-	generatePlanFn := tc.planFactory
-	if generatePlanFn == nil {
-		generatePlanFn = func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error) {
-			return diff.Generate(ctx, connPool, diff.DDLSchemaSource(newSchemaDDL),
-				append(planOpts,
-					diff.WithTempDbFactory(tempDbFactory),
-				)...)
+	plan, err := tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
+	if tc.expectations.planErrorIs != nil || len(tc.expectations.planErrorContains) > 0 {
+		if tc.expectations.planErrorIs != nil {
+			suite.ErrorIs(err, tc.expectations.planErrorIs)
 		}
-	}
-
-	plan, err := generatePlanFn(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, planOpts...)
-	if expects.planErrorIs != nil || len(expects.planErrorContains) > 0 {
-		if expects.planErrorIs != nil {
-			suite.ErrorIs(err, expects.planErrorIs)
-		}
-		if len(expects.planErrorContains) > 0 {
-			suite.ErrorContains(err, expects.planErrorContains)
+		if len(tc.expectations.planErrorContains) > 0 {
+			suite.ErrorContains(err, tc.expectations.planErrorContains)
 		}
 		return
 	}
 	suite.Require().NoError(err)
 
 	suite.assertValidPlan(plan)
-	if expects.empty {
+	if tc.expectations.empty {
 		// It shouldn't be necessary, but we'll run all checks below this point just in case rather than exiting early
 		suite.Empty(plan.Statements)
 	}
@@ -185,7 +172,7 @@ func (suite *acceptanceTestSuite) runSubtest(tc acceptanceTestCase, expects expe
 	oldDbDump, err := pgdump.GetDump(oldDb, pgdump.WithSchemaOnly())
 	suite.Require().NoError(err)
 
-	newDbDump := suite.directlyRunDDLAndGetDump(expects.outputState)
+	newDbDump := suite.directlyRunDDLAndGetDump(tc.expectations.outputState)
 	suite.Equal(newDbDump, oldDbDump, prettySprintPlan(plan))
 
 	if tc.ddl != nil {
@@ -202,7 +189,7 @@ func (suite *acceptanceTestSuite) runSubtest(tc acceptanceTestCase, expects expe
 	}
 
 	// Make sure no diff is found if we try to regenerate a plan
-	plan, err = generatePlanFn(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, planOpts...)
+	plan, err = tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
 	suite.Require().NoError(err)
 	suite.Empty(plan.Statements, prettySprintPlan(plan))
 }

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -87,7 +87,7 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
 			diff.MigrationHazardTypeDeletesData,
 		},
-		vanillaExpectations: expectations{
+		expectations: expectations{
 			outputState: []string{`
 			-- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
@@ -127,49 +127,6 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 			CREATE TABLE fizz(
 			);
 			`},
-		},
-		dataPackingExpectations: expectations{
-			outputState: []string{
-				`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-            CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();	
-
-			CREATE TABLE new_foobar(
-				bar TIMESTAMPTZ NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-
-			CREATE TABLE foobar_1 PARTITION of new_foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
-
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
-
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-
-			CREATE TABLE fizz(
-			);
-			`,
-			},
 		},
 
 		// Ensure that we're maintaining backwards compatibility with the old generate plan func

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -87,8 +87,8 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
 			diff.MigrationHazardTypeDeletesData,
 		},
-		expectations: expectations{
-			outputState: []string{`
+
+		expectedDBSchemaDDL: []string{`
 			-- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
 			CREATE TABLE schema_filtered_1.foo();	
@@ -127,7 +127,6 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 			CREATE TABLE fizz(
 			);
 			`},
-		},
 
 		// Ensure that we're maintaining backwards compatibility with the old generate plan func
 		planFactory: diff.GeneratePlan,

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -25,10 +25,7 @@ var checkConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -83,10 +80,7 @@ var checkConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -358,10 +352,7 @@ var checkConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -536,10 +527,7 @@ var checkConstraintCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -25,9 +25,7 @@ var checkConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Add check constraint (validate constraint added online)",
@@ -49,7 +47,7 @@ var checkConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_check\" CHECK((bar > id)) NOT VALID",
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_check\"",
 		},
@@ -80,9 +78,8 @@ var checkConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Add check constraint with system function dependency should not error",
@@ -352,9 +349,8 @@ var checkConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Drop check constraint with system function dependency should not error",
@@ -399,7 +395,7 @@ var checkConstraintCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"bar_check\"",
 		},
 	},
@@ -527,9 +523,8 @@ var checkConstraintCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Alter check constraint with system function dependency should not error",

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -27,9 +27,8 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Add one column with default",
@@ -138,14 +137,13 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		expectations: expectations{
-			outputState: []string{`
+
+		expectedDBSchemaDDL: []string{`
 					CREATE TABLE foobar(
 						id INT PRIMARY KEY,
 						my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
 					)
 				`},
-		},
 	},
 	{
 		name: "Delete one column",
@@ -290,7 +288,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
 			"ANALYZE \"public\".\"Foobar\" (\"some_time_col\")",
 		},
@@ -386,7 +384,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE character varying(255) COLLATE \"pg_catalog\".\"POSIX\" using \"foobar\"::character varying(255)",
 			"ANALYZE \"public\".\"foobar\" (\"foobar\")",
 		},
@@ -493,7 +491,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		ddl: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
+		expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
 	},
 	{
 		name: "Set NOT NULL (add invalid CC)",
@@ -514,7 +512,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -543,7 +541,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -570,7 +568,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
 		},
@@ -594,7 +592,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -620,7 +618,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
 		},
 	},
@@ -643,7 +641,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
 			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
 		},
@@ -668,7 +666,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
 			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((length((foobar)::text) > 0)) NOT VALID",
@@ -697,7 +695,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeImpactsDatabasePerformance,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -795,9 +793,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeImpactsDatabasePerformance,
 		},
-		expectations: expectations{
-			planErrorContains: errValidatingPlan.Error(),
-		},
+		expectedPlanErrorContains: errValidatingPlan.Error(),
 	},
 	{
 		name: "Change from NULL default to no default and NOT NULL",

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -27,10 +27,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -141,15 +138,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		vanillaExpectations: expectations{
-			outputState: []string{`
-					CREATE TABLE foobar(
-						id INT PRIMARY KEY,
-						my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
-					)
-				`},
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			outputState: []string{`
 					CREATE TABLE foobar(
 						id INT PRIMARY KEY,
@@ -806,10 +795,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeImpactsDatabasePerformance,
 		},
-		vanillaExpectations: expectations{
-			planErrorContains: errValidatingPlan.Error(),
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorContains: errValidatingPlan.Error(),
 		},
 	},

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -1,0 +1,145 @@
+package migration_acceptance_tests
+
+import "github.com/stripe/pg-schema-diff/pkg/diff"
+
+var dataPackingCases = []acceptanceTestCase{
+	{
+		name:         "Create table",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
+		},
+		expectations: expectations{
+			outputState: []string{`
+			CREATE TABLE foobar(
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
+			},
+		},
+	},
+	{
+		name:         "Create partitioned table with shared primary key and RLS enabled globally",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+			`,
+		},
+		expectations: expectations{
+			outputState: []string{`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+				`,
+			},
+		},
+	},
+}
+
+func (suite *acceptanceTestSuite) TestDataPackingTestCases() {
+	var tcs []acceptanceTestCase
+	for _, tc := range dataPackingCases {
+		tc.planOpts = append(tc.planOpts, diff.WithDataPackNewTables())
+		tcs = append(tcs, tc)
+	}
+	suite.runTestCases(tcs)
+}

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -32,8 +32,8 @@ var dataPackingCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
 			`,
 		},
-		expectations: expectations{
-			outputState: []string{`
+
+		expectedDBSchemaDDL: []string{`
 			CREATE TABLE foobar(
 			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
@@ -57,7 +57,6 @@ var dataPackingCases = []acceptanceTestCase{
 			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
 			`,
-			},
 		},
 	},
 	{
@@ -97,8 +96,8 @@ var dataPackingCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 			`,
 		},
-		expectations: expectations{
-			outputState: []string{`
+
+		expectedDBSchemaDDL: []string{`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
 			    id INT,
@@ -130,7 +129,6 @@ var dataPackingCases = []acceptanceTestCase{
 			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 				`,
-			},
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -22,9 +22,7 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name: "create enum",
@@ -114,9 +112,7 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 
 		// Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
 		// as a validation error. In the future, we can identify this in the actual plan generation stage.
-		expectations: expectations{
-			planErrorContains: errValidatingPlan.Error(),
-		},
+		expectedPlanErrorContains: errValidatingPlan.Error(),
 	},
 }
 

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -22,10 +22,7 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -117,10 +114,7 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 
 		// Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
 		// as a validation error. In the future, we can identify this in the actual plan generation stage.
-		vanillaExpectations: expectations{
-			planErrorContains: errValidatingPlan.Error(),
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorContains: errValidatingPlan.Error(),
 		},
 	},

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -19,10 +19,7 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 			CREATE EXTENSION amcheck;
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -19,9 +19,7 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 			CREATE EXTENSION amcheck;
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name: "create multiple extensions",

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -39,9 +39,8 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Add FK with most options",
@@ -358,7 +357,7 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
 			`,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar fk\" VALIDATE CONSTRAINT \"some_fk\"",
 		},
 	},
@@ -562,9 +561,8 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		expectations: expectations{
-			planErrorContains: errValidatingPlan.Error(),
-		},
+
+		expectedPlanErrorContains: errValidatingPlan.Error(),
 	},
 	{
 		name: "Switch FK owning table (to partitioned table)",

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -39,10 +39,7 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -565,10 +562,7 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorContains: errValidatingPlan.Error(),
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorContains: errValidatingPlan.Error(),
 		},
 	},

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -37,9 +37,8 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 			$$ LANGUAGE plpgsql;
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+
+		expectEmptyPlan: true,
 	},
 	{
 		name:         "Create functions (with conflicting names)",

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -37,10 +37,7 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 			$$ LANGUAGE plpgsql;
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -31,10 +31,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -31,9 +31,8 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Add a normal index",
@@ -376,7 +375,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeDeletesData,
 			diff.MigrationHazardTypeIndexDropped,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"DROP INDEX CONCURRENTLY \"public\".\"some_idx\"",
 			"ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"foo\"",
 		},
@@ -786,7 +785,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
 			CREATE INDEX new_idx ON foobar(bar);
 		`},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
 			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar USING btree (bar)",
 			"CREATE INDEX CONCURRENTLY some_idx_with_a_very_long_name ON public.foobar USING btree (foo, bar)",

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -41,10 +41,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -41,9 +41,8 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Add local indexes",

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -11,9 +11,7 @@ var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
 			CREATE SCHEMA "schema 1";	
 			CREATE SCHEMA "schema 2";
 		`},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name: "create schema",

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -11,10 +11,7 @@ var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
 			CREATE SCHEMA "schema 1";	
 			CREATE SCHEMA "schema 2";
 		`},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -41,10 +41,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -1048,10 +1045,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -1082,10 +1076,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -1116,10 +1107,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -41,9 +41,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Add a normal partitioned index",
@@ -600,7 +598,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeIndexDropped,
 			diff.MigrationHazardTypeDeletesData,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
 			"DROP INDEX \"public\".\"some_idx\"",
 			"ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"id\"",
@@ -645,7 +643,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeIndexDropped,
 			diff.MigrationHazardTypeIndexBuild,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER INDEX \"public\".\"some_idx\" RENAME TO \"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"id\" IS NOT NULL) NOT VALID",
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
@@ -1045,9 +1043,8 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
@@ -1076,9 +1073,8 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
@@ -1107,9 +1103,8 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -101,9 +101,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name:         "Create partitioned table with shared primary key and RLS enabled globally",
@@ -142,8 +140,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 			`,
 		},
-		expectations: expectations{
-			outputState: []string{`
+
+		expectedDBSchemaDDL: []string{`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
 			    id INT,
@@ -175,7 +173,6 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 				`,
-			},
 		},
 	},
 	{
@@ -545,9 +542,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Unpartitioned to partitioned",
@@ -1156,9 +1152,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) PARTITION BY LIST (foo);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Altering a partition's 'FOR VALUES' errors",
@@ -1186,9 +1181,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Re-creating base table causes partitions to be re-created",

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -101,10 +101,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -136,23 +133,23 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) FOR VALUES IN ('foo_1');
 			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
 			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
 			-- partitioned indexes
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
 			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
 			-- local indexes
 			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 			`,
 		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			outputState: []string{`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
 			    id INT,
-				fizz SERIAL,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
 				CHECK ( fizz > 0 ),
 			    PRIMARY KEY (foo, id),
 			    UNIQUE (foo, bar)
@@ -548,10 +545,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -1162,10 +1156,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) PARTITION BY LIST (foo);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -1195,10 +1186,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -31,9 +31,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 					WITH CHECK (true);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Add permissive ALL policy target on non-public schema",
@@ -182,7 +180,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			// Ensure that the policy is created before enabling RLS.
 			"CREATE POLICY \"foobar_policy\" ON \"public\".\"foobar\"\n\tAS RESTRICTIVE\n\tFOR SELECT\n\tTO PUBLIC\n\tUSING (true)",
 			"ALTER TABLE \"public\".\"foobar\" ENABLE ROW LEVEL SECURITY",
@@ -250,7 +248,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
 		},
-		ddl: []string{
+		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" DISABLE ROW LEVEL SECURITY",
 			"ALTER TABLE \"public\".\"foobar\" NO FORCE ROW LEVEL SECURITY",
 			"DROP POLICY \"foobar_policy\" ON \"public\".\"foobar\"",
@@ -627,9 +625,8 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 					WITH CHECK (true);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Add policy on existing partition (not implemented)",
@@ -654,9 +651,8 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 					WITH CHECK (true);
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 }
 

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -31,7 +31,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 					WITH CHECK (true);
 			`,
 		},
-		vanillaExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -627,10 +627,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 					WITH CHECK (true);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -657,10 +654,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 					WITH CHECK (true);
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -156,9 +156,7 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name:  "Add schema, drop schema, Add enum, Drop enum, Drop table, Add Table, Drop Seq, Add Seq, Drop Funcs, Add Funcs, Drop Triggers, Add Triggers, Create Extension, Drop Extension, Create Index Using Extension, Add policies, Drop policies",

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -156,10 +156,7 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -57,9 +57,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+
+		expectEmptyPlan: true,
 	},
 	{
 		name:         "Create table",
@@ -138,9 +137,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
 			`,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Drop table",
@@ -260,9 +258,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
 		},
-		expectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
 	{
 		name: "Enable RLS",

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -57,10 +57,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},
@@ -92,33 +89,6 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
 			`,
-		},
-		dataPackingExpectations: expectations{
-			outputState: []string{`
-			CREATE TABLE foobar(
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
-			},
 		},
 	},
 	{
@@ -168,10 +138,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
 			`,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},
@@ -293,10 +260,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
 		},
-		vanillaExpectations: expectations{
-			planErrorIs: diff.ErrNotImplemented,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			planErrorIs: diff.ErrNotImplemented,
 		},
 	},

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -79,9 +79,7 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE FUNCTION check_content();
 			`,
 		},
-		expectations: expectations{
-			empty: true,
-		},
+		expectEmptyPlan: true,
 	},
 	{
 		name: "Create trigger with quoted name",

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -79,10 +79,7 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE FUNCTION check_content();
 			`,
 		},
-		vanillaExpectations: expectations{
-			empty: true,
-		},
-		dataPackingExpectations: expectations{
+		expectations: expectations{
 			empty: true,
 		},
 	},


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
- Instead of each test case defining two specs for vanilla and data packing, run data packing as their own independent test cases. This simplifies test specs and running tess
- Flatten `expectations`. The distinction was arbitrary because of the need to potentially define two test specs

The fact that this is net negative code despite copying two test cases -- we really only had TWO data packing test cases for all of this complexity in the test spec -- implies this PR moves the code in the right direction.
### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Fixes #106 
### Testing
[//]: # (Describe how you tested these changes)
Covered by tests