### PR TITLE
fix: #67 converting all tabs to spaces in migration acceptance tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you want to make changes yourself, follow these steps:
 2. Make your changes
 3. Test your changes
 ```bash
- docker build -t pg-schema-diff-test-runner -f ./build/Dockerfile.test --build-arg POSTGRES_PACKAGE=postgresql{14, 15} .
+ docker build -t pg-schema-diff-test-runner -f ./build/Dockerfile.test .
  ```
 3. Submit a [pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,10 @@ If you want to make changes yourself, follow these steps:
 2. Make your changes
 3. Test your changes
 ```bash
- docker build -t pg-schema-diff-test-runner -f ./build/Dockerfile.test .
+# builds image running tests with the postgresql14 image (can also omit because it is the default arg)
+ docker build -t pg-schema-diff-test-runner -f ./build/Dockerfile.test --build-arg POSTGRES_PACKAGE=postgresql14 .
+# builds image running tests with the postgresql15 image.
+ docker build -t pg-schema-diff-test-runner -f ./build/Dockerfile.test --build-arg POSTGRES_PACKAGE=postgresql15 .
  ```
 3. Submit a [pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 

--- a/internal/migration_acceptance_tests/acceptance_test.go
+++ b/internal/migration_acceptance_tests/acceptance_test.go
@@ -1,264 +1,264 @@
 package migration_acceptance_tests
 
 import (
-    "context"
-    "database/sql"
-    "fmt"
-    "testing"
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
 
-    "github.com/google/uuid"
-    _ "github.com/jackc/pgx/v4/stdlib"
-    "github.com/kr/pretty"
-    "github.com/stretchr/testify/suite"
-    "github.com/stripe/pg-schema-diff/internal/pgdump"
-    "github.com/stripe/pg-schema-diff/internal/pgengine"
-    "github.com/stripe/pg-schema-diff/pkg/diff"
-    "github.com/stripe/pg-schema-diff/pkg/log"
-    "github.com/stripe/pg-schema-diff/pkg/sqldb"
+	"github.com/google/uuid"
+	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/suite"
+	"github.com/stripe/pg-schema-diff/internal/pgdump"
+	"github.com/stripe/pg-schema-diff/internal/pgengine"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/log"
+	"github.com/stripe/pg-schema-diff/pkg/sqldb"
 
-    "github.com/stripe/pg-schema-diff/pkg/tempdb"
+	"github.com/stripe/pg-schema-diff/pkg/tempdb"
 )
 
 var (
-    errValidatingPlan = fmt.Errorf("validating migration plan")
+	errValidatingPlan = fmt.Errorf("validating migration plan")
 )
 
 type (
-    planFactory func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error)
+	planFactory func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error)
 
-    acceptanceTestCase struct {
-        name string
+	acceptanceTestCase struct {
+		name string
 
-        // planOpts is a list of options that should be passed to the plan generator
-        planOpts []diff.PlanOpt
+		// planOpts is a list of options that should be passed to the plan generator
+		planOpts []diff.PlanOpt
 
-        // roles is a list of roles that should be created before the DDL is applied
-        roles        []string
-        oldSchemaDDL []string
-        newSchemaDDL []string
+		// roles is a list of roles that should be created before the DDL is applied
+		roles        []string
+		oldSchemaDDL []string
+		newSchemaDDL []string
 
-        // planFactory is used to generate the actual plan. This is useful for testing different plan generation paths
-        // outside of the normal path. If not specified, a plan will be generated using a default.
-        planFactory planFactory
+		// planFactory is used to generate the actual plan. This is useful for testing different plan generation paths
+		// outside of the normal path. If not specified, a plan will be generated using a default.
+		planFactory planFactory
 
-        // expectedHazardTypes should contain all the unique migration hazard types that are expected to be within the
-        // generated plan
-        expectedHazardTypes       []diff.MigrationHazardType
-        expectedPlanErrorIs       error
-        expectedPlanErrorContains string
-        // expectedPlanDDL is used to assert the exact DDL (of the statements) that  generated. This is useful when asserting
-        // exactly how a migration is performed
-        expectedPlanDDL []string
-        // expectEmptyPlan asserts the plan is expectEmptyPlan
-        expectEmptyPlan bool
-        // expectedDBSchemaDDL should be the DDL required to reconstruct the expected output state of the database
-        //
-        // The expectedDBSchemaDDL might differ from the newSchemaDDL due to options passed to the migrator. For example,
-        // the data packing option will cause the column ordering for new tables in the expectedDBSchemaDDL to differ from
-        // the column ordering of those tables defined in newSchemaDDL
-        //
-        // If no expectedDBSchemaDDL is specified, the newSchemaDDL will be used
-        expectedDBSchemaDDL []string
-    }
+		// expectedHazardTypes should contain all the unique migration hazard types that are expected to be within the
+		// generated plan
+		expectedHazardTypes       []diff.MigrationHazardType
+		expectedPlanErrorIs       error
+		expectedPlanErrorContains string
+		// expectedPlanDDL is used to assert the exact DDL (of the statements) that  generated. This is useful when asserting
+		// exactly how a migration is performed
+		expectedPlanDDL []string
+		// expectEmptyPlan asserts the plan is expectEmptyPlan
+		expectEmptyPlan bool
+		// expectedDBSchemaDDL should be the DDL required to reconstruct the expected output state of the database
+		//
+		// The expectedDBSchemaDDL might differ from the newSchemaDDL due to options passed to the migrator. For example,
+		// the data packing option will cause the column ordering for new tables in the expectedDBSchemaDDL to differ from
+		// the column ordering of those tables defined in newSchemaDDL
+		//
+		// If no expectedDBSchemaDDL is specified, the newSchemaDDL will be used
+		expectedDBSchemaDDL []string
+	}
 
-    acceptanceTestSuite struct {
-        suite.Suite
-        pgEngine *pgengine.Engine
-    }
+	acceptanceTestSuite struct {
+		suite.Suite
+		pgEngine *pgengine.Engine
+	}
 )
 
 func (suite *acceptanceTestSuite) SetupSuite() {
-    engine, err := pgengine.StartEngine()
-    suite.Require().NoError(err)
-    suite.pgEngine = engine
+	engine, err := pgengine.StartEngine()
+	suite.Require().NoError(err)
+	suite.pgEngine = engine
 }
 
 func (suite *acceptanceTestSuite) TearDownSuite() {
-    suite.pgEngine.Close()
+	suite.pgEngine.Close()
 }
 
 // Simulates migrating a database and uses pgdump to compare the actual state to the expected state
 func (suite *acceptanceTestSuite) runTestCases(acceptanceTestCases []acceptanceTestCase) {
-    for _, tc := range acceptanceTestCases {
-        suite.Run(tc.name, func() {
-            suite.runTest(tc)
-        })
-    }
+	for _, tc := range acceptanceTestCases {
+		suite.Run(tc.name, func() {
+			suite.runTest(tc)
+		})
+	}
 }
 
 func (suite *acceptanceTestSuite) runTest(tc acceptanceTestCase) {
-    uuid.SetRand(&deterministicRandReader{})
+	uuid.SetRand(&deterministicRandReader{})
 
-    // Normalize the subtest
-    tc.planOpts = append(tc.planOpts, diff.WithLogger(log.SimpleLogger()))
-    if tc.expectedDBSchemaDDL == nil {
-        tc.expectedDBSchemaDDL = tc.newSchemaDDL
-    }
-    if tc.planFactory == nil {
-        tc.planFactory = func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error) {
-            return diff.Generate(ctx, connPool, diff.DDLSchemaSource(newSchemaDDL),
-                append(tc.planOpts,
-                    diff.WithTempDbFactory(tempDbFactory),
-                )...)
-        }
-    }
+	// Normalize the subtest
+	tc.planOpts = append(tc.planOpts, diff.WithLogger(log.SimpleLogger()))
+	if tc.expectedDBSchemaDDL == nil {
+		tc.expectedDBSchemaDDL = tc.newSchemaDDL
+	}
+	if tc.planFactory == nil {
+		tc.planFactory = func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error) {
+			return diff.Generate(ctx, connPool, diff.DDLSchemaSource(newSchemaDDL),
+				append(tc.planOpts,
+					diff.WithTempDbFactory(tempDbFactory),
+				)...)
+		}
+	}
 
-    // Create roles since they are global
-    rootDb, err := sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseDSN())
-    suite.Require().NoError(err)
-    defer rootDb.Close()
-    for _, r := range tc.roles {
-        _, err := rootDb.Exec(fmt.Sprintf("CREATE ROLE %s", r))
-        suite.Require().NoError(err)
-    }
-    defer func() {
-        // This will drop the roles (and attempt to reset other cluster-level state)
-        suite.Require().NoError(pgengine.ResetInstance(context.Background(), rootDb))
-    }()
+	// Create roles since they are global
+	rootDb, err := sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseDSN())
+	suite.Require().NoError(err)
+	defer rootDb.Close()
+	for _, r := range tc.roles {
+		_, err := rootDb.Exec(fmt.Sprintf("CREATE ROLE %s", r))
+		suite.Require().NoError(err)
+	}
+	defer func() {
+		// This will drop the roles (and attempt to reset other cluster-level state)
+		suite.Require().NoError(pgengine.ResetInstance(context.Background(), rootDb))
+	}()
 
-    // Apply old schema DDL to old DB
-    oldDb, err := suite.pgEngine.CreateDatabase()
-    suite.Require().NoError(err)
-    defer oldDb.DropDB()
-    // Apply the old schema
-    suite.Require().NoError(applyDDL(oldDb, tc.oldSchemaDDL))
+	// Apply old schema DDL to old DB
+	oldDb, err := suite.pgEngine.CreateDatabase()
+	suite.Require().NoError(err)
+	defer oldDb.DropDB()
+	// Apply the old schema
+	suite.Require().NoError(applyDDL(oldDb, tc.oldSchemaDDL))
 
-    // Migrate the old DB
-    oldDBConnPool, err := sql.Open("pgx", oldDb.GetDSN())
-    suite.Require().NoError(err)
-    defer oldDBConnPool.Close()
+	// Migrate the old DB
+	oldDBConnPool, err := sql.Open("pgx", oldDb.GetDSN())
+	suite.Require().NoError(err)
+	defer oldDBConnPool.Close()
 
-    tempDbFactory, err := tempdb.NewOnInstanceFactory(context.Background(), func(ctx context.Context, dbName string) (*sql.DB, error) {
-        return sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseConnOpts().With("dbname", dbName).ToDSN())
-    })
-    suite.Require().NoError(err)
-    defer func(tempDbFactory tempdb.Factory) {
-        // It's important that this closes properly (the temp database is dropped),
-        // so assert it has no error for acceptance tests
-        suite.Require().NoError(tempDbFactory.Close())
-    }(tempDbFactory)
+	tempDbFactory, err := tempdb.NewOnInstanceFactory(context.Background(), func(ctx context.Context, dbName string) (*sql.DB, error) {
+		return sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseConnOpts().With("dbname", dbName).ToDSN())
+	})
+	suite.Require().NoError(err)
+	defer func(tempDbFactory tempdb.Factory) {
+		// It's important that this closes properly (the temp database is dropped),
+		// so assert it has no error for acceptance tests
+		suite.Require().NoError(tempDbFactory.Close())
+	}(tempDbFactory)
 
-    plan, err := tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
-    if tc.expectedPlanErrorIs != nil || len(tc.expectedPlanErrorContains) > 0 {
-        if tc.expectedPlanErrorIs != nil {
-            suite.ErrorIs(err, tc.expectedPlanErrorIs)
-        }
-        if len(tc.expectedPlanErrorContains) > 0 {
-            suite.ErrorContains(err, tc.expectedPlanErrorContains)
-        }
-        return
-    }
-    suite.Require().NoError(err)
+	plan, err := tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
+	if tc.expectedPlanErrorIs != nil || len(tc.expectedPlanErrorContains) > 0 {
+		if tc.expectedPlanErrorIs != nil {
+			suite.ErrorIs(err, tc.expectedPlanErrorIs)
+		}
+		if len(tc.expectedPlanErrorContains) > 0 {
+			suite.ErrorContains(err, tc.expectedPlanErrorContains)
+		}
+		return
+	}
+	suite.Require().NoError(err)
 
-    suite.assertValidPlan(plan)
-    if tc.expectEmptyPlan {
-        // It shouldn't be necessary, but we'll run all checks below this point just in case rather than exiting early
-        suite.Empty(plan.Statements)
-    }
-    suite.ElementsMatch(tc.expectedHazardTypes, getUniqueHazardTypesFromStatements(plan.Statements), prettySprintPlan(plan))
+	suite.assertValidPlan(plan)
+	if tc.expectEmptyPlan {
+		// It shouldn't be necessary, but we'll run all checks below this point just in case rather than exiting early
+		suite.Empty(plan.Statements)
+	}
+	suite.ElementsMatch(tc.expectedHazardTypes, getUniqueHazardTypesFromStatements(plan.Statements), prettySprintPlan(plan))
 
-    // Apply the plan
-    suite.Require().NoError(applyPlan(oldDb, plan), prettySprintPlan(plan))
+	// Apply the plan
+	suite.Require().NoError(applyPlan(oldDb, plan), prettySprintPlan(plan))
 
-    // Make sure the pgdump after running the migration is the same as the
-    // pgdump from a database where we directly run the newSchemaDDL
-    oldDbDump, err := pgdump.GetDump(oldDb, pgdump.WithSchemaOnly())
-    suite.Require().NoError(err)
+	// Make sure the pgdump after running the migration is the same as the
+	// pgdump from a database where we directly run the newSchemaDDL
+	oldDbDump, err := pgdump.GetDump(oldDb, pgdump.WithSchemaOnly())
+	suite.Require().NoError(err)
 
-    newDbDump := suite.directlyRunDDLAndGetDump(tc.expectedDBSchemaDDL)
-    suite.Equal(newDbDump, oldDbDump, prettySprintPlan(plan))
+	newDbDump := suite.directlyRunDDLAndGetDump(tc.expectedDBSchemaDDL)
+	suite.Equal(newDbDump, oldDbDump, prettySprintPlan(plan))
 
-    if tc.expectedPlanDDL != nil {
-        var generatedDDL []string
-        for _, stmt := range plan.Statements {
-            generatedDDL = append(generatedDDL, stmt.DDL)
-        }
-        // In the future, we might want to allow users to assert expectations for vanilla options and data packing
-        //
-        // We can also make the system more advanced by using tokens in place of the "randomly" generated UUIDs, such
-        // the test case doesn't need to be updated if the UUID generation changes. If we built this functionality, we
-        // should also integrate it with the schema_migration_plan_test.go tests.
-        suite.Equal(tc.expectedPlanDDL, generatedDDL, "data packing can change the the generated UUID and DDL")
-    }
+	if tc.expectedPlanDDL != nil {
+		var generatedDDL []string
+		for _, stmt := range plan.Statements {
+			generatedDDL = append(generatedDDL, stmt.DDL)
+		}
+		// In the future, we might want to allow users to assert expectations for vanilla options and data packing
+		//
+		// We can also make the system more advanced by using tokens in place of the "randomly" generated UUIDs, such
+		// the test case doesn't need to be updated if the UUID generation changes. If we built this functionality, we
+		// should also integrate it with the schema_migration_plan_test.go tests.
+		suite.Equal(tc.expectedPlanDDL, generatedDDL, "data packing can change the the generated UUID and DDL")
+	}
 
-    // Make sure no diff is found if we try to regenerate a plan
-    plan, err = tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
-    suite.Require().NoError(err)
-    suite.Empty(plan.Statements, prettySprintPlan(plan))
+	// Make sure no diff is found if we try to regenerate a plan
+	plan, err = tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
+	suite.Require().NoError(err)
+	suite.Empty(plan.Statements, prettySprintPlan(plan))
 }
 
 func (suite *acceptanceTestSuite) assertValidPlan(plan diff.Plan) {
-    for _, stmt := range plan.Statements {
-        suite.Greater(stmt.Timeout.Nanoseconds(), int64(0), "timeout should be greater than 0. stmt=%+v", stmt)
-        suite.Greater(stmt.LockTimeout.Nanoseconds(), int64(0), "lock timeout should be greater than 0. stmt=%+v", stmt)
-    }
+	for _, stmt := range plan.Statements {
+		suite.Greater(stmt.Timeout.Nanoseconds(), int64(0), "timeout should be greater than 0. stmt=%+v", stmt)
+		suite.Greater(stmt.LockTimeout.Nanoseconds(), int64(0), "lock timeout should be greater than 0. stmt=%+v", stmt)
+	}
 }
 
 func (suite *acceptanceTestSuite) directlyRunDDLAndGetDump(ddl []string) string {
-    newDb, err := suite.pgEngine.CreateDatabase()
-    suite.Require().NoError(err)
-    defer newDb.DropDB()
-    suite.Require().NoError(applyDDL(newDb, ddl))
+	newDb, err := suite.pgEngine.CreateDatabase()
+	suite.Require().NoError(err)
+	defer newDb.DropDB()
+	suite.Require().NoError(applyDDL(newDb, ddl))
 
-    newDbDump, err := pgdump.GetDump(newDb, pgdump.WithSchemaOnly())
-    suite.Require().NoError(err)
-    return newDbDump
+	newDbDump, err := pgdump.GetDump(newDb, pgdump.WithSchemaOnly())
+	suite.Require().NoError(err)
+	return newDbDump
 }
 
 func applyDDL(db *pgengine.DB, ddl []string) error {
-    conn, err := sql.Open("pgx", db.GetDSN())
-    if err != nil {
-        return err
-    }
-    defer conn.Close()
+	conn, err := sql.Open("pgx", db.GetDSN())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 
-    for _, stmt := range ddl {
-        _, err := conn.Exec(stmt)
-        if err != nil {
-            return fmt.Errorf("DDL:\n: %w"+stmt, err)
-        }
-    }
-    return nil
+	for _, stmt := range ddl {
+		_, err := conn.Exec(stmt)
+		if err != nil {
+			return fmt.Errorf("DDL:\n: %w"+stmt, err)
+		}
+	}
+	return nil
 }
 
 func applyPlan(db *pgengine.DB, plan diff.Plan) error {
-    var ddl []string
-    for _, stmt := range plan.Statements {
-        ddl = append(ddl, stmt.ToSQL())
-    }
-    return applyDDL(db, ddl)
+	var ddl []string
+	for _, stmt := range plan.Statements {
+		ddl = append(ddl, stmt.ToSQL())
+	}
+	return applyDDL(db, ddl)
 }
 
 func getUniqueHazardTypesFromStatements(statements []diff.Statement) []diff.MigrationHazardType {
-    var seenHazardTypes = make(map[diff.MigrationHazardType]bool)
-    var hazardTypes []diff.MigrationHazardType
-    for _, stmt := range statements {
-        for _, hazard := range stmt.Hazards {
-            if _, hasHazard := seenHazardTypes[hazard.Type]; !hasHazard {
-                seenHazardTypes[hazard.Type] = true
-                hazardTypes = append(hazardTypes, hazard.Type)
-            }
-        }
-    }
-    return hazardTypes
+	var seenHazardTypes = make(map[diff.MigrationHazardType]bool)
+	var hazardTypes []diff.MigrationHazardType
+	for _, stmt := range statements {
+		for _, hazard := range stmt.Hazards {
+			if _, hasHazard := seenHazardTypes[hazard.Type]; !hasHazard {
+				seenHazardTypes[hazard.Type] = true
+				hazardTypes = append(hazardTypes, hazard.Type)
+			}
+		}
+	}
+	return hazardTypes
 }
 
 func prettySprintPlan(plan diff.Plan) string {
-    return fmt.Sprintf("%# v", pretty.Formatter(plan.Statements))
+	return fmt.Sprintf("%# v", pretty.Formatter(plan.Statements))
 }
 
 type deterministicRandReader struct {
-    counter int8
+	counter int8
 }
 
 func (r *deterministicRandReader) Read(p []byte) (int, error) {
-    for i := 0; i < len(p); i++ {
-        p[i] = byte(r.counter)
-        r.counter++
-    }
-    return len(p), nil
+	for i := 0; i < len(p); i++ {
+		p[i] = byte(r.counter)
+		r.counter++
+	}
+	return len(p), nil
 }
 
 func TestAcceptanceSuite(t *testing.T) {
-    suite.Run(t, new(acceptanceTestSuite))
+	suite.Run(t, new(acceptanceTestSuite))
 }

--- a/internal/migration_acceptance_tests/acceptance_test.go
+++ b/internal/migration_acceptance_tests/acceptance_test.go
@@ -1,264 +1,264 @@
 package migration_acceptance_tests
 
 import (
-	"context"
-	"database/sql"
-	"fmt"
-	"testing"
+    "context"
+    "database/sql"
+    "fmt"
+    "testing"
 
-	"github.com/google/uuid"
-	_ "github.com/jackc/pgx/v4/stdlib"
-	"github.com/kr/pretty"
-	"github.com/stretchr/testify/suite"
-	"github.com/stripe/pg-schema-diff/internal/pgdump"
-	"github.com/stripe/pg-schema-diff/internal/pgengine"
-	"github.com/stripe/pg-schema-diff/pkg/diff"
-	"github.com/stripe/pg-schema-diff/pkg/log"
-	"github.com/stripe/pg-schema-diff/pkg/sqldb"
+    "github.com/google/uuid"
+    _ "github.com/jackc/pgx/v4/stdlib"
+    "github.com/kr/pretty"
+    "github.com/stretchr/testify/suite"
+    "github.com/stripe/pg-schema-diff/internal/pgdump"
+    "github.com/stripe/pg-schema-diff/internal/pgengine"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/log"
+    "github.com/stripe/pg-schema-diff/pkg/sqldb"
 
-	"github.com/stripe/pg-schema-diff/pkg/tempdb"
+    "github.com/stripe/pg-schema-diff/pkg/tempdb"
 )
 
 var (
-	errValidatingPlan = fmt.Errorf("validating migration plan")
+    errValidatingPlan = fmt.Errorf("validating migration plan")
 )
 
 type (
-	planFactory func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error)
+    planFactory func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error)
 
-	acceptanceTestCase struct {
-		name string
+    acceptanceTestCase struct {
+        name string
 
-		// planOpts is a list of options that should be passed to the plan generator
-		planOpts []diff.PlanOpt
+        // planOpts is a list of options that should be passed to the plan generator
+        planOpts []diff.PlanOpt
 
-		// roles is a list of roles that should be created before the DDL is applied
-		roles        []string
-		oldSchemaDDL []string
-		newSchemaDDL []string
+        // roles is a list of roles that should be created before the DDL is applied
+        roles        []string
+        oldSchemaDDL []string
+        newSchemaDDL []string
 
-		// planFactory is used to generate the actual plan. This is useful for testing different plan generation paths
-		// outside of the normal path. If not specified, a plan will be generated using a default.
-		planFactory planFactory
+        // planFactory is used to generate the actual plan. This is useful for testing different plan generation paths
+        // outside of the normal path. If not specified, a plan will be generated using a default.
+        planFactory planFactory
 
-		// expectedHazardTypes should contain all the unique migration hazard types that are expected to be within the
-		// generated plan
-		expectedHazardTypes       []diff.MigrationHazardType
-		expectedPlanErrorIs       error
-		expectedPlanErrorContains string
-		// expectedPlanDDL is used to assert the exact DDL (of the statements) that  generated. This is useful when asserting
-		// exactly how a migration is performed
-		expectedPlanDDL []string
-		// expectEmptyPlan asserts the plan is expectEmptyPlan
-		expectEmptyPlan bool
-		// expectedDBSchemaDDL should be the DDL required to reconstruct the expected output state of the database
-		//
-		// The expectedDBSchemaDDL might differ from the newSchemaDDL due to options passed to the migrator. For example,
-		// the data packing option will cause the column ordering for new tables in the expectedDBSchemaDDL to differ from
-		// the column ordering of those tables defined in newSchemaDDL
-		//
-		// If no expectedDBSchemaDDL is specified, the newSchemaDDL will be used
-		expectedDBSchemaDDL []string
-	}
+        // expectedHazardTypes should contain all the unique migration hazard types that are expected to be within the
+        // generated plan
+        expectedHazardTypes       []diff.MigrationHazardType
+        expectedPlanErrorIs       error
+        expectedPlanErrorContains string
+        // expectedPlanDDL is used to assert the exact DDL (of the statements) that  generated. This is useful when asserting
+        // exactly how a migration is performed
+        expectedPlanDDL []string
+        // expectEmptyPlan asserts the plan is expectEmptyPlan
+        expectEmptyPlan bool
+        // expectedDBSchemaDDL should be the DDL required to reconstruct the expected output state of the database
+        //
+        // The expectedDBSchemaDDL might differ from the newSchemaDDL due to options passed to the migrator. For example,
+        // the data packing option will cause the column ordering for new tables in the expectedDBSchemaDDL to differ from
+        // the column ordering of those tables defined in newSchemaDDL
+        //
+        // If no expectedDBSchemaDDL is specified, the newSchemaDDL will be used
+        expectedDBSchemaDDL []string
+    }
 
-	acceptanceTestSuite struct {
-		suite.Suite
-		pgEngine *pgengine.Engine
-	}
+    acceptanceTestSuite struct {
+        suite.Suite
+        pgEngine *pgengine.Engine
+    }
 )
 
 func (suite *acceptanceTestSuite) SetupSuite() {
-	engine, err := pgengine.StartEngine()
-	suite.Require().NoError(err)
-	suite.pgEngine = engine
+    engine, err := pgengine.StartEngine()
+    suite.Require().NoError(err)
+    suite.pgEngine = engine
 }
 
 func (suite *acceptanceTestSuite) TearDownSuite() {
-	suite.pgEngine.Close()
+    suite.pgEngine.Close()
 }
 
 // Simulates migrating a database and uses pgdump to compare the actual state to the expected state
 func (suite *acceptanceTestSuite) runTestCases(acceptanceTestCases []acceptanceTestCase) {
-	for _, tc := range acceptanceTestCases {
-		suite.Run(tc.name, func() {
-			suite.runTest(tc)
-		})
-	}
+    for _, tc := range acceptanceTestCases {
+        suite.Run(tc.name, func() {
+            suite.runTest(tc)
+        })
+    }
 }
 
 func (suite *acceptanceTestSuite) runTest(tc acceptanceTestCase) {
-	uuid.SetRand(&deterministicRandReader{})
+    uuid.SetRand(&deterministicRandReader{})
 
-	// Normalize the subtest
-	tc.planOpts = append(tc.planOpts, diff.WithLogger(log.SimpleLogger()))
-	if tc.expectedDBSchemaDDL == nil {
-		tc.expectedDBSchemaDDL = tc.newSchemaDDL
-	}
-	if tc.planFactory == nil {
-		tc.planFactory = func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error) {
-			return diff.Generate(ctx, connPool, diff.DDLSchemaSource(newSchemaDDL),
-				append(tc.planOpts,
-					diff.WithTempDbFactory(tempDbFactory),
-				)...)
-		}
-	}
+    // Normalize the subtest
+    tc.planOpts = append(tc.planOpts, diff.WithLogger(log.SimpleLogger()))
+    if tc.expectedDBSchemaDDL == nil {
+        tc.expectedDBSchemaDDL = tc.newSchemaDDL
+    }
+    if tc.planFactory == nil {
+        tc.planFactory = func(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (diff.Plan, error) {
+            return diff.Generate(ctx, connPool, diff.DDLSchemaSource(newSchemaDDL),
+                append(tc.planOpts,
+                    diff.WithTempDbFactory(tempDbFactory),
+                )...)
+        }
+    }
 
-	// Create roles since they are global
-	rootDb, err := sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseDSN())
-	suite.Require().NoError(err)
-	defer rootDb.Close()
-	for _, r := range tc.roles {
-		_, err := rootDb.Exec(fmt.Sprintf("CREATE ROLE %s", r))
-		suite.Require().NoError(err)
-	}
-	defer func() {
-		// This will drop the roles (and attempt to reset other cluster-level state)
-		suite.Require().NoError(pgengine.ResetInstance(context.Background(), rootDb))
-	}()
+    // Create roles since they are global
+    rootDb, err := sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseDSN())
+    suite.Require().NoError(err)
+    defer rootDb.Close()
+    for _, r := range tc.roles {
+        _, err := rootDb.Exec(fmt.Sprintf("CREATE ROLE %s", r))
+        suite.Require().NoError(err)
+    }
+    defer func() {
+        // This will drop the roles (and attempt to reset other cluster-level state)
+        suite.Require().NoError(pgengine.ResetInstance(context.Background(), rootDb))
+    }()
 
-	// Apply old schema DDL to old DB
-	oldDb, err := suite.pgEngine.CreateDatabase()
-	suite.Require().NoError(err)
-	defer oldDb.DropDB()
-	// Apply the old schema
-	suite.Require().NoError(applyDDL(oldDb, tc.oldSchemaDDL))
+    // Apply old schema DDL to old DB
+    oldDb, err := suite.pgEngine.CreateDatabase()
+    suite.Require().NoError(err)
+    defer oldDb.DropDB()
+    // Apply the old schema
+    suite.Require().NoError(applyDDL(oldDb, tc.oldSchemaDDL))
 
-	// Migrate the old DB
-	oldDBConnPool, err := sql.Open("pgx", oldDb.GetDSN())
-	suite.Require().NoError(err)
-	defer oldDBConnPool.Close()
+    // Migrate the old DB
+    oldDBConnPool, err := sql.Open("pgx", oldDb.GetDSN())
+    suite.Require().NoError(err)
+    defer oldDBConnPool.Close()
 
-	tempDbFactory, err := tempdb.NewOnInstanceFactory(context.Background(), func(ctx context.Context, dbName string) (*sql.DB, error) {
-		return sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseConnOpts().With("dbname", dbName).ToDSN())
-	})
-	suite.Require().NoError(err)
-	defer func(tempDbFactory tempdb.Factory) {
-		// It's important that this closes properly (the temp database is dropped),
-		// so assert it has no error for acceptance tests
-		suite.Require().NoError(tempDbFactory.Close())
-	}(tempDbFactory)
+    tempDbFactory, err := tempdb.NewOnInstanceFactory(context.Background(), func(ctx context.Context, dbName string) (*sql.DB, error) {
+        return sql.Open("pgx", suite.pgEngine.GetPostgresDatabaseConnOpts().With("dbname", dbName).ToDSN())
+    })
+    suite.Require().NoError(err)
+    defer func(tempDbFactory tempdb.Factory) {
+        // It's important that this closes properly (the temp database is dropped),
+        // so assert it has no error for acceptance tests
+        suite.Require().NoError(tempDbFactory.Close())
+    }(tempDbFactory)
 
-	plan, err := tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
-	if tc.expectedPlanErrorIs != nil || len(tc.expectedPlanErrorContains) > 0 {
-		if tc.expectedPlanErrorIs != nil {
-			suite.ErrorIs(err, tc.expectedPlanErrorIs)
-		}
-		if len(tc.expectedPlanErrorContains) > 0 {
-			suite.ErrorContains(err, tc.expectedPlanErrorContains)
-		}
-		return
-	}
-	suite.Require().NoError(err)
+    plan, err := tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
+    if tc.expectedPlanErrorIs != nil || len(tc.expectedPlanErrorContains) > 0 {
+        if tc.expectedPlanErrorIs != nil {
+            suite.ErrorIs(err, tc.expectedPlanErrorIs)
+        }
+        if len(tc.expectedPlanErrorContains) > 0 {
+            suite.ErrorContains(err, tc.expectedPlanErrorContains)
+        }
+        return
+    }
+    suite.Require().NoError(err)
 
-	suite.assertValidPlan(plan)
-	if tc.expectEmptyPlan {
-		// It shouldn't be necessary, but we'll run all checks below this point just in case rather than exiting early
-		suite.Empty(plan.Statements)
-	}
-	suite.ElementsMatch(tc.expectedHazardTypes, getUniqueHazardTypesFromStatements(plan.Statements), prettySprintPlan(plan))
+    suite.assertValidPlan(plan)
+    if tc.expectEmptyPlan {
+        // It shouldn't be necessary, but we'll run all checks below this point just in case rather than exiting early
+        suite.Empty(plan.Statements)
+    }
+    suite.ElementsMatch(tc.expectedHazardTypes, getUniqueHazardTypesFromStatements(plan.Statements), prettySprintPlan(plan))
 
-	// Apply the plan
-	suite.Require().NoError(applyPlan(oldDb, plan), prettySprintPlan(plan))
+    // Apply the plan
+    suite.Require().NoError(applyPlan(oldDb, plan), prettySprintPlan(plan))
 
-	// Make sure the pgdump after running the migration is the same as the
-	// pgdump from a database where we directly run the newSchemaDDL
-	oldDbDump, err := pgdump.GetDump(oldDb, pgdump.WithSchemaOnly())
-	suite.Require().NoError(err)
+    // Make sure the pgdump after running the migration is the same as the
+    // pgdump from a database where we directly run the newSchemaDDL
+    oldDbDump, err := pgdump.GetDump(oldDb, pgdump.WithSchemaOnly())
+    suite.Require().NoError(err)
 
-	newDbDump := suite.directlyRunDDLAndGetDump(tc.expectedDBSchemaDDL)
-	suite.Equal(newDbDump, oldDbDump, prettySprintPlan(plan))
+    newDbDump := suite.directlyRunDDLAndGetDump(tc.expectedDBSchemaDDL)
+    suite.Equal(newDbDump, oldDbDump, prettySprintPlan(plan))
 
-	if tc.expectedPlanDDL != nil {
-		var generatedDDL []string
-		for _, stmt := range plan.Statements {
-			generatedDDL = append(generatedDDL, stmt.DDL)
-		}
-		// In the future, we might want to allow users to assert expectations for vanilla options and data packing
-		//
-		// We can also make the system more advanced by using tokens in place of the "randomly" generated UUIDs, such
-		// the test case doesn't need to be updated if the UUID generation changes. If we built this functionality, we
-		// should also integrate it with the schema_migration_plan_test.go tests.
-		suite.Equal(tc.expectedPlanDDL, generatedDDL, "data packing can change the the generated UUID and DDL")
-	}
+    if tc.expectedPlanDDL != nil {
+        var generatedDDL []string
+        for _, stmt := range plan.Statements {
+            generatedDDL = append(generatedDDL, stmt.DDL)
+        }
+        // In the future, we might want to allow users to assert expectations for vanilla options and data packing
+        //
+        // We can also make the system more advanced by using tokens in place of the "randomly" generated UUIDs, such
+        // the test case doesn't need to be updated if the UUID generation changes. If we built this functionality, we
+        // should also integrate it with the schema_migration_plan_test.go tests.
+        suite.Equal(tc.expectedPlanDDL, generatedDDL, "data packing can change the the generated UUID and DDL")
+    }
 
-	// Make sure no diff is found if we try to regenerate a plan
-	plan, err = tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
-	suite.Require().NoError(err)
-	suite.Empty(plan.Statements, prettySprintPlan(plan))
+    // Make sure no diff is found if we try to regenerate a plan
+    plan, err = tc.planFactory(context.Background(), oldDBConnPool, tempDbFactory, tc.newSchemaDDL, tc.planOpts...)
+    suite.Require().NoError(err)
+    suite.Empty(plan.Statements, prettySprintPlan(plan))
 }
 
 func (suite *acceptanceTestSuite) assertValidPlan(plan diff.Plan) {
-	for _, stmt := range plan.Statements {
-		suite.Greater(stmt.Timeout.Nanoseconds(), int64(0), "timeout should be greater than 0. stmt=%+v", stmt)
-		suite.Greater(stmt.LockTimeout.Nanoseconds(), int64(0), "lock timeout should be greater than 0. stmt=%+v", stmt)
-	}
+    for _, stmt := range plan.Statements {
+        suite.Greater(stmt.Timeout.Nanoseconds(), int64(0), "timeout should be greater than 0. stmt=%+v", stmt)
+        suite.Greater(stmt.LockTimeout.Nanoseconds(), int64(0), "lock timeout should be greater than 0. stmt=%+v", stmt)
+    }
 }
 
 func (suite *acceptanceTestSuite) directlyRunDDLAndGetDump(ddl []string) string {
-	newDb, err := suite.pgEngine.CreateDatabase()
-	suite.Require().NoError(err)
-	defer newDb.DropDB()
-	suite.Require().NoError(applyDDL(newDb, ddl))
+    newDb, err := suite.pgEngine.CreateDatabase()
+    suite.Require().NoError(err)
+    defer newDb.DropDB()
+    suite.Require().NoError(applyDDL(newDb, ddl))
 
-	newDbDump, err := pgdump.GetDump(newDb, pgdump.WithSchemaOnly())
-	suite.Require().NoError(err)
-	return newDbDump
+    newDbDump, err := pgdump.GetDump(newDb, pgdump.WithSchemaOnly())
+    suite.Require().NoError(err)
+    return newDbDump
 }
 
 func applyDDL(db *pgengine.DB, ddl []string) error {
-	conn, err := sql.Open("pgx", db.GetDSN())
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
+    conn, err := sql.Open("pgx", db.GetDSN())
+    if err != nil {
+        return err
+    }
+    defer conn.Close()
 
-	for _, stmt := range ddl {
-		_, err := conn.Exec(stmt)
-		if err != nil {
-			return fmt.Errorf("DDL:\n: %w"+stmt, err)
-		}
-	}
-	return nil
+    for _, stmt := range ddl {
+        _, err := conn.Exec(stmt)
+        if err != nil {
+            return fmt.Errorf("DDL:\n: %w"+stmt, err)
+        }
+    }
+    return nil
 }
 
 func applyPlan(db *pgengine.DB, plan diff.Plan) error {
-	var ddl []string
-	for _, stmt := range plan.Statements {
-		ddl = append(ddl, stmt.ToSQL())
-	}
-	return applyDDL(db, ddl)
+    var ddl []string
+    for _, stmt := range plan.Statements {
+        ddl = append(ddl, stmt.ToSQL())
+    }
+    return applyDDL(db, ddl)
 }
 
 func getUniqueHazardTypesFromStatements(statements []diff.Statement) []diff.MigrationHazardType {
-	var seenHazardTypes = make(map[diff.MigrationHazardType]bool)
-	var hazardTypes []diff.MigrationHazardType
-	for _, stmt := range statements {
-		for _, hazard := range stmt.Hazards {
-			if _, hasHazard := seenHazardTypes[hazard.Type]; !hasHazard {
-				seenHazardTypes[hazard.Type] = true
-				hazardTypes = append(hazardTypes, hazard.Type)
-			}
-		}
-	}
-	return hazardTypes
+    var seenHazardTypes = make(map[diff.MigrationHazardType]bool)
+    var hazardTypes []diff.MigrationHazardType
+    for _, stmt := range statements {
+        for _, hazard := range stmt.Hazards {
+            if _, hasHazard := seenHazardTypes[hazard.Type]; !hasHazard {
+                seenHazardTypes[hazard.Type] = true
+                hazardTypes = append(hazardTypes, hazard.Type)
+            }
+        }
+    }
+    return hazardTypes
 }
 
 func prettySprintPlan(plan diff.Plan) string {
-	return fmt.Sprintf("%# v", pretty.Formatter(plan.Statements))
+    return fmt.Sprintf("%# v", pretty.Formatter(plan.Statements))
 }
 
 type deterministicRandReader struct {
-	counter int8
+    counter int8
 }
 
 func (r *deterministicRandReader) Read(p []byte) (int, error) {
-	for i := 0; i < len(p); i++ {
-		p[i] = byte(r.counter)
-		r.counter++
-	}
-	return len(p), nil
+    for i := 0; i < len(p); i++ {
+        p[i] = byte(r.counter)
+        r.counter++
+    }
+    return len(p), nil
 }
 
 func TestAcceptanceSuite(t *testing.T) {
-	suite.Run(t, new(acceptanceTestSuite))
+    suite.Run(t, new(acceptanceTestSuite))
 }

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -7,81 +7,81 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-            -- Create a table in a different schema to validate it is being ignored (no delete operation).
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-            CREATE TABLE schema_filtered_1.foo();    
+			CREATE TABLE schema_filtered_1.foo();	
 
-            CREATE TABLE foobar(
-                id INT,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE foobar(
+			    id INT,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            CREATE TABLE fizz(
-            );
-            `,
+			CREATE TABLE fizz(
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE new_foobar(
-                id INT,
-                bar TIMESTAMPTZ NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE new_foobar(
+			    id INT,
+				bar TIMESTAMPTZ NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of new_foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of new_foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            CREATE TABLE fizz(
-            );
-            `,
+			CREATE TABLE fizz(
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -89,44 +89,44 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		},
 
 		expectedDBSchemaDDL: []string{`
-            -- Create a table in a different schema to validate it is being ignored (no delete operation).
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-            CREATE TABLE schema_filtered_1.foo();    
+			CREATE TABLE schema_filtered_1.foo();	
 
-            CREATE TABLE new_foobar(
-                id INT,
-                bar TIMESTAMPTZ NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE new_foobar(
+			    id INT,
+				bar TIMESTAMPTZ NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of new_foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of new_foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            CREATE TABLE fizz(
-            );
-            `},
+			CREATE TABLE fizz(
+			);
+			`},
 
 		// Ensure that we're maintaining backwards compatibility with the old generate plan func
 		planFactory: diff.GeneratePlan,

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -3,136 +3,136 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var backCompatAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "Drop partitioned table, Add partitioned table with local keys",
-        oldSchemaDDL: []string{
-            `
-            -- Create a table in a different schema to validate it is being ignored (no delete operation).
+	{
+		name: "Drop partitioned table, Add partitioned table with local keys",
+		oldSchemaDDL: []string{
+			`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-            CREATE TABLE schema_filtered_1.foo();    
+			CREATE TABLE schema_filtered_1.foo();	
 
-            CREATE TABLE foobar(
-                id INT,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE foobar(
+			    id INT,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            CREATE TABLE fizz(
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE new_foobar(
-                id INT,
-                bar TIMESTAMPTZ NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE fizz(
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE new_foobar(
+			    id INT,
+				bar TIMESTAMPTZ NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of new_foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of new_foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            CREATE TABLE fizz(
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-        },
+			CREATE TABLE fizz(
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+		},
 
-        expectedDBSchemaDDL: []string{`
-            -- Create a table in a different schema to validate it is being ignored (no delete operation).
+		expectedDBSchemaDDL: []string{`
+			-- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-            CREATE TABLE schema_filtered_1.foo();    
+			CREATE TABLE schema_filtered_1.foo();	
 
-            CREATE TABLE new_foobar(
-                id INT,
-                bar TIMESTAMPTZ NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE new_foobar(
+			    id INT,
+				bar TIMESTAMPTZ NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of new_foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of new_foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            CREATE TABLE fizz(
-            );
-            `},
+			CREATE TABLE fizz(
+			);
+			`},
 
-        // Ensure that we're maintaining backwards compatibility with the old generate plan func
-        planFactory: diff.GeneratePlan,
-    },
+		// Ensure that we're maintaining backwards compatibility with the old generate plan func
+		planFactory: diff.GeneratePlan,
+	},
 }
 
 func (suite *acceptanceTestSuite) TestBackCompatTestCases() {
-    suite.runTestCases(backCompatAcceptanceTestCases)
+	suite.runTestCases(backCompatAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -7,80 +7,80 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-			CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();	
+            -- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+            CREATE TABLE schema_filtered_1.foo();    
 
-			CREATE TABLE foobar(
-				id INT,
-				bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-				fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE new_foobar(
-				id INT,
-				bar TIMESTAMPTZ NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE new_foobar(
+                id INT,
+                bar TIMESTAMPTZ NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of new_foobar(
-				fizz NOT NULL,
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of new_foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-			CREATE table bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -89,43 +89,43 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		},
 
 		expectedDBSchemaDDL: []string{`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-			CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();	
+            -- Create a table in a different schema to validate it is being ignored (no delete operation).
+            CREATE SCHEMA schema_filtered_1;
+            CREATE TABLE schema_filtered_1.foo();    
 
-			CREATE TABLE new_foobar(
-				id INT,
-				bar TIMESTAMPTZ NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE new_foobar(
+                id INT,
+                bar TIMESTAMPTZ NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of new_foobar(
-				fizz NOT NULL,
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of new_foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-			CREATE table bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 			`},
 
 		// Ensure that we're maintaining backwards compatibility with the old generate plan func

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -3,136 +3,136 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var backCompatAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "Drop partitioned table, Add partitioned table with local keys",
-		oldSchemaDDL: []string{
-			`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+    {
+        name: "Drop partitioned table, Add partitioned table with local keys",
+        oldSchemaDDL: []string{
+            `
+            -- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();	
+            CREATE TABLE schema_filtered_1.foo();    
 
-			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE new_foobar(
-			    id INT,
-				bar TIMESTAMPTZ NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE fizz(
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE new_foobar(
+                id INT,
+                bar TIMESTAMPTZ NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of new_foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of new_foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-		},
+            CREATE TABLE fizz(
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+        },
 
-		expectedDBSchemaDDL: []string{`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+        expectedDBSchemaDDL: []string{`
+            -- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();	
+            CREATE TABLE schema_filtered_1.foo();    
 
-			CREATE TABLE new_foobar(
-			    id INT,
-				bar TIMESTAMPTZ NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE new_foobar(
+                id INT,
+                bar TIMESTAMPTZ NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of new_foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of new_foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
-			`},
+            CREATE TABLE fizz(
+            );
+            `},
 
-		// Ensure that we're maintaining backwards compatibility with the old generate plan func
-		planFactory: diff.GeneratePlan,
-	},
+        // Ensure that we're maintaining backwards compatibility with the old generate plan func
+        planFactory: diff.GeneratePlan,
+    },
 }
 
 func (suite *acceptanceTestSuite) TestBackCompatTestCases() {
-	suite.runTestCases(backCompatAcceptanceTestCases)
+    suite.runTestCases(backCompatAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -7,81 +7,81 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            -- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();	
+            CREATE TABLE schema_filtered_1.foo();    
 
-			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
-			`,
+            CREATE TABLE fizz(
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE new_foobar(
-			    id INT,
-				bar TIMESTAMPTZ NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE new_foobar(
+                id INT,
+                bar TIMESTAMPTZ NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of new_foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of new_foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
-			`,
+            CREATE TABLE fizz(
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -89,44 +89,44 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		},
 
 		expectedDBSchemaDDL: []string{`
-			-- Create a table in a different schema to validate it is being ignored (no delete operation).
+            -- Create a table in a different schema to validate it is being ignored (no delete operation).
             CREATE SCHEMA schema_filtered_1;
-			CREATE TABLE schema_filtered_1.foo();	
+            CREATE TABLE schema_filtered_1.foo();    
 
-			CREATE TABLE new_foobar(
-			    id INT,
-				bar TIMESTAMPTZ NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE new_foobar(
+                id INT,
+                bar TIMESTAMPTZ NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of new_foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of new_foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON new_foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			CREATE TABLE fizz(
-			);
-			`},
+            CREATE TABLE fizz(
+            );
+            `},
 
 		// Ensure that we're maintaining backwards compatibility with the old generate plan func
 		planFactory: diff.GeneratePlan,

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -8,20 +8,20 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-            CREATE SCHEMA schema_filtered_1;
+			CREATE SCHEMA schema_filtered_1;
 			CREATE TABLE schema_filtered_1.foo();	
 
 			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
+				id INT,
+				bar SERIAL NOT NULL,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 
 			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
+				fizz NOT NULL
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- partitioned indexes
@@ -31,12 +31,12 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
 			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
 			);
 			CREATE INDEX bar_normal_idx ON bar(bar);
 			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
@@ -49,16 +49,16 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE new_foobar(
-			    id INT,
+				id INT,
 				bar TIMESTAMPTZ NOT NULL,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    UNIQUE (foo, bar)
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 
 			CREATE TABLE foobar_1 PARTITION of new_foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
+				fizz NOT NULL,
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- local indexes
@@ -68,11 +68,11 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
 			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
 			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
 			);
 			CREATE INDEX bar_normal_idx ON bar(bar);
@@ -90,20 +90,20 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 
 		expectedDBSchemaDDL: []string{`
 			-- Create a table in a different schema to validate it is being ignored (no delete operation).
-            CREATE SCHEMA schema_filtered_1;
+			CREATE SCHEMA schema_filtered_1;
 			CREATE TABLE schema_filtered_1.foo();	
 
 			CREATE TABLE new_foobar(
-			    id INT,
+				id INT,
 				bar TIMESTAMPTZ NOT NULL,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    UNIQUE (foo, bar)
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 
 			CREATE TABLE foobar_1 PARTITION of new_foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
+				fizz NOT NULL,
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- local indexes
@@ -113,11 +113,11 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_unique_idx ON new_foobar(foo, fizz);
 
 			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
 			   	FOREIGN KEY (foo, fizz) REFERENCES new_foobar (foo, fizz)
 			);
 			CREATE INDEX bar_normal_idx ON bar(bar);

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -10,7 +10,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT CHECK ( bar > id )
 			);
@@ -19,7 +19,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT CHECK ( bar > id )
 			);
@@ -32,7 +32,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -41,7 +41,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT CHECK ( bar > id )
 			);
@@ -57,7 +57,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);
@@ -72,7 +72,7 @@ var checkConstraintCases = []acceptanceTestCase{
 				RETURN a + b;
 
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT CHECK ( add(bar, id) > 0 )
 			);
@@ -86,7 +86,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);
@@ -95,7 +95,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
 			);
@@ -107,7 +107,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -116,7 +116,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT,
 				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
@@ -129,7 +129,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			`,
@@ -137,7 +137,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
 			);
@@ -149,7 +149,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			`,
@@ -157,7 +157,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo INT CHECK ( foo > 0 )
 			);
 			`,
@@ -172,7 +172,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
+				"ID" INT PRIMARY KEY,
 				foo VARCHAR(255),
 				"Bar" BIGINT
 			);
@@ -181,7 +181,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
+				"ID" INT PRIMARY KEY,
 				foo VARCHAR(255),
 			   	"Bar" BIGINT
 			);
@@ -194,7 +194,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -203,7 +203,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -216,7 +216,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -225,7 +225,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -238,7 +238,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT CHECK ( bar > id )
 			);
@@ -247,7 +247,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -259,7 +259,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
+				"ID" INT PRIMARY KEY,
 				foo VARCHAR(255),
 				"Bar" BIGINT
 			);
@@ -269,7 +269,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
+				"ID" INT PRIMARY KEY,
 				foo VARCHAR(255),
 			   	"Bar" BIGINT
 			);
@@ -281,7 +281,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
+				"ID" INT PRIMARY KEY,
 				foo VARCHAR(255),
 				"Bar" BIGINT CHECK ( "Bar" > 0 )
 			);
@@ -290,7 +290,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
+				"ID" INT PRIMARY KEY,
 				foo VARCHAR(255),
 			   	"Bar" TEXT
 			);
@@ -306,7 +306,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT,
 				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
@@ -316,7 +316,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			`,
@@ -334,7 +334,7 @@ var checkConstraintCases = []acceptanceTestCase{
 				RETURN a + b;
 
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT CHECK ( add(bar, id) > 0 )
 			);
@@ -343,7 +343,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);
@@ -357,7 +357,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
 			);
@@ -366,7 +366,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);
@@ -378,7 +378,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -388,7 +388,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -404,7 +404,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -414,7 +414,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -427,7 +427,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -437,7 +437,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -450,7 +450,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -460,7 +460,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT
 			);
@@ -473,7 +473,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT CHECK (bar > id)
 			);
@@ -482,7 +482,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar BIGINT CHECK (bar < id)
 			);
@@ -500,7 +500,7 @@ var checkConstraintCases = []acceptanceTestCase{
 				RETURN a + b;
 
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);
@@ -516,7 +516,7 @@ var checkConstraintCases = []acceptanceTestCase{
 				RETURN a + b;
 
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);
@@ -531,7 +531,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);
@@ -541,7 +541,7 @@ var checkConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar INT
 			);

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -9,21 +9,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
 		},
 		expectEmptyPlan: true,
 	},
@@ -31,21 +31,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint (validate constraint added online)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_check\" CHECK((bar > id)) NOT VALID",
@@ -56,27 +56,27 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( add(bar, id) > 0 )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( add(bar, id) > 0 )
+            );
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -85,82 +85,82 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+            );
+            `,
 		},
 	},
 	{
 		name: "Add multiple check constraints",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT,
-				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT,
+                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
+            `,
 		},
 	},
 	{
 		name: "Add check constraints to new column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
+            `,
 		},
 	},
 	{
 		name: "Add check constraint and change data type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo INT CHECK ( foo > 0 )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo INT CHECK ( foo > 0 )
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -171,130 +171,130 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with quoted identifiers",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-			`,
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+            `,
 		},
 	},
 	{
 		name: "Add no inherit check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            `,
 		},
 	},
 	{
 		name: "Add No-Inherit, Not-Valid check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
+            `,
 		},
 	},
 	{
 		name: "Drop check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
 		},
 	},
 	{
 		name: "Drop check constraint with quoted identifiers",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-			`,
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" BIGINT
+            );
+            `,
 		},
 	},
 	{
 		name: "Drop check constraint and change data type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT CHECK ( "Bar" > 0 )
-			);
-			`,
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT CHECK ( "Bar" > 0 )
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" TEXT
-			);
-			`,
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" TEXT
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -305,21 +305,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop column with check constraints",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT,
-				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT,
+                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
 	},
@@ -327,27 +327,27 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( add(bar, id) > 0 )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( add(bar, id) > 0 )
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -356,44 +356,44 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
 		},
 	},
 	{
 		name: "Alter an invalid check constraint to be valid (validate constraint isn't dropped and re-added)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"bar_check\"",
@@ -403,125 +403,125 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter a valid check constraint to be invalid",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+            `,
 		},
 	},
 	{
 		name: "Alter a no-Inherit check constraint to be Inheritable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
 		},
 	},
 	{
 		name: "Alter an Inheritable check constraint to be no-inherit",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            `,
 		},
 	},
 	{
 		name: "Alter a check constraint expression",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK (bar > id)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK (bar > id)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK (bar < id)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK (bar < id)
+            );
+            `,
 		},
 	},
 	{
 		name: "Alter check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -530,23 +530,23 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
+            `,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -9,21 +9,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
 		},
 		expectEmptyPlan: true,
 	},
@@ -31,21 +31,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint (validate constraint added online)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_check\" CHECK((bar > id)) NOT VALID",
@@ -56,27 +56,27 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( add(bar, id) > 0 )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( add(bar, id) > 0 )
+			);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -85,82 +85,82 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+			);
+			`,
 		},
 	},
 	{
 		name: "Add multiple check constraints",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT,
-                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT,
+				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+			);
+			`,
 		},
 	},
 	{
 		name: "Add check constraints to new column",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+			);
+			`,
 		},
 	},
 	{
 		name: "Add check constraint and change data type",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo INT CHECK ( foo > 0 )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo INT CHECK ( foo > 0 )
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -171,130 +171,130 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with quoted identifiers",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                "Bar" BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+				"Bar" BIGINT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                   "Bar" BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-            `,
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+			   	"Bar" BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+			`,
 		},
 	},
 	{
 		name: "Add no inherit check constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+			`,
 		},
 	},
 	{
 		name: "Add No-Inherit, Not-Valid check constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
+			`,
 		},
 	},
 	{
 		name: "Drop check constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
 		},
 	},
 	{
 		name: "Drop check constraint with quoted identifiers",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                "Bar" BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-            `,
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+				"Bar" BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                   "Bar" BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+			   	"Bar" BIGINT
+			);
+			`,
 		},
 	},
 	{
 		name: "Drop check constraint and change data type",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                "Bar" BIGINT CHECK ( "Bar" > 0 )
-            );
-            `,
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+				"Bar" BIGINT CHECK ( "Bar" > 0 )
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                   "Bar" TEXT
-            );
-            `,
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+			   	"Bar" TEXT
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -305,21 +305,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop column with check constraints",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT,
-                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT,
+				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
 	},
@@ -327,27 +327,27 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( add(bar, id) > 0 )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( add(bar, id) > 0 )
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -356,44 +356,44 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
 		},
 	},
 	{
 		name: "Alter an invalid check constraint to be valid (validate constraint isn't dropped and re-added)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"bar_check\"",
@@ -403,125 +403,125 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter a valid check constraint to be invalid",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+			`,
 		},
 	},
 	{
 		name: "Alter a no-Inherit check constraint to be Inheritable",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
 		},
 	},
 	{
 		name: "Alter an Inheritable check constraint to be no-inherit",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+			`,
 		},
 	},
 	{
 		name: "Alter a check constraint expression",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK (bar > id)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK (bar > id)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK (bar < id)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK (bar < id)
+			);
+			`,
 		},
 	},
 	{
 		name: "Alter check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -530,23 +530,23 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
+			`,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -1,556 +1,556 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var checkConstraintCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
-        },
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Add check constraint (validate constraint added online)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_check\" CHECK((bar > id)) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_check\"",
-        },
-    },
-    {
-        name: "Add check constraint with UDF dependency should error",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Add check constraint (validate constraint added online)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_check\" CHECK((bar > id)) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_check\"",
+		},
+	},
+	{
+		name: "Add check constraint with UDF dependency should error",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( add(bar, id) > 0 )
-            );
-            `,
-        },
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( add(bar, id) > 0 )
+			);
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Add check constraint with system function dependency should not error",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-            );
-            `,
-        },
-    },
-    {
-        name: "Add multiple check constraints",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT,
-                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-            );
-            `,
-        },
-    },
-    {
-        name: "Add check constraints to new column",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-            );
-            `,
-        },
-    },
-    {
-        name: "Add check constraint and change data type",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo INT CHECK ( foo > 0 )
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Add check constraint with quoted identifiers",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                "Bar" BIGINT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                   "Bar" BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-            `,
-        },
-    },
-    {
-        name: "Add no inherit check constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-            `,
-        },
-    },
-    {
-        name: "Add No-Inherit, Not-Valid check constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
-            `,
-        },
-    },
-    {
-        name: "Drop check constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK ( bar > id )
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            `,
-        },
-    },
-    {
-        name: "Drop check constraint with quoted identifiers",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                "Bar" BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                   "Bar" BIGINT
-            );
-            `,
-        },
-    },
-    {
-        name: "Drop check constraint and change data type",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                "Bar" BIGINT CHECK ( "Bar" > 0 )
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "ID" INT PRIMARY KEY,
-                foo VARCHAR(255),
-                   "Bar" TEXT
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Drop column with check constraints",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT,
-                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
-    },
-    {
-        name: "Drop check constraint with UDF dependency should error",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Add check constraint with system function dependency should not error",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+			);
+			`,
+		},
+	},
+	{
+		name: "Add multiple check constraints",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT,
+				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+			);
+			`,
+		},
+	},
+	{
+		name: "Add check constraints to new column",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+			);
+			`,
+		},
+	},
+	{
+		name: "Add check constraint and change data type",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo INT CHECK ( foo > 0 )
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Add check constraint with quoted identifiers",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+				"Bar" BIGINT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+			   	"Bar" BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+			`,
+		},
+	},
+	{
+		name: "Add no inherit check constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+			`,
+		},
+	},
+	{
+		name: "Add No-Inherit, Not-Valid check constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
+			`,
+		},
+	},
+	{
+		name: "Drop check constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK ( bar > id )
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			`,
+		},
+	},
+	{
+		name: "Drop check constraint with quoted identifiers",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+				"Bar" BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+			   	"Bar" BIGINT
+			);
+			`,
+		},
+	},
+	{
+		name: "Drop check constraint and change data type",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+				"Bar" BIGINT CHECK ( "Bar" > 0 )
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "ID" INT PRIMARY KEY,
+				foo VARCHAR(255),
+			   	"Bar" TEXT
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Drop column with check constraints",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT,
+				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
+	},
+	{
+		name: "Drop check constraint with UDF dependency should error",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( add(bar, id) > 0 )
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
-        },
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( add(bar, id) > 0 )
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Drop check constraint with system function dependency should not error",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            `,
-        },
-    },
-    {
-        name: "Alter an invalid check constraint to be valid (validate constraint isn't dropped and re-added)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"bar_check\"",
-        },
-    },
-    {
-        name: "Alter a valid check constraint to be invalid",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-            `,
-        },
-    },
-    {
-        name: "Alter a no-Inherit check constraint to be Inheritable",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
-        },
-    },
-    {
-        name: "Alter an Inheritable check constraint to be no-inherit",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-            `,
-        },
-    },
-    {
-        name: "Alter a check constraint expression",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK (bar > id)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar BIGINT CHECK (bar < id)
-            );
-            `,
-        },
-    },
-    {
-        name: "Alter check constraint with UDF dependency should error",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Drop check constraint with system function dependency should not error",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			`,
+		},
+	},
+	{
+		name: "Alter an invalid check constraint to be valid (validate constraint isn't dropped and re-added)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"bar_check\"",
+		},
+	},
+	{
+		name: "Alter a valid check constraint to be invalid",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+			`,
+		},
+	},
+	{
+		name: "Alter a no-Inherit check constraint to be Inheritable",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
+		},
+	},
+	{
+		name: "Alter an Inheritable check constraint to be no-inherit",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+			`,
+		},
+	},
+	{
+		name: "Alter a check constraint expression",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK (bar > id)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar BIGINT CHECK (bar < id)
+			);
+			`,
+		},
+	},
+	{
+		name: "Alter check constraint with UDF dependency should error",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
-            `,
-        },
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Alter check constraint with system function dependency should not error",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar INT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
-            `,
-        },
-    },
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Alter check constraint with system function dependency should not error",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar INT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
+			`,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestCheckConstraintTestCases() {
-    suite.runTestCases(checkConstraintCases)
+	suite.runTestCases(checkConstraintCases)
 }

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -1,556 +1,556 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var checkConstraintCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
-		},
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Add check constraint (validate constraint added online)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_check\" CHECK((bar > id)) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_check\"",
-		},
-	},
-	{
-		name: "Add check constraint with UDF dependency should error",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
+        },
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Add check constraint (validate constraint added online)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_check\" CHECK((bar > id)) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_check\"",
+        },
+    },
+    {
+        name: "Add check constraint with UDF dependency should error",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( add(bar, id) > 0 )
-			);
-			`,
-		},
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( add(bar, id) > 0 )
+            );
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Add check constraint with system function dependency should not error",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-			);
-			`,
-		},
-	},
-	{
-		name: "Add multiple check constraints",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT,
-				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
-			`,
-		},
-	},
-	{
-		name: "Add check constraints to new column",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
-			`,
-		},
-	},
-	{
-		name: "Add check constraint and change data type",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo INT CHECK ( foo > 0 )
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Add check constraint with quoted identifiers",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-			`,
-		},
-	},
-	{
-		name: "Add no inherit check constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-			`,
-		},
-	},
-	{
-		name: "Add No-Inherit, Not-Valid check constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
-			`,
-		},
-	},
-	{
-		name: "Drop check constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			`,
-		},
-	},
-	{
-		name: "Drop check constraint with quoted identifiers",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" BIGINT
-			);
-			`,
-		},
-	},
-	{
-		name: "Drop check constraint and change data type",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT CHECK ( "Bar" > 0 )
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" TEXT
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Drop column with check constraints",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT,
-				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
-	},
-	{
-		name: "Drop check constraint with UDF dependency should error",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Add check constraint with system function dependency should not error",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+            );
+            `,
+        },
+    },
+    {
+        name: "Add multiple check constraints",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT,
+                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
+            `,
+        },
+    },
+    {
+        name: "Add check constraints to new column",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
+            `,
+        },
+    },
+    {
+        name: "Add check constraint and change data type",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo INT CHECK ( foo > 0 )
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Add check constraint with quoted identifiers",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+            `,
+        },
+    },
+    {
+        name: "Add no inherit check constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            `,
+        },
+    },
+    {
+        name: "Add No-Inherit, Not-Valid check constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
+            `,
+        },
+    },
+    {
+        name: "Drop check constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            `,
+        },
+    },
+    {
+        name: "Drop check constraint with quoted identifiers",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" BIGINT
+            );
+            `,
+        },
+    },
+    {
+        name: "Drop check constraint and change data type",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT CHECK ( "Bar" > 0 )
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" TEXT
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Drop column with check constraints",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT,
+                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
+    },
+    {
+        name: "Drop check constraint with UDF dependency should error",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( add(bar, id) > 0 )
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
-		},
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( add(bar, id) > 0 )
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Drop check constraint with system function dependency should not error",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			`,
-		},
-	},
-	{
-		name: "Alter an invalid check constraint to be valid (validate constraint isn't dropped and re-added)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"bar_check\"",
-		},
-	},
-	{
-		name: "Alter a valid check constraint to be invalid",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
-			`,
-		},
-	},
-	{
-		name: "Alter a no-Inherit check constraint to be Inheritable",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
-		},
-	},
-	{
-		name: "Alter an Inheritable check constraint to be no-inherit",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
-			`,
-		},
-	},
-	{
-		name: "Alter a check constraint expression",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK (bar > id)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK (bar < id)
-			);
-			`,
-		},
-	},
-	{
-		name: "Alter check constraint with UDF dependency should error",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Drop check constraint with system function dependency should not error",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            `,
+        },
+    },
+    {
+        name: "Alter an invalid check constraint to be valid (validate constraint isn't dropped and re-added)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"bar_check\"",
+        },
+    },
+    {
+        name: "Alter a valid check constraint to be invalid",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+            `,
+        },
+    },
+    {
+        name: "Alter a no-Inherit check constraint to be Inheritable",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
+        },
+    },
+    {
+        name: "Alter an Inheritable check constraint to be no-inherit",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            `,
+        },
+    },
+    {
+        name: "Alter a check constraint expression",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK (bar > id)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK (bar < id)
+            );
+            `,
+        },
+    },
+    {
+        name: "Alter check constraint with UDF dependency should error",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
-			`,
-		},
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Alter check constraint with system function dependency should not error",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
-			`,
-		},
-	},
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Alter check constraint with system function dependency should not error",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
+            `,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestCheckConstraintTestCases() {
-	suite.runTestCases(checkConstraintCases)
+    suite.runTestCases(checkConstraintCases)
 }

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -9,20 +9,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
 			`,
 		},
 		expectEmptyPlan: true,
@@ -31,20 +31,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint (validate constraint added online)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -56,26 +56,26 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( add(bar, id) > 0 )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( add(bar, id) > 0 )
+            );
 			`,
 		},
 
@@ -85,20 +85,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+            );
 			`,
 		},
 	},
@@ -106,21 +106,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add multiple check constraints",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT,
-				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT,
+                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
 			`,
 		},
 	},
@@ -128,19 +128,19 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraints to new column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
 			`,
 		},
 	},
@@ -148,18 +148,18 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint and change data type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo INT CHECK ( foo > 0 )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo INT CHECK ( foo > 0 )
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -171,21 +171,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add check constraint with quoted identifiers",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT
-			);
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
 			`,
 		},
 	},
@@ -193,21 +193,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add no inherit check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
 			`,
 		},
 	},
@@ -215,21 +215,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Add No-Inherit, Not-Valid check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT NOT VALID;
 			`,
 		},
 	},
@@ -237,20 +237,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK ( bar > id )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK ( bar > id )
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
 			`,
 		},
 	},
@@ -258,21 +258,21 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint with quoted identifiers",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT "BAR_CHECK" CHECK ( "Bar" < "ID" );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" BIGINT
-			);
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" BIGINT
+            );
 			`,
 		},
 	},
@@ -280,20 +280,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint and change data type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-				"Bar" BIGINT CHECK ( "Bar" > 0 )
-			);
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                "Bar" BIGINT CHECK ( "Bar" > 0 )
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"ID" INT PRIMARY KEY,
-				foo VARCHAR(255),
-			   	"Bar" TEXT
-			);
+            CREATE TABLE foobar(
+                "ID" INT PRIMARY KEY,
+                foo VARCHAR(255),
+                   "Bar" TEXT
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -305,20 +305,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop column with check constraints",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT,
-				CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT,
+                CHECK ( bar > id ), CHECK ( bar IS NOT NULL ), CHECK (bar > 0)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
@@ -327,26 +327,26 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( add(bar, id) > 0 )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( add(bar, id) > 0 )
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
 			`,
 		},
 
@@ -356,20 +356,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Drop check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP )
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
 			`,
 		},
 	},
@@ -377,22 +377,22 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter an invalid check constraint to be valid (validate constraint isn't dropped and re-added)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -403,22 +403,22 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter a valid check constraint to be invalid",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NOT VALID;
 			`,
 		},
 	},
@@ -426,22 +426,22 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter a no-Inherit check constraint to be Inheritable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
 			`,
 		},
 	},
@@ -449,22 +449,22 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter an Inheritable check constraint to be no-inherit",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT bar_check CHECK ( bar > id ) NO INHERIT;
 			`,
 		},
 	},
@@ -472,20 +472,20 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter a check constraint expression",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK (bar > id)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK (bar > id)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar BIGINT CHECK (bar < id)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar BIGINT CHECK (bar < id)
+            );
 			`,
 		},
 	},
@@ -493,34 +493,34 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter check constraint with UDF dependency should error",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 ) NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( add(bar, id) > 0 );
 			`,
 		},
 
@@ -530,22 +530,22 @@ var checkConstraintCases = []acceptanceTestCase{
 		name: "Alter check constraint with system function dependency should not error",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP ) NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar INT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT some_constraint CHECK ( to_timestamp(id) <= CURRENT_TIMESTAMP );
 			`,
 		},
 	},

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -1,932 +1,932 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var columnAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL
-			);
-			`,
-		},
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL
+            );
+            `,
+        },
 
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Add one column with default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) DEFAULT 'a'
-			);
-			`,
-		},
-	},
-	{
-		name: "Add one column with quoted names",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"My_new_column" VARCHAR(255) DEFAULT 'a'
-			);
-			`,
-		},
-	},
-	{
-		name: "Add one column with nullability",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-	},
-	{
-		name: "Add one column with serial",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column SERIAL NOT NULL
-			);
-			`,
-		},
-	},
-	{
-		name: "Add one column with all options",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
-			);
-			`,
-		},
-	},
-	{
-		name: "Add one column and change ordering",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-				my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Add one column with default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) DEFAULT 'a'
+            );
+            `,
+        },
+    },
+    {
+        name: "Add one column with quoted names",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "My_new_column" VARCHAR(255) DEFAULT 'a'
+            );
+            `,
+        },
+    },
+    {
+        name: "Add one column with nullability",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+    },
+    {
+        name: "Add one column with serial",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column SERIAL NOT NULL
+            );
+            `,
+        },
+    },
+    {
+        name: "Add one column with all options",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
+            );
+            `,
+        },
+    },
+    {
+        name: "Add one column and change ordering",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
+                id INT PRIMARY KEY
+            );
+            `,
+        },
 
-		expectedDBSchemaDDL: []string{`
-					CREATE TABLE foobar(
-						id INT PRIMARY KEY,
-						my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
-					)
-				`},
-	},
-	{
-		name: "Delete one column",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete one column with quoted name",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete one column with serial",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id BIGSERIAL PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete column with valid not null check constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Modify data type (int -> serial)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SERIAL NOT NULL
-			);
-			`,
-		},
-	},
-	{
-		name: "Modify data type (serial -> int)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SERIAL NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				some_time_col BIGINT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				some_time_col TIMESTAMP 
-			);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
-			"ANALYZE \"public\".\"Foobar\" (\"some_time_col\")",
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Modify data type (varchar -> TEXT) with compatible default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'some default' NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Modify data type and collation (varchar -> char)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "C" NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar CHAR COLLATE "POSIX" NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Modify data type to incompatible (bytea -> char)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar bytea NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar CHAR NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Modify collation (default -> non-default) (validate ANALYZE is run)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "C" NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-			);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE character varying(255) COLLATE \"pg_catalog\".\"POSIX\" using \"foobar\"::character varying(255)",
-			"ANALYZE \"public\".\"foobar\" (\"foobar\")",
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Modify collation (non-default -> non-default)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Add Default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
-			`,
-		},
-	},
-	{
-		name: "Remove Default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
-		},
-	},
-	{
-		name: "Change Default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'Something else'
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
-			`,
-		},
-	},
-	{
-		name: "Set NOT NULL",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
-	},
-	{
-		name: "Set NOT NULL (add invalid CC)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-		},
-	},
+        expectedDBSchemaDDL: []string{`
+                    CREATE TABLE foobar(
+                        id INT PRIMARY KEY,
+                        my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
+                    )
+                `},
+    },
+    {
+        name: "Delete one column",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete one column with quoted name",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                "Id" INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete one column with serial",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id BIGSERIAL PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete column with valid not null check constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Modify data type (int -> serial)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SERIAL NOT NULL
+            );
+            `,
+        },
+    },
+    {
+        name: "Modify data type (serial -> int)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SERIAL NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col BIGINT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col TIMESTAMP 
+            );
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
+            "ANALYZE \"public\".\"Foobar\" (\"some_time_col\")",
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Modify data type (varchar -> TEXT) with compatible default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'some default' NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Modify data type and collation (varchar -> char)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "C" NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR COLLATE "POSIX" NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Modify data type to incompatible (bytea -> char)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar bytea NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Modify collation (default -> non-default) (validate ANALYZE is run)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "C" NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+            );
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE character varying(255) COLLATE \"pg_catalog\".\"POSIX\" using \"foobar\"::character varying(255)",
+            "ANALYZE \"public\".\"foobar\" (\"foobar\")",
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Modify collation (non-default -> non-default)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Add Default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
+            `,
+        },
+    },
+    {
+        name: "Remove Default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
+        },
+    },
+    {
+        name: "Change Default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'Something else'
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
+            `,
+        },
+    },
+    {
+        name: "Set NOT NULL",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
+    },
+    {
+        name: "Set NOT NULL (add invalid CC)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+        },
+    },
 
-	{
-		name: "Set NOT NULL (invalid CC already exists)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-		},
-	},
-	{
-		name: "Set NOT NULL (invalid to valid CC)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-		},
-	},
-	{
-		name: "Set NOT NULL (add valid CC)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-		},
-	},
-	{
-		name: "Set NOT NULL (valid CC already exists)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-		},
-	},
-	{
-		name: "Set NOT NULL (dropping valid CC)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
-		},
-	},
-	{
-		name: "Set NOT NULL (dropping valid CC via recreation)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((length((foobar)::text) > 0)) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
-		},
-	},
-	{
-		name: "Set NOT NULL (data type change with additional CC)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL CHECK (foobar > 0)
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE integer using \"foobar\"::integer",
-			"ANALYZE \"public\".\"foobar\" (\"foobar\")",
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_foobar_check\" CHECK((foobar > 0)) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_foobar_check\"",
-			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-		},
-	},
-	{
-		name: "Remove NOT NULL",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
-		},
-	},
-	{
-		name: "Add default and change data type (new default is incompatible with old type)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'SOMETHING'
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Change default and data type (new default is incompatible with old type)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT 0
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'SOMETHING'
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Change default and data type (old default is incompatible with new type)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'SOMETHING'
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT 8
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-		expectedPlanErrorContains: errValidatingPlan.Error(),
-	},
-	{
-		name: "Change from NULL default to no default and NOT NULL",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
-		},
-	},
-	{
-		name: "Change from NOT NULL to no NULL default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT NULL
-			);
-			`,
-		},
-	},
-	{
-		name: "Change data type and to nullable",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SMALLINT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Change data type and to not nullable",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SMALLINT NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Change data type, nullability (NOT NULL), and default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'some default'
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar CHAR NOT NULL DEFAULT 'A'
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Change data type and collation, nullability (NOT NULL), and default with quoted names",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foobar" TEXT DEFAULT 'some default'
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
+    {
+        name: "Set NOT NULL (invalid CC already exists)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+        },
+    },
+    {
+        name: "Set NOT NULL (invalid to valid CC)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+        },
+    },
+    {
+        name: "Set NOT NULL (add valid CC)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+        },
+    },
+    {
+        name: "Set NOT NULL (valid CC already exists)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+        },
+    },
+    {
+        name: "Set NOT NULL (dropping valid CC)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
+        },
+    },
+    {
+        name: "Set NOT NULL (dropping valid CC via recreation)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((length((foobar)::text) > 0)) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
+        },
+    },
+    {
+        name: "Set NOT NULL (data type change with additional CC)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL CHECK (foobar > 0)
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE integer using \"foobar\"::integer",
+            "ANALYZE \"public\".\"foobar\" (\"foobar\")",
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_foobar_check\" CHECK((foobar > 0)) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_foobar_check\"",
+            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+        },
+    },
+    {
+        name: "Remove NOT NULL",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
+        },
+    },
+    {
+        name: "Add default and change data type (new default is incompatible with old type)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'SOMETHING'
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Change default and data type (new default is incompatible with old type)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT 0
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'SOMETHING'
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Change default and data type (old default is incompatible with new type)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'SOMETHING'
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT 8
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+        expectedPlanErrorContains: errValidatingPlan.Error(),
+    },
+    {
+        name: "Change from NULL default to no default and NOT NULL",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
+        },
+    },
+    {
+        name: "Change from NOT NULL to no NULL default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT NULL
+            );
+            `,
+        },
+    },
+    {
+        name: "Change data type and to nullable",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SMALLINT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Change data type and to not nullable",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SMALLINT NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Change data type, nullability (NOT NULL), and default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'some default'
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR NOT NULL DEFAULT 'A'
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Change data type and collation, nullability (NOT NULL), and default with quoted names",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foobar" TEXT DEFAULT 'some default'
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestColumnTestCases() {
-	suite.runTestCases(columnAcceptanceTestCases)
+    suite.runTestCases(columnAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -9,23 +9,23 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz BOOLEAN NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz BOOLEAN NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz BOOLEAN NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz BOOLEAN NOT NULL
+			);
+			`,
 		},
 
 		expectEmptyPlan: true,
@@ -34,131 +34,131 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column with default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column VARCHAR(255) DEFAULT 'a'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column VARCHAR(255) DEFAULT 'a'
+			);
+			`,
 		},
 	},
 	{
 		name: "Add one column with quoted names",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "My_new_column" VARCHAR(255) DEFAULT 'a'
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"My_new_column" VARCHAR(255) DEFAULT 'a'
+			);
+			`,
 		},
 	},
 	{
 		name: "Add one column with nullability",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 	},
 	{
 		name: "Add one column with serial",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column SERIAL NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column SERIAL NOT NULL
+			);
+			`,
 		},
 	},
 	{
 		name: "Add one column with all options",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
+			);
+			`,
 		},
 	},
 	{
 		name: "Add one column and change ordering",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+				my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-                    CREATE TABLE foobar(
-                        id INT PRIMARY KEY,
-                        my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
-                    )
-                `},
+					CREATE TABLE foobar(
+						id INT PRIMARY KEY,
+						my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
+					)
+				`},
 	},
 	{
 		name: "Delete one column",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-            );
-            `,
+			CREATE TABLE foobar(
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -170,16 +170,16 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete one column with quoted name",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                "Id" INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    "Id" INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -191,16 +191,16 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete one column with serial",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id BIGSERIAL PRIMARY KEY
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id BIGSERIAL PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -212,18 +212,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete column with valid not null check constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -233,38 +233,38 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type (int -> serial)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SERIAL NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SERIAL NOT NULL
+			);
+			`,
 		},
 	},
 	{
 		name: "Modify data type (serial -> int)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SERIAL NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SERIAL NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -274,19 +274,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                some_time_col BIGINT
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				some_time_col BIGINT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                some_time_col TIMESTAMP 
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				some_time_col TIMESTAMP 
+			);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
@@ -301,19 +301,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type (varchar -> TEXT) with compatible default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT DEFAULT 'some default' NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT DEFAULT 'some default' NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -324,19 +324,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type and collation (varchar -> char)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "C" NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "C" NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar CHAR COLLATE "POSIX" NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar CHAR COLLATE "POSIX" NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -347,19 +347,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type to incompatible (bytea -> char)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar bytea NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar bytea NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar CHAR NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar CHAR NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -370,19 +370,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify collation (default -> non-default) (validate ANALYZE is run)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "C" NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "C" NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+			);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE character varying(255) COLLATE \"pg_catalog\".\"POSIX\" using \"foobar\"::character varying(255)",
@@ -397,19 +397,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify collation (non-default -> non-default)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -420,76 +420,76 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add Default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT ''
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT ''
+			);
+			`,
 		},
 	},
 	{
 		name: "Remove Default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT ''
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT ''
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
 		},
 	},
 	{
 		name: "Change Default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'Something else'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'Something else'
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT ''
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT ''
+			);
+			`,
 		},
 	},
 	{
 		name: "Set NOT NULL",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
 	},
@@ -497,20 +497,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (add invalid CC)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
@@ -525,21 +525,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (invalid CC already exists)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
@@ -552,21 +552,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (invalid to valid CC)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
@@ -577,20 +577,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (add valid CC)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
@@ -602,21 +602,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (valid CC already exists)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -626,20 +626,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (dropping valid CC)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -650,21 +650,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (dropping valid CC via recreation)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -677,19 +677,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (data type change with additional CC)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL CHECK (foobar > 0)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL CHECK (foobar > 0)
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -710,38 +710,38 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove NOT NULL",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
 		},
 	},
 	{
 		name: "Add default and change data type (new default is incompatible with old type)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'SOMETHING'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'SOMETHING'
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -752,19 +752,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change default and data type (new default is incompatible with old type)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT 0
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT 0
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'SOMETHING'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'SOMETHING'
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -775,19 +775,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change default and data type (old default is incompatible with new type)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT DEFAULT 'SOMETHING'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT DEFAULT 'SOMETHING'
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT 8
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT 8
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -799,57 +799,57 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change from NULL default to no default and NOT NULL",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
 		},
 	},
 	{
 		name: "Change from NOT NULL to no NULL default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT NULL
+			);
+			`,
 		},
 	},
 	{
 		name: "Change data type and to nullable",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SMALLINT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SMALLINT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -860,19 +860,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type and to not nullable",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SMALLINT NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SMALLINT NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -883,19 +883,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type, nullability (NOT NULL), and default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT DEFAULT 'some default'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT DEFAULT 'some default'
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar CHAR NOT NULL DEFAULT 'A'
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar CHAR NOT NULL DEFAULT 'A'
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -906,19 +906,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type and collation, nullability (NOT NULL), and default with quoted names",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foobar" TEXT DEFAULT 'some default'
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foobar" TEXT DEFAULT 'some default'
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -10,20 +10,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz BOOLEAN NOT NULL
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz BOOLEAN NOT NULL
 			);
 			`,
 		},
@@ -35,14 +35,14 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				my_new_column VARCHAR(255) DEFAULT 'a'
 			);
 			`,
@@ -53,14 +53,14 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"My_new_column" VARCHAR(255) DEFAULT 'a'
 			);
 			`,
@@ -71,14 +71,14 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				my_new_column VARCHAR(255) NOT NULL
 			);
 			`,
@@ -89,14 +89,14 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				my_new_column SERIAL NOT NULL
 			);
 			`,
@@ -107,14 +107,14 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
 			);
 			`,
@@ -125,7 +125,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -133,7 +133,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE TABLE foobar(
 				my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -150,7 +150,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -171,7 +171,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    "Id" INT PRIMARY KEY
+				"Id" INT PRIMARY KEY
 			);
 			`,
 		},
@@ -192,7 +192,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id BIGSERIAL PRIMARY KEY
+				id BIGSERIAL PRIMARY KEY
 			);
 			`,
 		},
@@ -213,7 +213,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
 			);
 			`,
@@ -221,7 +221,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -234,7 +234,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT NOT NULL
 			);
 			`,
@@ -242,7 +242,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar SERIAL NOT NULL
 			);
 			`,
@@ -253,7 +253,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar SERIAL NOT NULL
 			);
 			`,
@@ -261,7 +261,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT NOT NULL
 			);
 			`,
@@ -275,7 +275,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				some_time_col BIGINT
 			);
 			`,
@@ -283,7 +283,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				some_time_col TIMESTAMP 
 			);
 			`,
@@ -302,7 +302,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
 			);
 			`,
@@ -310,7 +310,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar TEXT DEFAULT 'some default' NOT NULL
 			);
 			`,
@@ -325,7 +325,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) COLLATE "C" NOT NULL
 			);
 			`,
@@ -333,7 +333,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar CHAR COLLATE "POSIX" NOT NULL
 			);
 			`,
@@ -348,7 +348,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar bytea NOT NULL
 			);
 			`,
@@ -356,7 +356,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar CHAR NOT NULL
 			);
 			`,
@@ -371,7 +371,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) COLLATE "C" NOT NULL
 			);
 			`,
@@ -379,7 +379,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
 			);
 			`,
@@ -398,7 +398,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			`,
@@ -406,7 +406,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
 			);
 			`,
@@ -421,7 +421,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			`,
@@ -429,7 +429,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) DEFAULT ''
 			);
 			`,
@@ -440,7 +440,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) DEFAULT ''
 			);
 			`,
@@ -448,7 +448,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			`,
@@ -459,7 +459,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) DEFAULT 'Something else'
 			);
 			`,
@@ -467,7 +467,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) DEFAULT ''
 			);
 			`,
@@ -478,7 +478,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			`,
@@ -486,7 +486,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			`,
@@ -498,7 +498,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			`,
@@ -506,7 +506,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
@@ -526,7 +526,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
@@ -535,7 +535,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
@@ -553,7 +553,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
@@ -562,7 +562,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
@@ -578,7 +578,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			`,
@@ -586,7 +586,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
@@ -603,7 +603,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
@@ -612,7 +612,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
@@ -627,7 +627,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
@@ -636,7 +636,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			`,
@@ -651,7 +651,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
@@ -660,7 +660,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
@@ -678,7 +678,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			`,
@@ -686,7 +686,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT NOT NULL CHECK (foobar > 0)
 			);
 			`,
@@ -711,7 +711,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) NOT NULL
 			);
 			`,
@@ -719,7 +719,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255)
 			);
 			`,
@@ -730,7 +730,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT
 			);
 			`,
@@ -738,7 +738,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) DEFAULT 'SOMETHING'
 			);
 			`,
@@ -753,7 +753,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT DEFAULT 0
 			);
 			`,
@@ -761,7 +761,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar VARCHAR(255) DEFAULT 'SOMETHING'
 			);
 			`,
@@ -776,7 +776,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar TEXT DEFAULT 'SOMETHING'
 			);
 			`,
@@ -784,7 +784,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT DEFAULT 8
 			);
 			`,
@@ -800,7 +800,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT DEFAULT NULL
 			);
 			`,
@@ -808,7 +808,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT NOT NULL
 			);
 			`,
@@ -819,7 +819,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT NOT NULL
 			);
 			`,
@@ -827,7 +827,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT DEFAULT NULL
 			);
 			`,
@@ -838,7 +838,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT NOT NULL
 			);
 			`,
@@ -846,7 +846,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar SMALLINT NULL
 			);
 			`,
@@ -861,7 +861,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar INT
 			);
 			`,
@@ -869,7 +869,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar SMALLINT NOT NULL
 			);
 			`,
@@ -884,7 +884,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar TEXT DEFAULT 'some default'
 			);
 			`,
@@ -892,7 +892,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar CHAR NOT NULL DEFAULT 'A'
 			);
 			`,
@@ -907,7 +907,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"Foobar" TEXT DEFAULT 'some default'
 			);
 			`,
@@ -915,7 +915,7 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
 			);
 			`,

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -1,932 +1,932 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var columnAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz BOOLEAN NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz BOOLEAN NOT NULL
-            );
-            `,
-        },
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz BOOLEAN NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz BOOLEAN NOT NULL
+			);
+			`,
+		},
 
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Add one column with default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column VARCHAR(255) DEFAULT 'a'
-            );
-            `,
-        },
-    },
-    {
-        name: "Add one column with quoted names",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "My_new_column" VARCHAR(255) DEFAULT 'a'
-            );
-            `,
-        },
-    },
-    {
-        name: "Add one column with nullability",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-    },
-    {
-        name: "Add one column with serial",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column SERIAL NOT NULL
-            );
-            `,
-        },
-    },
-    {
-        name: "Add one column with all options",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
-            );
-            `,
-        },
-    },
-    {
-        name: "Add one column and change ordering",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
-                id INT PRIMARY KEY
-            );
-            `,
-        },
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Add one column with default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column VARCHAR(255) DEFAULT 'a'
+			);
+			`,
+		},
+	},
+	{
+		name: "Add one column with quoted names",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"My_new_column" VARCHAR(255) DEFAULT 'a'
+			);
+			`,
+		},
+	},
+	{
+		name: "Add one column with nullability",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+	},
+	{
+		name: "Add one column with serial",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column SERIAL NOT NULL
+			);
+			`,
+		},
+	},
+	{
+		name: "Add one column with all options",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
+			);
+			`,
+		},
+	},
+	{
+		name: "Add one column and change ordering",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+				my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
 
-        expectedDBSchemaDDL: []string{`
-                    CREATE TABLE foobar(
-                        id INT PRIMARY KEY,
-                        my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
-                    )
-                `},
-    },
-    {
-        name: "Delete one column",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete one column with quoted name",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                "Id" INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete one column with serial",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id BIGSERIAL PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete column with valid not null check constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Modify data type (int -> serial)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SERIAL NOT NULL
-            );
-            `,
-        },
-    },
-    {
-        name: "Modify data type (serial -> int)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SERIAL NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                some_time_col BIGINT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                some_time_col TIMESTAMP 
-            );
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
-            "ANALYZE \"public\".\"Foobar\" (\"some_time_col\")",
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Modify data type (varchar -> TEXT) with compatible default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT DEFAULT 'some default' NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Modify data type and collation (varchar -> char)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "C" NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar CHAR COLLATE "POSIX" NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Modify data type to incompatible (bytea -> char)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar bytea NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar CHAR NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Modify collation (default -> non-default) (validate ANALYZE is run)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "C" NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-            );
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE character varying(255) COLLATE \"pg_catalog\".\"POSIX\" using \"foobar\"::character varying(255)",
-            "ANALYZE \"public\".\"foobar\" (\"foobar\")",
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Modify collation (non-default -> non-default)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Add Default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT ''
-            );
-            `,
-        },
-    },
-    {
-        name: "Remove Default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT ''
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
-        },
-    },
-    {
-        name: "Change Default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'Something else'
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT ''
-            );
-            `,
-        },
-    },
-    {
-        name: "Set NOT NULL",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
-    },
-    {
-        name: "Set NOT NULL (add invalid CC)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-        },
-    },
+		expectedDBSchemaDDL: []string{`
+					CREATE TABLE foobar(
+						id INT PRIMARY KEY,
+						my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
+					)
+				`},
+	},
+	{
+		name: "Delete one column",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete one column with quoted name",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    "Id" INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete one column with serial",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id BIGSERIAL PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete column with valid not null check constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Modify data type (int -> serial)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SERIAL NOT NULL
+			);
+			`,
+		},
+	},
+	{
+		name: "Modify data type (serial -> int)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SERIAL NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				some_time_col BIGINT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				some_time_col TIMESTAMP 
+			);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
+			"ANALYZE \"public\".\"Foobar\" (\"some_time_col\")",
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Modify data type (varchar -> TEXT) with compatible default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT DEFAULT 'some default' NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Modify data type and collation (varchar -> char)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "C" NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar CHAR COLLATE "POSIX" NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Modify data type to incompatible (bytea -> char)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar bytea NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar CHAR NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Modify collation (default -> non-default) (validate ANALYZE is run)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "C" NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+			);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE character varying(255) COLLATE \"pg_catalog\".\"POSIX\" using \"foobar\"::character varying(255)",
+			"ANALYZE \"public\".\"foobar\" (\"foobar\")",
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Modify collation (non-default -> non-default)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Add Default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT ''
+			);
+			`,
+		},
+	},
+	{
+		name: "Remove Default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT ''
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
+		},
+	},
+	{
+		name: "Change Default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'Something else'
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT ''
+			);
+			`,
+		},
+	},
+	{
+		name: "Set NOT NULL",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
+	},
+	{
+		name: "Set NOT NULL (add invalid CC)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+		},
+	},
 
-    {
-        name: "Set NOT NULL (invalid CC already exists)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-        },
-    },
-    {
-        name: "Set NOT NULL (invalid to valid CC)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-        },
-    },
-    {
-        name: "Set NOT NULL (add valid CC)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-        },
-    },
-    {
-        name: "Set NOT NULL (valid CC already exists)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-        },
-    },
-    {
-        name: "Set NOT NULL (dropping valid CC)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
-        },
-    },
-    {
-        name: "Set NOT NULL (dropping valid CC via recreation)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((length((foobar)::text) > 0)) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
-        },
-    },
-    {
-        name: "Set NOT NULL (data type change with additional CC)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL CHECK (foobar > 0)
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE integer using \"foobar\"::integer",
-            "ANALYZE \"public\".\"foobar\" (\"foobar\")",
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_foobar_check\" CHECK((foobar > 0)) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_foobar_check\"",
-            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-        },
-    },
-    {
-        name: "Remove NOT NULL",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255)
-            );
-            `,
-        },
-    },
-    {
-        name: "Add default and change data type (new default is incompatible with old type)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'SOMETHING'
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Change default and data type (new default is incompatible with old type)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT 0
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar VARCHAR(255) DEFAULT 'SOMETHING'
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Change default and data type (old default is incompatible with new type)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT DEFAULT 'SOMETHING'
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT 8
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-        expectedPlanErrorContains: errValidatingPlan.Error(),
-    },
-    {
-        name: "Change from NULL default to no default and NOT NULL",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
-        },
-    },
-    {
-        name: "Change from NOT NULL to no NULL default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT DEFAULT NULL
-            );
-            `,
-        },
-    },
-    {
-        name: "Change data type and to nullable",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SMALLINT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Change data type and to not nullable",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar SMALLINT NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Change data type, nullability (NOT NULL), and default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT DEFAULT 'some default'
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar CHAR NOT NULL DEFAULT 'A'
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Change data type and collation, nullability (NOT NULL), and default with quoted names",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foobar" TEXT DEFAULT 'some default'
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
+	{
+		name: "Set NOT NULL (invalid CC already exists)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+		},
+	},
+	{
+		name: "Set NOT NULL (invalid to valid CC)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+		},
+	},
+	{
+		name: "Set NOT NULL (add valid CC)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+		},
+	},
+	{
+		name: "Set NOT NULL (valid CC already exists)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+		},
+	},
+	{
+		name: "Set NOT NULL (dropping valid CC)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
+		},
+	},
+	{
+		name: "Set NOT NULL (dropping valid CC via recreation)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"foobar\"",
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((length((foobar)::text) > 0)) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
+		},
+	},
+	{
+		name: "Set NOT NULL (data type change with additional CC)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL CHECK (foobar > 0)
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE integer using \"foobar\"::integer",
+			"ANALYZE \"public\".\"foobar\" (\"foobar\")",
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar_foobar_check\" CHECK((foobar > 0)) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar_foobar_check\"",
+			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+		},
+	},
+	{
+		name: "Remove NOT NULL",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255)
+			);
+			`,
+		},
+	},
+	{
+		name: "Add default and change data type (new default is incompatible with old type)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'SOMETHING'
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Change default and data type (new default is incompatible with old type)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT 0
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar VARCHAR(255) DEFAULT 'SOMETHING'
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Change default and data type (old default is incompatible with new type)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT DEFAULT 'SOMETHING'
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT 8
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+		expectedPlanErrorContains: errValidatingPlan.Error(),
+	},
+	{
+		name: "Change from NULL default to no default and NOT NULL",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
+		},
+	},
+	{
+		name: "Change from NOT NULL to no NULL default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT DEFAULT NULL
+			);
+			`,
+		},
+	},
+	{
+		name: "Change data type and to nullable",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SMALLINT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Change data type and to not nullable",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar SMALLINT NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Change data type, nullability (NOT NULL), and default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT DEFAULT 'some default'
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar CHAR NOT NULL DEFAULT 'A'
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Change data type and collation, nullability (NOT NULL), and default with quoted names",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foobar" TEXT DEFAULT 'some default'
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestColumnTestCases() {
-    suite.runTestCases(columnAcceptanceTestCases)
+	suite.runTestCases(columnAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -9,23 +9,23 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL
+            );
+            `,
 		},
 
 		expectEmptyPlan: true,
@@ -34,131 +34,131 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column with default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) DEFAULT 'a'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) DEFAULT 'a'
+            );
+            `,
 		},
 	},
 	{
 		name: "Add one column with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"My_new_column" VARCHAR(255) DEFAULT 'a'
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "My_new_column" VARCHAR(255) DEFAULT 'a'
+            );
+            `,
 		},
 	},
 	{
 		name: "Add one column with nullability",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 	},
 	{
 		name: "Add one column with serial",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column SERIAL NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column SERIAL NOT NULL
+            );
+            `,
 		},
 	},
 	{
 		name: "Add one column with all options",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
+            );
+            `,
 		},
 	},
 	{
 		name: "Add one column and change ordering",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 
 		expectedDBSchemaDDL: []string{`
-					CREATE TABLE foobar(
-						id INT PRIMARY KEY,
-						my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
-					)
-				`},
+                    CREATE TABLE foobar(
+                        id INT PRIMARY KEY,
+                        my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
+                    )
+                `},
 	},
 	{
 		name: "Delete one column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			);
-			`,
+            CREATE TABLE foobar(
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -170,16 +170,16 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete one column with quoted name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                "Id" INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			);
-			`,
+            CREATE TABLE "Foobar"(
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -191,16 +191,16 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete one column with serial",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id BIGSERIAL PRIMARY KEY
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id BIGSERIAL PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			);
-			`,
+            CREATE TABLE "Foobar"(
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -212,18 +212,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete column with valid not null check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -233,38 +233,38 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type (int -> serial)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SERIAL NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SERIAL NOT NULL
+            );
+            `,
 		},
 	},
 	{
 		name: "Modify data type (serial -> int)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SERIAL NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SERIAL NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -274,19 +274,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				some_time_col BIGINT
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col BIGINT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				some_time_col TIMESTAMP 
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col TIMESTAMP 
+            );
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
@@ -301,19 +301,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type (varchar -> TEXT) with compatible default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'some default' NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'some default' NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -324,19 +324,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type and collation (varchar -> char)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "C" NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "C" NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar CHAR COLLATE "POSIX" NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR COLLATE "POSIX" NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -347,19 +347,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type to incompatible (bytea -> char)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar bytea NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar bytea NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar CHAR NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -370,19 +370,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify collation (default -> non-default) (validate ANALYZE is run)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "C" NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "C" NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+            );
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET DATA TYPE character varying(255) COLLATE \"pg_catalog\".\"POSIX\" using \"foobar\"::character varying(255)",
@@ -397,19 +397,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify collation (non-default -> non-default)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -420,76 +420,76 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add Default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
+            `,
 		},
 	},
 	{
 		name: "Remove Default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
 		},
 	},
 	{
 		name: "Change Default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'Something else'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'Something else'
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
+            `,
 		},
 	},
 	{
 		name: "Set NOT NULL",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
 	},
@@ -497,20 +497,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (add invalid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
@@ -525,21 +525,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (invalid CC already exists)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID",
@@ -552,21 +552,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (invalid to valid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"foobar\"",
@@ -577,20 +577,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (add valid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"foobar\" CHECK((foobar IS NOT NULL)) NOT VALID",
@@ -602,21 +602,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (valid CC already exists)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -626,20 +626,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (dropping valid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -650,21 +650,21 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (dropping valid CC via recreation)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL",
@@ -677,19 +677,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (data type change with additional CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL CHECK (foobar > 0)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL CHECK (foobar > 0)
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -710,38 +710,38 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove NOT NULL",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            `,
 		},
 	},
 	{
 		name: "Add default and change data type (new default is incompatible with old type)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'SOMETHING'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'SOMETHING'
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -752,19 +752,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change default and data type (new default is incompatible with old type)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT 0
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT 0
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'SOMETHING'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'SOMETHING'
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -775,19 +775,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change default and data type (old default is incompatible with new type)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'SOMETHING'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'SOMETHING'
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT 8
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT 8
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -799,57 +799,57 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change from NULL default to no default and NOT NULL",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
 		},
 	},
 	{
 		name: "Change from NOT NULL to no NULL default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT DEFAULT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT NULL
+            );
+            `,
 		},
 	},
 	{
 		name: "Change data type and to nullable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SMALLINT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SMALLINT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -860,19 +860,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type and to not nullable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar SMALLINT NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SMALLINT NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -883,19 +883,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type, nullability (NOT NULL), and default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'some default'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'some default'
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar CHAR NOT NULL DEFAULT 'A'
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR NOT NULL DEFAULT 'A'
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -906,19 +906,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type and collation, nullability (NOT NULL), and default with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foobar" TEXT DEFAULT 'some default'
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foobar" TEXT DEFAULT 'some default'
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -9,22 +9,22 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz BOOLEAN NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz BOOLEAN NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL
+            );
 			`,
 		},
 
@@ -34,17 +34,17 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column with default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) DEFAULT 'a'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) DEFAULT 'a'
+            );
 			`,
 		},
 	},
@@ -52,17 +52,17 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"My_new_column" VARCHAR(255) DEFAULT 'a'
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "My_new_column" VARCHAR(255) DEFAULT 'a'
+            );
 			`,
 		},
 	},
@@ -70,17 +70,17 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column with nullability",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 	},
@@ -88,17 +88,17 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column with serial",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				my_new_column SERIAL NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column SERIAL NOT NULL
+            );
 			`,
 		},
 	},
@@ -106,17 +106,17 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column with all options",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                my_new_column VARCHAR(255) COLLATE "C" NOT NULL DEFAULT 'a'
+            );
 			`,
 		},
 	},
@@ -124,40 +124,40 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add one column and change ordering",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                my_new_column VARCHAR(255) NOT NULL DEFAULT 'a',
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-					CREATE TABLE foobar(
-						id INT PRIMARY KEY,
-						my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
-					)
+                    CREATE TABLE foobar(
+                        id INT PRIMARY KEY,
+                        my_new_column VARCHAR(255) NOT NULL DEFAULT 'a'
+                    )
 				`},
 	},
 	{
 		name: "Delete one column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			);
+            CREATE TABLE foobar(
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -170,15 +170,15 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete one column with quoted name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				"Id" INT PRIMARY KEY
-			);
+            CREATE TABLE "Foobar"(
+                "Id" INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			);
+            CREATE TABLE "Foobar"(
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -191,15 +191,15 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete one column with serial",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id BIGSERIAL PRIMARY KEY
-			);
+            CREATE TABLE "Foobar"(
+                id BIGSERIAL PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			);
+            CREATE TABLE "Foobar"(
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -212,17 +212,17 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete column with valid not null check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL CHECK ( foo IS NOT NULL )
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -233,18 +233,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type (int -> serial)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar SERIAL NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SERIAL NOT NULL
+            );
 			`,
 		},
 	},
@@ -252,18 +252,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type (serial -> int)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar SERIAL NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SERIAL NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -274,18 +274,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				some_time_col BIGINT
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col BIGINT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				some_time_col TIMESTAMP 
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col TIMESTAMP 
+            );
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -301,18 +301,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type (varchar -> TEXT) with compatible default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'some default' NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'some default' NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'some default' NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -324,18 +324,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type and collation (varchar -> char)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "C" NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "C" NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar CHAR COLLATE "POSIX" NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR COLLATE "POSIX" NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -347,18 +347,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify data type to incompatible (bytea -> char)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar bytea NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar bytea NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar CHAR NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -370,18 +370,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify collation (default -> non-default) (validate ANALYZE is run)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "C" NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "C" NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+            );
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -397,18 +397,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Modify collation (non-default -> non-default)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) COLLATE "POSIX" NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -420,18 +420,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add Default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
 			`,
 		},
 	},
@@ -439,18 +439,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove Default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
 			`,
 		},
 	},
@@ -458,18 +458,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change Default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'Something else'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'Something else'
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT ''
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT ''
+            );
 			`,
 		},
 	},
@@ -477,18 +477,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		expectedPlanDDL: []string{"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"foobar\" IS NOT NULL) NOT VALID", "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"", "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foobar\" SET NOT NULL", "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\""},
@@ -497,19 +497,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (add invalid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -525,20 +525,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (invalid CC already exists)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -552,20 +552,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (invalid to valid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL) NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -577,19 +577,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (add valid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -602,20 +602,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (valid CC already exists)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -626,19 +626,19 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (dropping valid CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -650,20 +650,20 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (dropping valid CC via recreation)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (foobar IS NOT NULL);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
-			ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar CHECK (LENGTH(foobar) > 0);
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -677,18 +677,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Set NOT NULL (data type change with additional CC)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT NOT NULL CHECK (foobar > 0)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL CHECK (foobar > 0)
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -710,18 +710,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove NOT NULL",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255)
+            );
 			`,
 		},
 	},
@@ -729,18 +729,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add default and change data type (new default is incompatible with old type)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'SOMETHING'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'SOMETHING'
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -752,18 +752,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change default and data type (new default is incompatible with old type)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT DEFAULT 0
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT 0
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar VARCHAR(255) DEFAULT 'SOMETHING'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar VARCHAR(255) DEFAULT 'SOMETHING'
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -775,18 +775,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change default and data type (old default is incompatible with new type)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'SOMETHING'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'SOMETHING'
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT DEFAULT 8
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT 8
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -799,18 +799,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change from NULL default to no default and NOT NULL",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT DEFAULT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
 			`,
 		},
 	},
@@ -818,18 +818,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change from NOT NULL to no NULL default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT DEFAULT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT DEFAULT NULL
+            );
 			`,
 		},
 	},
@@ -837,18 +837,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type and to nullable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar SMALLINT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SMALLINT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -860,18 +860,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type and to not nullable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar INT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar SMALLINT NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar SMALLINT NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -883,18 +883,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type, nullability (NOT NULL), and default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar TEXT DEFAULT 'some default'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT DEFAULT 'some default'
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar CHAR NOT NULL DEFAULT 'A'
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar CHAR NOT NULL DEFAULT 'A'
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -906,18 +906,18 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change data type and collation, nullability (NOT NULL), and default with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"Foobar" TEXT DEFAULT 'some default'
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foobar" TEXT DEFAULT 'some default'
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foobar" CHAR COLLATE "POSIX" NOT NULL DEFAULT 'A'
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -8,54 +8,54 @@ var dataPackingCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
 			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
 			`,
 		},
 	},
@@ -64,70 +64,70 @@ var dataPackingCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-				foo NOT NULL,
-				bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-				foo NOT NULL,
-				bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 				`,
 		},
 	},

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -8,55 +8,55 @@ var dataPackingCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
 		},
 
 		expectedDBSchemaDDL: []string{`
-			CREATE TABLE foobar(
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
 		},
 	},
 	{
@@ -64,71 +64,71 @@ var dataPackingCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-			`,
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            `,
 		},
 
 		expectedDBSchemaDDL: []string{`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-				`,
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+                `,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -9,10 +9,10 @@ var dataPackingCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL UNIQUE,
 				buzz REAL CHECK (buzz IS NOT NULL)
 			);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
@@ -23,8 +23,8 @@ var dataPackingCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -35,9 +35,9 @@ var dataPackingCases = []acceptanceTestCase{
 
 		expectedDBSchemaDDL: []string{`
 			CREATE TABLE foobar(
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-			    fizz SERIAL NOT NULL UNIQUE,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				fizz SERIAL NOT NULL UNIQUE,
 				buzz REAL CHECK (buzz IS NOT NULL),
 				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
 			);
@@ -49,8 +49,8 @@ var dataPackingCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -66,13 +66,13 @@ var dataPackingCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
 				fizz SERIAL,
 				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 			
@@ -82,8 +82,8 @@ var dataPackingCases = []acceptanceTestCase{
 			-- partitions
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
+				foo NOT NULL,
+				bar NOT NULL
 			) FOR VALUES IN ('foo_1');
 			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
@@ -100,13 +100,13 @@ var dataPackingCases = []acceptanceTestCase{
 		expectedDBSchemaDDL: []string{`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT,
+				id INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
 				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
@@ -116,8 +116,8 @@ var dataPackingCases = []acceptanceTestCase{
 			-- partitions
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
+				foo NOT NULL,
+				bar NOT NULL
 			) FOR VALUES IN ('foo_1');
 			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -3,141 +3,141 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var dataPackingCases = []acceptanceTestCase{
-    {
-        name:         "Create table",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+	{
+		name:         "Create table",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
-        },
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
+		},
 
-        expectedDBSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+		expectedDBSchemaDDL: []string{`
+			CREATE TABLE foobar(
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
-        },
-    },
-    {
-        name:         "Create partitioned table with shared primary key and RLS enabled globally",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-            
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
+		},
+	},
+	{
+		name:         "Create partitioned table with shared primary key and RLS enabled globally",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-            `,
-        },
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+			`,
+		},
 
-        expectedDBSchemaDDL: []string{`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+		expectedDBSchemaDDL: []string{`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-                `,
-        },
-    },
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+				`,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestDataPackingTestCases() {
-    var tcs []acceptanceTestCase
-    for _, tc := range dataPackingCases {
-        tc.planOpts = append(tc.planOpts, diff.WithDataPackNewTables())
-        tcs = append(tcs, tc)
-    }
-    suite.runTestCases(tcs)
+	var tcs []acceptanceTestCase
+	for _, tc := range dataPackingCases {
+		tc.planOpts = append(tc.planOpts, diff.WithDataPackNewTables())
+		tcs = append(tcs, tc)
+	}
+	suite.runTestCases(tcs)
 }

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -3,141 +3,141 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var dataPackingCases = []acceptanceTestCase{
-	{
-		name:         "Create table",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+    {
+        name:         "Create table",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
-		},
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
+        },
 
-		expectedDBSchemaDDL: []string{`
-			CREATE TABLE foobar(
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+        expectedDBSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
-		},
-	},
-	{
-		name:         "Create partitioned table with shared primary key and RLS enabled globally",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
+        },
+    },
+    {
+        name:         "Create partitioned table with shared primary key and RLS enabled globally",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-			`,
-		},
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            `,
+        },
 
-		expectedDBSchemaDDL: []string{`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+        expectedDBSchemaDDL: []string{`
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-				`,
-		},
-	},
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+                `,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestDataPackingTestCases() {
-	var tcs []acceptanceTestCase
-	for _, tc := range dataPackingCases {
-		tc.planOpts = append(tc.planOpts, diff.WithDataPackNewTables())
-		tcs = append(tcs, tc)
-	}
-	suite.runTestCases(tcs)
+    var tcs []acceptanceTestCase
+    for _, tc := range dataPackingCases {
+        tc.planOpts = append(tc.planOpts, diff.WithDataPackNewTables())
+        tcs = append(tcs, tc)
+    }
+    suite.runTestCases(tcs)
 }

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -8,55 +8,55 @@ var dataPackingCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
 		},
 	},
 	{
@@ -64,71 +64,71 @@ var dataPackingCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-            
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-            `,
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-                `,
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+				`,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/database_schema_source_cases_test.go
+++ b/internal/migration_acceptance_tests/database_schema_source_cases_test.go
@@ -43,78 +43,78 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
-		
-			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE fizz();
+        
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			`,
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
+            CREATE TABLE fizz();
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				bar TIMESTAMPTZ NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                bar TIMESTAMPTZ NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-			
-			`,
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,

--- a/internal/migration_acceptance_tests/database_schema_source_cases_test.go
+++ b/internal/migration_acceptance_tests/database_schema_source_cases_test.go
@@ -46,16 +46,16 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 			CREATE TABLE fizz();
 		
 			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
+				id INT,
+				bar SERIAL NOT NULL,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 
 			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
+				fizz NOT NULL
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- partitioned indexes
@@ -65,12 +65,12 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
 			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
 			);
 			CREATE INDEX bar_normal_idx ON bar(bar);
 			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
@@ -85,15 +85,15 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
 				bar TIMESTAMPTZ NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				id INT,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    UNIQUE (foo, bar)
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 
 			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
+				fizz NOT NULL,
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- local indexes
@@ -103,11 +103,11 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
 			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
 			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
 			);
 			CREATE INDEX bar_normal_idx ON bar(bar);

--- a/internal/migration_acceptance_tests/database_schema_source_cases_test.go
+++ b/internal/migration_acceptance_tests/database_schema_source_cases_test.go
@@ -1,130 +1,130 @@
 package migration_acceptance_tests
 
 import (
-    "context"
-    "fmt"
+	"context"
+	"fmt"
 
-    "github.com/stripe/pg-schema-diff/pkg/diff"
-    "github.com/stripe/pg-schema-diff/pkg/sqldb"
-    "github.com/stripe/pg-schema-diff/pkg/tempdb"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/sqldb"
+	"github.com/stripe/pg-schema-diff/pkg/tempdb"
 )
 
 func databaseSchemaSourcePlanFactory(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (_ diff.Plan, retErr error) {
-    newSchemaDb, err := tempDbFactory.Create(ctx)
-    if err != nil {
-        return diff.Plan{}, fmt.Errorf("creating temp database: %w", err)
-    }
+	newSchemaDb, err := tempDbFactory.Create(ctx)
+	if err != nil {
+		return diff.Plan{}, fmt.Errorf("creating temp database: %w", err)
+	}
 
-    defer func() {
-        tempDbErr := newSchemaDb.Close(ctx)
-        if retErr == nil {
-            retErr = tempDbErr
-        }
-    }()
+	defer func() {
+		tempDbErr := newSchemaDb.Close(ctx)
+		if retErr == nil {
+			retErr = tempDbErr
+		}
+	}()
 
-    for _, stmt := range newSchemaDDL {
-        if _, err := newSchemaDb.ConnPool.ExecContext(ctx, stmt); err != nil {
-            return diff.Plan{}, fmt.Errorf("running DDL: %w", err)
-        }
-    }
+	for _, stmt := range newSchemaDDL {
+		if _, err := newSchemaDb.ConnPool.ExecContext(ctx, stmt); err != nil {
+			return diff.Plan{}, fmt.Errorf("running DDL: %w", err)
+		}
+	}
 
-    // Clone the opts so we don't modify the original.
-    opts = append([]diff.PlanOpt(nil), opts...)
-    opts = append(opts, diff.WithTempDbFactory(tempDbFactory))
-    for _, o := range newSchemaDb.ExcludeMetadataOptions {
-        opts = append(opts, diff.WithGetSchemaOpts(o))
-    }
+	// Clone the opts so we don't modify the original.
+	opts = append([]diff.PlanOpt(nil), opts...)
+	opts = append(opts, diff.WithTempDbFactory(tempDbFactory))
+	for _, o := range newSchemaDb.ExcludeMetadataOptions {
+		opts = append(opts, diff.WithGetSchemaOpts(o))
+	}
 
-    return diff.Generate(ctx, connPool, diff.DBSchemaSource(newSchemaDb.ConnPool), opts...)
+	return diff.Generate(ctx, connPool, diff.DBSchemaSource(newSchemaDb.ConnPool), opts...)
 }
 
 var databaseSchemaSourceTestCases = []acceptanceTestCase{
-    {
-        name: "Drop partitioned table, Add partitioned table with local keys",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE fizz();
-        
-            CREATE TABLE foobar(
-                id INT,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+	{
+		name: "Drop partitioned table, Add partitioned table with local keys",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE fizz();
+		
+			CREATE TABLE foobar(
+			    id INT,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE fizz();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE fizz();
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                bar TIMESTAMPTZ NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				bar TIMESTAMPTZ NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-            
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-        },
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+		},
 
-        planFactory: databaseSchemaSourcePlanFactory,
-    },
+		planFactory: databaseSchemaSourcePlanFactory,
+	},
 }
 
 func (suite *acceptanceTestSuite) TestDatabaseSchemaSourceTestCases() {
-    suite.runTestCases(databaseSchemaSourceTestCases)
+	suite.runTestCases(databaseSchemaSourceTestCases)
 }

--- a/internal/migration_acceptance_tests/database_schema_source_cases_test.go
+++ b/internal/migration_acceptance_tests/database_schema_source_cases_test.go
@@ -43,78 +43,78 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE fizz();
-        
-            CREATE TABLE foobar(
-                id INT,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE fizz();
+		
+			CREATE TABLE foobar(
+			    id INT,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            `,
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE fizz();
+			CREATE TABLE fizz();
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                bar TIMESTAMPTZ NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				bar TIMESTAMPTZ NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-            
-            `,
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,

--- a/internal/migration_acceptance_tests/database_schema_source_cases_test.go
+++ b/internal/migration_acceptance_tests/database_schema_source_cases_test.go
@@ -43,77 +43,77 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
-		
-			CREATE TABLE foobar(
-				id INT,
-				bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE fizz();
+        
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-				fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
+            CREATE TABLE fizz();
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				bar TIMESTAMPTZ NOT NULL,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                bar TIMESTAMPTZ NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-				fizz NOT NULL,
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-			CREATE table bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-			
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/database_schema_source_cases_test.go
+++ b/internal/migration_acceptance_tests/database_schema_source_cases_test.go
@@ -1,130 +1,130 @@
 package migration_acceptance_tests
 
 import (
-	"context"
-	"fmt"
+    "context"
+    "fmt"
 
-	"github.com/stripe/pg-schema-diff/pkg/diff"
-	"github.com/stripe/pg-schema-diff/pkg/sqldb"
-	"github.com/stripe/pg-schema-diff/pkg/tempdb"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/sqldb"
+    "github.com/stripe/pg-schema-diff/pkg/tempdb"
 )
 
 func databaseSchemaSourcePlanFactory(ctx context.Context, connPool sqldb.Queryable, tempDbFactory tempdb.Factory, newSchemaDDL []string, opts ...diff.PlanOpt) (_ diff.Plan, retErr error) {
-	newSchemaDb, err := tempDbFactory.Create(ctx)
-	if err != nil {
-		return diff.Plan{}, fmt.Errorf("creating temp database: %w", err)
-	}
+    newSchemaDb, err := tempDbFactory.Create(ctx)
+    if err != nil {
+        return diff.Plan{}, fmt.Errorf("creating temp database: %w", err)
+    }
 
-	defer func() {
-		tempDbErr := newSchemaDb.Close(ctx)
-		if retErr == nil {
-			retErr = tempDbErr
-		}
-	}()
+    defer func() {
+        tempDbErr := newSchemaDb.Close(ctx)
+        if retErr == nil {
+            retErr = tempDbErr
+        }
+    }()
 
-	for _, stmt := range newSchemaDDL {
-		if _, err := newSchemaDb.ConnPool.ExecContext(ctx, stmt); err != nil {
-			return diff.Plan{}, fmt.Errorf("running DDL: %w", err)
-		}
-	}
+    for _, stmt := range newSchemaDDL {
+        if _, err := newSchemaDb.ConnPool.ExecContext(ctx, stmt); err != nil {
+            return diff.Plan{}, fmt.Errorf("running DDL: %w", err)
+        }
+    }
 
-	// Clone the opts so we don't modify the original.
-	opts = append([]diff.PlanOpt(nil), opts...)
-	opts = append(opts, diff.WithTempDbFactory(tempDbFactory))
-	for _, o := range newSchemaDb.ExcludeMetadataOptions {
-		opts = append(opts, diff.WithGetSchemaOpts(o))
-	}
+    // Clone the opts so we don't modify the original.
+    opts = append([]diff.PlanOpt(nil), opts...)
+    opts = append(opts, diff.WithTempDbFactory(tempDbFactory))
+    for _, o := range newSchemaDb.ExcludeMetadataOptions {
+        opts = append(opts, diff.WithGetSchemaOpts(o))
+    }
 
-	return diff.Generate(ctx, connPool, diff.DBSchemaSource(newSchemaDb.ConnPool), opts...)
+    return diff.Generate(ctx, connPool, diff.DBSchemaSource(newSchemaDb.ConnPool), opts...)
 }
 
 var databaseSchemaSourceTestCases = []acceptanceTestCase{
-	{
-		name: "Drop partitioned table, Add partitioned table with local keys",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE fizz();
-		
-			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+    {
+        name: "Drop partitioned table, Add partitioned table with local keys",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE fizz();
+        
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE fizz();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE fizz();
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				bar TIMESTAMPTZ NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                bar TIMESTAMPTZ NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-			
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-		},
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+        },
 
-		planFactory: databaseSchemaSourcePlanFactory,
-	},
+        planFactory: databaseSchemaSourcePlanFactory,
+    },
 }
 
 func (suite *acceptanceTestSuite) TestDatabaseSchemaSourceTestCases() {
-	suite.runTestCases(databaseSchemaSourceTestCases)
+    suite.runTestCases(databaseSchemaSourceTestCases)
 }

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -3,119 +3,119 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var enumAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "no-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color color DEFAULT 'green'
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color color DEFAULT 'green'
-            );
-            `,
-        },
+	{
+		name: "no-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color color DEFAULT 'green'
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color color DEFAULT 'green'
+			);
+			`,
+		},
 
-        expectEmptyPlan: true,
-    },
-    {
-        name: "create enum",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foo();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color schema_1.color DEFAULT 'green'
-            );
-            `,
-        },
-    },
-    {
-        name: "drop enum",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color schema_1.color DEFAULT 'green'
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE foo(
-                color VARCHAR(255) DEFAULT 'green'
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "add values",
-        oldSchemaDDL: []string{
-            `
-            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-            CREATE TABLE foo(
-                val some_enum_1
-            );
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
-            CREATE TABLE foo(
-                val some_enum_1 DEFAULT '1.5'
-            );
-        `},
-    },
-    {
-        name: "delete value and add value (enum not used)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-        `},
-    },
-    {
-        name: "delete value and add value (enum used)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-            CREATE TABLE foo(
-                val some_enum_1
-            );
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-            CREATE TABLE foo(
-                val some_enum_1
-            );
-        `},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "create enum",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foo();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color schema_1.color DEFAULT 'green'
+			);
+			`,
+		},
+	},
+	{
+		name: "drop enum",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color schema_1.color DEFAULT 'green'
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE foo(
+			    color VARCHAR(255) DEFAULT 'green'
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "add values",
+		oldSchemaDDL: []string{
+			`
+			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+			CREATE TABLE foo(
+				val some_enum_1
+			);
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
+			CREATE TABLE foo(
+				val some_enum_1 DEFAULT '1.5'
+			);
+		`},
+	},
+	{
+		name: "delete value and add value (enum not used)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+		`},
+	},
+	{
+		name: "delete value and add value (enum used)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+			CREATE TABLE foo(
+				val some_enum_1
+			);
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+			CREATE TABLE foo(
+				val some_enum_1
+			);
+		`},
 
-        // Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
-        // as a validation error. In the future, we can identify this in the actual plan generation stage.
-        expectedPlanErrorContains: errValidatingPlan.Error(),
-    },
+		// Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
+		// as a validation error. In the future, we can identify this in the actual plan generation stage.
+		expectedPlanErrorContains: errValidatingPlan.Error(),
+	},
 }
 
 func (suite *acceptanceTestSuite) TestEnumTestCases() {
-    suite.runTestCases(enumAcceptanceTestCases)
+	suite.runTestCases(enumAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -7,18 +7,18 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "no-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color color DEFAULT 'green'
-			);
+            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color color DEFAULT 'green'
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color color DEFAULT 'green'
-			);
+            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color color DEFAULT 'green'
+            );
 			`,
 		},
 
@@ -28,16 +28,16 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "create enum",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foo();
+            CREATE TABLE foo();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color schema_1.color DEFAULT 'green'
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color schema_1.color DEFAULT 'green'
+            );
 			`,
 		},
 	},
@@ -45,19 +45,19 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "drop enum",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color schema_1.color DEFAULT 'green'
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color schema_1.color DEFAULT 'green'
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE foo(
-				color VARCHAR(255) DEFAULT 'green'
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE foo(
+                color VARCHAR(255) DEFAULT 'green'
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -69,45 +69,45 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "add values",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
-			CREATE TABLE foo(
-				val some_enum_1 DEFAULT '1.5'
-			);
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
+            CREATE TABLE foo(
+                val some_enum_1 DEFAULT '1.5'
+            );
 		`},
 	},
 	{
 		name: "delete value and add value (enum not used)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
 		`},
 	},
 	{
 		name: "delete value and add value (enum used)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
 		`},
 
 		// Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -7,19 +7,19 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "no-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color color DEFAULT 'green'
-			);
-			`,
+            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color color DEFAULT 'green'
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color color DEFAULT 'green'
-			);
-			`,
+            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color color DEFAULT 'green'
+            );
+            `,
 		},
 
 		expectEmptyPlan: true,
@@ -28,37 +28,37 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "create enum",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foo();
-			`,
+            CREATE TABLE foo();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color schema_1.color DEFAULT 'green'
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color schema_1.color DEFAULT 'green'
+            );
+            `,
 		},
 	},
 	{
 		name: "drop enum",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color schema_1.color DEFAULT 'green'
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color schema_1.color DEFAULT 'green'
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE foo(
-			    color VARCHAR(255) DEFAULT 'green'
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE foo(
+                color VARCHAR(255) DEFAULT 'green'
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -69,46 +69,46 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "add values",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
-		`},
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
-			CREATE TABLE foo(
-				val some_enum_1 DEFAULT '1.5'
-			);
-		`},
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
+            CREATE TABLE foo(
+                val some_enum_1 DEFAULT '1.5'
+            );
+        `},
 	},
 	{
 		name: "delete value and add value (enum not used)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-		`},
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-		`},
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+        `},
 	},
 	{
 		name: "delete value and add value (enum used)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
-		`},
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
-		`},
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
+        `},
 
 		// Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
 		// as a validation error. In the future, we can identify this in the actual plan generation stage.

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -7,19 +7,19 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "no-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color color DEFAULT 'green'
-            );
-            `,
+			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color color DEFAULT 'green'
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color color DEFAULT 'green'
-            );
-            `,
+			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color color DEFAULT 'green'
+			);
+			`,
 		},
 
 		expectEmptyPlan: true,
@@ -28,37 +28,37 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "create enum",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foo();
-            `,
+			CREATE TABLE foo();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color schema_1.color DEFAULT 'green'
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color schema_1.color DEFAULT 'green'
+			);
+			`,
 		},
 	},
 	{
 		name: "drop enum",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-            CREATE TABLE foo(
-                color schema_1.color DEFAULT 'green'
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TABLE foo(
+				color schema_1.color DEFAULT 'green'
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE foo(
-                color VARCHAR(255) DEFAULT 'green'
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE foo(
+			    color VARCHAR(255) DEFAULT 'green'
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -69,46 +69,46 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 		name: "add values",
 		oldSchemaDDL: []string{
 			`
-            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-            CREATE TABLE foo(
-                val some_enum_1
-            );
-        `},
+			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+			CREATE TABLE foo(
+				val some_enum_1
+			);
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
-            CREATE TABLE foo(
-                val some_enum_1 DEFAULT '1.5'
-            );
-        `},
+			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
+			CREATE TABLE foo(
+				val some_enum_1 DEFAULT '1.5'
+			);
+		`},
 	},
 	{
 		name: "delete value and add value (enum not used)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-        `},
+			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-        `},
+			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+		`},
 	},
 	{
 		name: "delete value and add value (enum used)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-            CREATE TABLE foo(
-                val some_enum_1
-            );
-        `},
+			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+			CREATE TABLE foo(
+				val some_enum_1
+			);
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-            CREATE TABLE foo(
-                val some_enum_1
-            );
-        `},
+			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+			CREATE TABLE foo(
+				val some_enum_1
+			);
+		`},
 
 		// Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
 		// as a validation error. In the future, we can identify this in the actual plan generation stage.

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -56,7 +56,7 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE foo(
-			    color VARCHAR(255) DEFAULT 'green'
+				color VARCHAR(255) DEFAULT 'green'
 			);
 			`,
 		},

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -3,119 +3,119 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var enumAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "no-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color color DEFAULT 'green'
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TYPE color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color color DEFAULT 'green'
-			);
-			`,
-		},
+    {
+        name: "no-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color color DEFAULT 'green'
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color color DEFAULT 'green'
+            );
+            `,
+        },
 
-		expectEmptyPlan: true,
-	},
-	{
-		name: "create enum",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foo();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color schema_1.color DEFAULT 'green'
-			);
-			`,
-		},
-	},
-	{
-		name: "drop enum",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
-			CREATE TABLE foo(
-				color schema_1.color DEFAULT 'green'
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE foo(
-			    color VARCHAR(255) DEFAULT 'green'
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "add values",
-		oldSchemaDDL: []string{
-			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
-			CREATE TABLE foo(
-				val some_enum_1 DEFAULT '1.5'
-			);
-		`},
-	},
-	{
-		name: "delete value and add value (enum not used)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-		`},
-	},
-	{
-		name: "delete value and add value (enum used)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
-			CREATE TABLE foo(
-				val some_enum_1
-			);
-		`},
+        expectEmptyPlan: true,
+    },
+    {
+        name: "create enum",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foo();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color schema_1.color DEFAULT 'green'
+            );
+            `,
+        },
+    },
+    {
+        name: "drop enum",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TABLE foo(
+                color schema_1.color DEFAULT 'green'
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE foo(
+                color VARCHAR(255) DEFAULT 'green'
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "add values",
+        oldSchemaDDL: []string{
+            `
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '1.5', '2', '2.5', '3', '4');
+            CREATE TABLE foo(
+                val some_enum_1 DEFAULT '1.5'
+            );
+        `},
+    },
+    {
+        name: "delete value and add value (enum not used)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+        `},
+    },
+    {
+        name: "delete value and add value (enum used)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TYPE some_enum_1 AS ENUM ('1', '2', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE TYPE some_enum_1 AS ENUM ('0', '1', '3');
+            CREATE TABLE foo(
+                val some_enum_1
+            );
+        `},
 
-		// Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
-		// as a validation error. In the future, we can identify this in the actual plan generation stage.
-		expectedPlanErrorContains: errValidatingPlan.Error(),
-	},
+        // Removing a value from an enum in-use is impossible in Postgres. pg-schema-diff will currently identify this
+        // as a validation error. In the future, we can identify this in the actual plan generation stage.
+        expectedPlanErrorContains: errValidatingPlan.Error(),
+    },
 }
 
 func (suite *acceptanceTestSuite) TestEnumTestCases() {
-	suite.runTestCases(enumAcceptanceTestCases)
+    suite.runTestCases(enumAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -7,17 +7,17 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "no-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
+            `,
 		},
 		expectEmptyPlan: true,
 	},
@@ -25,25 +25,25 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "create multiple extensions",
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
+            `,
 		},
 	},
 	{
 		name: "drop one extension",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm;
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm;
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE EXTENSION pg_trgm;
-			`,
+            CREATE EXTENSION pg_trgm;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -51,17 +51,17 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "upgrade an extension implicitly and explicitly",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH VERSION '1.5';
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH VERSION '1.5';
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH VERSION '1.6';
-			CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH VERSION '1.6';
+            CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeExtensionVersionUpgrade},
 	},

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -3,70 +3,70 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var extensionAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "no-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
-            `,
-        },
-        expectEmptyPlan: true,
-    },
-    {
-        name: "create multiple extensions",
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
-            `,
-        },
-    },
-    {
-        name: "drop one extension",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm;
-            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE EXTENSION pg_trgm;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "upgrade an extension implicitly and explicitly",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH VERSION '1.5';
-            CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH VERSION '1.6';
-            CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeExtensionVersionUpgrade},
-    },
+	{
+		name: "no-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "create multiple extensions",
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
+			`,
+		},
+	},
+	{
+		name: "drop one extension",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm;
+			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE EXTENSION pg_trgm;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "upgrade an extension implicitly and explicitly",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH VERSION '1.5';
+			CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH VERSION '1.6';
+			CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeExtensionVersionUpgrade},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestExtensionTestCases() {
-    suite.runTestCases(extensionAcceptanceTestCases)
+	suite.runTestCases(extensionAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -7,17 +7,17 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "no-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
+			`,
 		},
 		expectEmptyPlan: true,
 	},
@@ -25,25 +25,25 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "create multiple extensions",
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
+			`,
 		},
 	},
 	{
 		name: "drop one extension",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm;
-            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm;
+			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE EXTENSION pg_trgm;
-            `,
+			CREATE EXTENSION pg_trgm;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -51,17 +51,17 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "upgrade an extension implicitly and explicitly",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH VERSION '1.5';
-            CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH VERSION '1.5';
+			CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION pg_trgm WITH VERSION '1.6';
-            CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION pg_trgm WITH VERSION '1.6';
+			CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeExtensionVersionUpgrade},
 	},

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -3,70 +3,70 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var extensionAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "no-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
-			`,
-		},
-		expectEmptyPlan: true,
-	},
-	{
-		name: "create multiple extensions",
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
-			`,
-		},
-	},
-	{
-		name: "drop one extension",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm;
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE EXTENSION pg_trgm;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "upgrade an extension implicitly and explicitly",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH VERSION '1.5';
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH VERSION '1.6';
-			CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeExtensionVersionUpgrade},
-	},
+    {
+        name: "no-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
+            `,
+        },
+        expectEmptyPlan: true,
+    },
+    {
+        name: "create multiple extensions",
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
+            `,
+        },
+    },
+    {
+        name: "drop one extension",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm;
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE EXTENSION pg_trgm;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "upgrade an extension implicitly and explicitly",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH VERSION '1.5';
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH VERSION '1.6';
+            CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeExtensionVersionUpgrade},
+    },
 }
 
 func (suite *acceptanceTestSuite) TestExtensionTestCases() {
-	suite.runTestCases(extensionAcceptanceTestCases)
+    suite.runTestCases(extensionAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -7,16 +7,16 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "no-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 			`,
 		},
 		expectEmptyPlan: true,
@@ -25,9 +25,9 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "create multiple extensions",
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 			`,
 		},
 	},
@@ -35,14 +35,14 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "drop one extension",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm;
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm;
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE EXTENSION pg_trgm;
+            CREATE EXTENSION pg_trgm;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -51,16 +51,16 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 		name: "upgrade an extension implicitly and explicitly",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH VERSION '1.5';
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH VERSION '1.5';
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1 VERSION '1.3'; 
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION pg_trgm WITH VERSION '1.6';
-			CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION pg_trgm WITH VERSION '1.6';
+            CREATE EXTENSION AMCHECK WITH SCHEMA schema_1;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeExtensionVersionUpgrade},

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -3,748 +3,748 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var foreignKeyConstraintCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id_part_1 INT,
-                id_part_2 VARCHAR(255),
-                PRIMARY KEY (id_part_1, id_part_2)
-            );
-            CREATE TABLE "foobar fk"(
-                fk_part_1 BIGINT,
-                fk_part_2 VARCHAR(255),
-                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id_part_1 INT,
-                id_part_2 VARCHAR(255),
-                PRIMARY KEY (id_part_1, id_part_2)
-            );
-            CREATE TABLE "foobar fk"(
-                fk_part_1 BIGINT,
-                fk_part_2 VARCHAR(255),
-                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id_part_1 INT,
+			    id_part_2 VARCHAR(255),
+			    PRIMARY KEY (id_part_1, id_part_2)
+			);
+			CREATE TABLE "foobar fk"(
+			    fk_part_1 BIGINT,
+			    fk_part_2 VARCHAR(255),
+			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id_part_1 INT,
+			    id_part_2 VARCHAR(255),
+			    PRIMARY KEY (id_part_1, id_part_2)
+			);
+			CREATE TABLE "foobar fk"(
+			    fk_part_1 BIGINT,
+			    fk_part_2 VARCHAR(255),
+			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
 
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Add FK with most options",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "foo bar"(
-                id INT,
-                PRIMARY KEY (id)
-            );
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Add FK with most options",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "foo bar"(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "foo bar"(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "foo bar"(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Add FK (only referenced table is new)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Add FK (only referenced table is new)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Add FK (owning table is not new)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Add FK (owning table is not new)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Add FK (tables new)",
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Add FK (tables new)",
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
-    },
-    {
-        name: "Add not-valid FK (neither table is new)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
+	},
+	{
+		name: "Add not-valid FK (neither table is new)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    NOT VALID;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{},
-    },
-    {
-        name: "Add FK (partitioned table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT,
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Drop FK",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			        NOT VALID;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{},
+	},
+	{
+		name: "Add FK (partitioned table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT,
+			    FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Drop FK",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
-        },
-    },
-    {
-        name: "Add and drop FK (conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                  id TEXT PRIMARY KEY
-            );
-            
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id TEXT,
-                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                  id TEXT PRIMARY KEY
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
+		},
+	},
+	{
+		name: "Add and drop FK (conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+          		id TEXT PRIMARY KEY
+			);
+			
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id TEXT,
+			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+          		id TEXT PRIMARY KEY
+			);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."foobar fk"(
-                fk_id TEXT,
-                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Drop FK (partitioned table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT,
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            `,
-        },
-    },
-    {
-        name: "Alter FK not valid to valid (validate FK isn't dropped and re-added)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."foobar fk"(
+			    fk_id TEXT,
+			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Drop FK (partitioned table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT,
+			    FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			`,
+		},
+	},
+	{
+		name: "Alter FK not valid to valid (validate FK isn't dropped and re-added)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
-            `,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar fk\" VALIDATE CONSTRAINT \"some_fk\"",
-        },
-    },
-    {
-        name: "Alter FK (valid to not valid)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			`,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar fk\" VALIDATE CONSTRAINT \"some_fk\"",
+		},
+	},
+	{
+		name: "Alter FK (valid to not valid)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                NOT VALID;
-            `,
-        },
-    },
-    {
-        name: "Alter FK (columns)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (id)
-            );
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				NOT VALID;
+			`,
+		},
+	},
+	{
+		name: "Alter FK (columns)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (id)
+			);
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                fk_foo VARCHAR(255)
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (id)
-            );
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    fk_foo VARCHAR(255)
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (id)
+			);
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                fk_foo VARCHAR(255)
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Alter FK (on update)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    fk_foo VARCHAR(255)
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Alter FK (on update)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                  ON UPDATE CASCADE
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Alter FK (on delete)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				  ON UPDATE CASCADE
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Alter FK (on delete)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON UPDATE CASCADE
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Alter castable type change",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON UPDATE CASCADE
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Alter castable type change",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id BIGINT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id BIGINT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Alter non-castable type change",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id BIGINT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Alter non-castable type change",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id BIGINT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id BIGINT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id TIMESTAMP,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id BIGINT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id TIMESTAMP,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id TIMESTAMP,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
-        },
+			CREATE TABLE "foobar fk"(
+			    fk_id TIMESTAMP,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
+		},
 
-        expectedPlanErrorContains: errValidatingPlan.Error(),
-    },
-    {
-        name: "Switch FK owning table (to partitioned table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+		expectedPlanErrorContains: errValidatingPlan.Error(),
+	},
+	{
+		name: "Switch FK owning table (to partitioned table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
-    {
-        name: "Switch FK owning table (analog tables in different schemas stay same)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
+	{
+		name: "Switch FK owning table (analog tables in different schemas stay same)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
 
-            CREATE SCHEMA schema_1;    
-            CREATE TABLE schema_1.foobar(
-                id TEXT,
-                PRIMARY KEY (id)
-            );
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id TEXT
-            );
-            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE SCHEMA schema_1;	
+			CREATE TABLE schema_1.foobar(
+			    id TEXT,
+			    PRIMARY KEY (id)
+			);
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id TEXT
+			);
+			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-            CREATE SCHEMA schema_1;    
-            -- Update schema_1.foobar_Fk to ensure there are some deps that reference it
-            CREATE TABLE schema_1.foobar(
-                id TEXT,
-                val TEXT,
-                PRIMARY KEY (id, val)
-            );
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id TEXT,
-                fk_val TEXT
-            );
-            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
+			CREATE SCHEMA schema_1;	
+			-- Update schema_1.foobar_Fk to ensure there are some deps that reference it
+			CREATE TABLE schema_1.foobar(
+			    id TEXT,
+			    val TEXT,
+			    PRIMARY KEY (id, val)
+			);
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id TEXT,
+			    fk_val TEXT
+			);
+			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
 `},
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Switch FK referenced table (to partitioned table with new unique index)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                foo varchar(255),
-                id INT,
-                PRIMARY KEY (id)
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Switch FK referenced table (to partitioned table with new unique index)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    foo varchar(255),
+			    id INT,
+			    PRIMARY KEY (id)
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
 
-            CREATE TABLE "foobar partitioned"(
-                foo varchar(255),
-                id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+			CREATE TABLE "foobar partitioned"(
+			    foo varchar(255),
+			    id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
 
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                foo varchar(255),
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    foo varchar(255),
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar partitioned"(
-                foo varchar(255),
-                id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
-            CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
+			CREATE TABLE "foobar partitioned"(
+			    foo varchar(255),
+			    id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+			CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
 
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-        },
-    },
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestForeignKeyConstraintTestCases() {
-    suite.runTestCases(foreignKeyConstraintCases)
+	suite.runTestCases(foreignKeyConstraintCases)
 }

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -8,34 +8,34 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id_part_1 INT,
-			    id_part_2 VARCHAR(255),
-			    PRIMARY KEY (id_part_1, id_part_2)
+				id_part_1 INT,
+				id_part_2 VARCHAR(255),
+				PRIMARY KEY (id_part_1, id_part_2)
 			);
 			CREATE TABLE "foobar fk"(
-			    fk_part_1 BIGINT,
-			    fk_part_2 VARCHAR(255),
-			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+				fk_part_1 BIGINT,
+				fk_part_2 VARCHAR(255),
+				FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id_part_1 INT,
-			    id_part_2 VARCHAR(255),
-			    PRIMARY KEY (id_part_1, id_part_2)
+				id_part_1 INT,
+				id_part_2 VARCHAR(255),
+				PRIMARY KEY (id_part_1, id_part_2)
 			);
 			CREATE TABLE "foobar fk"(
-			    fk_part_1 BIGINT,
-			    fk_part_2 VARCHAR(255),
-			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+				fk_part_1 BIGINT,
+				fk_part_2 VARCHAR(255),
+				FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
@@ -47,28 +47,28 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "foo bar"(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "foo bar"(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
@@ -81,21 +81,21 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 			);
 			`,
 		},
@@ -108,23 +108,23 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
@@ -137,16 +137,16 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
@@ -156,28 +156,28 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			        NOT VALID;
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					NOT VALID;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{},
@@ -187,31 +187,31 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
 			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
+				fk_foo VARCHAR(255),
+				fk_id INT
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
 			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT,
-			    FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
+				fk_foo VARCHAR(255),
+				fk_id INT,
+				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
 			);
 			`,
 		},
@@ -224,28 +224,28 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			`,
 		},
@@ -256,15 +256,15 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-          		id TEXT PRIMARY KEY
+		  		id TEXT PRIMARY KEY
 			);
 			
 			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT,
-			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+				fk_id TEXT,
+				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
@@ -272,16 +272,16 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-          		id TEXT PRIMARY KEY
+		  		id TEXT PRIMARY KEY
 			);
 
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2."foobar fk"(
-			    fk_id TEXT,
-			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+				fk_id TEXT,
+				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
 					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
+					ON UPDATE SET NULL
+					NOT DEFERRABLE
 			);
 			`,
 		},
@@ -296,16 +296,16 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
 			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT,
-			    FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
+				fk_foo VARCHAR(255),
+				fk_id INT,
+				FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
 			);
 			`,
 		},
@@ -313,15 +313,15 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
 			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
+				fk_foo VARCHAR(255),
+				fk_id INT
 			);
 			`,
 		},
@@ -331,30 +331,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 				NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -366,29 +366,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 				NOT VALID;
 			`,
 		},
@@ -398,36 +398,36 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (id)
+				id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (id)
 			);
 			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    fk_foo VARCHAR(255)
+				fk_id INT,
+				fk_foo VARCHAR(255)
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 				NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (id)
+				id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (id)
 			);
 			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    fk_foo VARCHAR(255)
+				fk_id INT,
+				fk_foo VARCHAR(255)
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
+				FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -439,12 +439,12 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
+				fk_id INT,
 				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 			);
 			`,
@@ -452,12 +452,12 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
+				fk_id INT,
 				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 				  ON UPDATE CASCADE
 			);
@@ -472,26 +472,26 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 					ON UPDATE CASCADE
 			);
 			`,
@@ -505,26 +505,26 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id BIGINT,
-			    PRIMARY KEY (id)
+				id BIGINT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 			);
 			`,
 		},
@@ -538,26 +538,26 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id BIGINT,
-			    PRIMARY KEY (id)
+				id BIGINT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id BIGINT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id BIGINT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id TIMESTAMP,
-			    PRIMARY KEY (id)
+				id TIMESTAMP,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id TIMESTAMP,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				fk_id TIMESTAMP,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
 			);
 			`,
 		},
@@ -569,19 +569,19 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
 				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
 			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
+				foo varchar(255),
+				fk_id INT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
@@ -590,17 +590,17 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 
 			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
+				foo varchar(255),
+				fk_id INT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
@@ -617,30 +617,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
 				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
 			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
+				foo varchar(255),
+				fk_id INT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
 
 			CREATE SCHEMA schema_1;	
 			CREATE TABLE schema_1.foobar(
-			    id TEXT,
-			    PRIMARY KEY (id)
+				id TEXT,
+				PRIMARY KEY (id)
 			);
 			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT
+				fk_id TEXT
 			);
 			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
 				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
@@ -649,17 +649,17 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar fk"(
-			    fk_id INT
+				fk_id INT
 			);
 
 			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
+				foo varchar(255),
+				fk_id INT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
@@ -669,13 +669,13 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 			CREATE SCHEMA schema_1;	
 			-- Update schema_1.foobar_Fk to ensure there are some deps that reference it
 			CREATE TABLE schema_1.foobar(
-			    id TEXT,
-			    val TEXT,
-			    PRIMARY KEY (id, val)
+				id TEXT,
+				val TEXT,
+				PRIMARY KEY (id, val)
 			);
 			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT,
-			    fk_val TEXT
+				fk_id TEXT,
+				fk_val TEXT
 			);
 			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
 				FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
@@ -692,22 +692,22 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    foo varchar(255),
-			    id INT,
-			    PRIMARY KEY (id)
+				foo varchar(255),
+				id INT,
+				PRIMARY KEY (id)
 			);
 			CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
 
 			CREATE TABLE "foobar partitioned"(
-			    foo varchar(255),
-			    id INT
+				foo varchar(255),
+				id INT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
 
 			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
+				fk_foo VARCHAR(255),
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
 				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
@@ -716,22 +716,22 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    foo varchar(255),
-			    id INT,
-			    PRIMARY KEY (id)
+				foo varchar(255),
+				id INT,
+				PRIMARY KEY (id)
 			);
 
 			CREATE TABLE "foobar partitioned"(
-			    foo varchar(255),
-			    id INT
+				foo varchar(255),
+				id INT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
 			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
 			CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
 
 			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
+				fk_foo VARCHAR(255),
+				fk_id INT
 			);
 			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
 				FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -7,37 +7,37 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id_part_1 INT,
-			    id_part_2 VARCHAR(255),
-			    PRIMARY KEY (id_part_1, id_part_2)
-			);
-			CREATE TABLE "foobar fk"(
-			    fk_part_1 BIGINT,
-			    fk_part_2 VARCHAR(255),
-			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE TABLE foobar(
+                id_part_1 INT,
+                id_part_2 VARCHAR(255),
+                PRIMARY KEY (id_part_1, id_part_2)
+            );
+            CREATE TABLE "foobar fk"(
+                fk_part_1 BIGINT,
+                fk_part_2 VARCHAR(255),
+                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id_part_1 INT,
-			    id_part_2 VARCHAR(255),
-			    PRIMARY KEY (id_part_1, id_part_2)
-			);
-			CREATE TABLE "foobar fk"(
-			    fk_part_1 BIGINT,
-			    fk_part_2 VARCHAR(255),
-			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE TABLE foobar(
+                id_part_1 INT,
+                id_part_2 VARCHAR(255),
+                PRIMARY KEY (id_part_1, id_part_2)
+            );
+            CREATE TABLE "foobar fk"(
+                fk_part_1 BIGINT,
+                fk_part_2 VARCHAR(255),
+                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 
 		expectEmptyPlan: true,
@@ -46,31 +46,31 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK with most options",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "foo bar"(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foo bar"(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "foo bar"(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foo bar"(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -80,24 +80,24 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (only referenced table is new)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -107,26 +107,26 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (owning table is not new)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -136,49 +136,49 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (tables new)",
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 	},
 	{
 		name: "Add not-valid FK (neither table is new)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			        NOT VALID;
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    NOT VALID;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{},
 	},
@@ -186,34 +186,34 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT,
-			    FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT,
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -223,67 +223,67 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Drop FK",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
 		},
 	},
 	{
 		name: "Add and drop FK (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-          		id TEXT PRIMARY KEY
-			);
-			
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT,
-			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                  id TEXT PRIMARY KEY
+            );
+            
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT,
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-          		id TEXT PRIMARY KEY
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                  id TEXT PRIMARY KEY
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."foobar fk"(
-			    fk_id TEXT,
-			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."foobar fk"(
+                fk_id TEXT,
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -294,68 +294,68 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Drop FK (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT,
-			    FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT,
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            `,
 		},
 	},
 	{
 		name: "Alter FK not valid to valid (validate FK isn't dropped and re-added)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            `,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar fk\" VALIDATE CONSTRAINT \"some_fk\"",
@@ -365,70 +365,70 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (valid to not valid)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
+            `,
 		},
 	},
 	{
 		name: "Alter FK (columns)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    fk_foo VARCHAR(255)
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                fk_foo VARCHAR(255)
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    fk_foo VARCHAR(255)
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                fk_foo VARCHAR(255)
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -438,30 +438,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (on update)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				  ON UPDATE CASCADE
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                  ON UPDATE CASCADE
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -471,30 +471,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (on delete)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON UPDATE CASCADE
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON UPDATE CASCADE
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -504,29 +504,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter castable type change",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id BIGINT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id BIGINT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -537,29 +537,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter non-castable type change",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id BIGINT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id BIGINT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id BIGINT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id BIGINT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id TIMESTAMP,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id TIMESTAMP,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id TIMESTAMP,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_id TIMESTAMP,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
 		},
 
 		expectedPlanErrorContains: errValidatingPlan.Error(),
@@ -568,45 +568,45 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK owning table (to partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
-			`,
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
-			`,
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -616,69 +616,69 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK owning table (analog tables in different schemas stay same)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
 
-			CREATE SCHEMA schema_1;	
-			CREATE TABLE schema_1.foobar(
-			    id TEXT,
-			    PRIMARY KEY (id)
-			);
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT
-			);
-			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
-			`,
+            CREATE SCHEMA schema_1;    
+            CREATE TABLE schema_1.foobar(
+                id TEXT,
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT
+            );
+            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE SCHEMA schema_1;	
-			-- Update schema_1.foobar_Fk to ensure there are some deps that reference it
-			CREATE TABLE schema_1.foobar(
-			    id TEXT,
-			    val TEXT,
-			    PRIMARY KEY (id, val)
-			);
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT,
-			    fk_val TEXT
-			);
-			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
+            CREATE SCHEMA schema_1;    
+            -- Update schema_1.foobar_Fk to ensure there are some deps that reference it
+            CREATE TABLE schema_1.foobar(
+                id TEXT,
+                val TEXT,
+                PRIMARY KEY (id, val)
+            );
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT,
+                fk_val TEXT
+            );
+            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
 `},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -691,51 +691,51 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK referenced table (to partitioned table with new unique index)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    foo varchar(255),
-			    id INT,
-			    PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
+            CREATE TABLE foobar(
+                foo varchar(255),
+                id INT,
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
 
-			CREATE TABLE "foobar partitioned"(
-			    foo varchar(255),
-			    id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+            CREATE TABLE "foobar partitioned"(
+                foo varchar(255),
+                id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
 
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    foo varchar(255),
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                foo varchar(255),
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar partitioned"(
-			    foo varchar(255),
-			    id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
-			CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
+            CREATE TABLE "foobar partitioned"(
+                foo varchar(255),
+                id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+            CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
 
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
-			`,
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -7,36 +7,36 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id_part_1 INT,
-				id_part_2 VARCHAR(255),
-				PRIMARY KEY (id_part_1, id_part_2)
-			);
-			CREATE TABLE "foobar fk"(
-				fk_part_1 BIGINT,
-				fk_part_2 VARCHAR(255),
-				FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE TABLE foobar(
+                id_part_1 INT,
+                id_part_2 VARCHAR(255),
+                PRIMARY KEY (id_part_1, id_part_2)
+            );
+            CREATE TABLE "foobar fk"(
+                fk_part_1 BIGINT,
+                fk_part_2 VARCHAR(255),
+                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id_part_1 INT,
-				id_part_2 VARCHAR(255),
-				PRIMARY KEY (id_part_1, id_part_2)
-			);
-			CREATE TABLE "foobar fk"(
-				fk_part_1 BIGINT,
-				fk_part_2 VARCHAR(255),
-				FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE TABLE foobar(
+                id_part_1 INT,
+                id_part_2 VARCHAR(255),
+                PRIMARY KEY (id_part_1, id_part_2)
+            );
+            CREATE TABLE "foobar fk"(
+                fk_part_1 BIGINT,
+                fk_part_2 VARCHAR(255),
+                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 
@@ -46,30 +46,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK with most options",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "foo bar"(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE "foo bar"(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "foo bar"(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE "foo bar"(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -80,23 +80,23 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (only referenced table is new)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -107,25 +107,25 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (owning table is not new)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -136,18 +136,18 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (tables new)",
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 	},
@@ -155,29 +155,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add not-valid FK (neither table is new)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					NOT VALID;
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    NOT VALID;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{},
@@ -186,33 +186,33 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-				fk_foo VARCHAR(255),
-				fk_id INT
-			);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-				fk_foo VARCHAR(255),
-				fk_id INT,
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT,
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -223,30 +223,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Drop FK",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 			`,
 		},
 	},
@@ -254,35 +254,35 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add and drop FK (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-		  		id TEXT PRIMARY KEY
-			);
-			
-			CREATE TABLE schema_1."foobar fk"(
-				fk_id TEXT,
-				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                  id TEXT PRIMARY KEY
+            );
+            
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT,
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-		  		id TEXT PRIMARY KEY
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                  id TEXT PRIMARY KEY
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."foobar fk"(
-				fk_id TEXT,
-				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-					ON DELETE SET NULL
-					ON UPDATE SET NULL
-					NOT DEFERRABLE
-			);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."foobar fk"(
+                fk_id TEXT,
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -294,35 +294,35 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Drop FK (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-				fk_foo VARCHAR(255),
-				fk_id INT,
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT,
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-				fk_foo VARCHAR(255),
-				fk_id INT
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
 			`,
 		},
 	},
@@ -330,31 +330,31 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK not valid to valid (validate FK isn't dropped and re-added)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 			`,
 		},
 		expectedPlanDDL: []string{
@@ -365,31 +365,31 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (valid to not valid)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
 			`,
 		},
 	},
@@ -397,37 +397,37 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (columns)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				fk_foo VARCHAR(255)
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                fk_foo VARCHAR(255)
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				fk_foo VARCHAR(255)
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                fk_foo VARCHAR(255)
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -438,29 +438,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (on update)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				  ON UPDATE CASCADE
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                  ON UPDATE CASCADE
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -471,29 +471,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (on delete)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON UPDATE CASCADE
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON UPDATE CASCADE
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -504,28 +504,28 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter castable type change",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id BIGINT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id BIGINT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -537,28 +537,28 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter non-castable type change",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id BIGINT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id BIGINT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id BIGINT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id BIGINT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id TIMESTAMP,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id TIMESTAMP,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id TIMESTAMP,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id TIMESTAMP,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
 			`,
 		},
 
@@ -568,44 +568,44 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK owning table (to partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE TABLE "foobar fk partitioned"(
-				foo varchar(255),
-				fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 
-			CREATE TABLE "foobar fk partitioned"(
-				foo varchar(255),
-				fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -616,69 +616,69 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK owning table (analog tables in different schemas stay same)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE TABLE "foobar fk partitioned"(
-				foo varchar(255),
-				fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
 
-			CREATE SCHEMA schema_1;	
-			CREATE TABLE schema_1.foobar(
-				id TEXT,
-				PRIMARY KEY (id)
-			);
-			CREATE TABLE schema_1."foobar fk"(
-				fk_id TEXT
-			);
-			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
+            CREATE SCHEMA schema_1;    
+            CREATE TABLE schema_1.foobar(
+                id TEXT,
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT
+            );
+            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-				fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 
-			CREATE TABLE "foobar fk partitioned"(
-				foo varchar(255),
-				fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE SCHEMA schema_1;	
-			-- Update schema_1.foobar_Fk to ensure there are some deps that reference it
-			CREATE TABLE schema_1.foobar(
-				id TEXT,
-				val TEXT,
-				PRIMARY KEY (id, val)
-			);
-			CREATE TABLE schema_1."foobar fk"(
-				fk_id TEXT,
-				fk_val TEXT
-			);
-			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
+            CREATE SCHEMA schema_1;    
+            -- Update schema_1.foobar_Fk to ensure there are some deps that reference it
+            CREATE TABLE schema_1.foobar(
+                id TEXT,
+                val TEXT,
+                PRIMARY KEY (id, val)
+            );
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT,
+                fk_val TEXT
+            );
+            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
 `},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -691,50 +691,50 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK referenced table (to partitioned table with new unique index)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				foo varchar(255),
-				id INT,
-				PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
+            CREATE TABLE foobar(
+                foo varchar(255),
+                id INT,
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
 
-			CREATE TABLE "foobar partitioned"(
-				foo varchar(255),
-				id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+            CREATE TABLE "foobar partitioned"(
+                foo varchar(255),
+                id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
 
-			CREATE TABLE "foobar fk"(
-				fk_foo VARCHAR(255),
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				foo varchar(255),
-				id INT,
-				PRIMARY KEY (id)
-			);
+            CREATE TABLE foobar(
+                foo varchar(255),
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar partitioned"(
-				foo varchar(255),
-				id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
-			CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
+            CREATE TABLE "foobar partitioned"(
+                foo varchar(255),
+                id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+            CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
 
-			CREATE TABLE "foobar fk"(
-				fk_foo VARCHAR(255),
-				fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -7,37 +7,37 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id_part_1 INT,
-                id_part_2 VARCHAR(255),
-                PRIMARY KEY (id_part_1, id_part_2)
-            );
-            CREATE TABLE "foobar fk"(
-                fk_part_1 BIGINT,
-                fk_part_2 VARCHAR(255),
-                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE TABLE foobar(
+			    id_part_1 INT,
+			    id_part_2 VARCHAR(255),
+			    PRIMARY KEY (id_part_1, id_part_2)
+			);
+			CREATE TABLE "foobar fk"(
+			    fk_part_1 BIGINT,
+			    fk_part_2 VARCHAR(255),
+			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id_part_1 INT,
-                id_part_2 VARCHAR(255),
-                PRIMARY KEY (id_part_1, id_part_2)
-            );
-            CREATE TABLE "foobar fk"(
-                fk_part_1 BIGINT,
-                fk_part_2 VARCHAR(255),
-                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE TABLE foobar(
+			    id_part_1 INT,
+			    id_part_2 VARCHAR(255),
+			    PRIMARY KEY (id_part_1, id_part_2)
+			);
+			CREATE TABLE "foobar fk"(
+			    fk_part_1 BIGINT,
+			    fk_part_2 VARCHAR(255),
+			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 
 		expectEmptyPlan: true,
@@ -46,31 +46,31 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK with most options",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "foo bar"(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foo bar"(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "foo bar"(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE "foo bar"(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -80,24 +80,24 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (only referenced table is new)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -107,26 +107,26 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (owning table is not new)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -136,49 +136,49 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (tables new)",
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 	},
 	{
 		name: "Add not-valid FK (neither table is new)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    NOT VALID;
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			        NOT VALID;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{},
 	},
@@ -186,34 +186,34 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Add FK (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT,
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT,
+			    FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -223,67 +223,67 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Drop FK",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			`,
 		},
 	},
 	{
 		name: "Add and drop FK (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                  id TEXT PRIMARY KEY
-            );
-            
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id TEXT,
-                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+          		id TEXT PRIMARY KEY
+			);
+			
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id TEXT,
+			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                  id TEXT PRIMARY KEY
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+          		id TEXT PRIMARY KEY
+			);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."foobar fk"(
-                fk_id TEXT,
-                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-                    ON DELETE SET NULL
-                    ON UPDATE SET NULL
-                    NOT DEFERRABLE
-            );
-            `,
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."foobar fk"(
+			    fk_id TEXT,
+			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+					ON DELETE SET NULL
+			        ON UPDATE SET NULL
+			        NOT DEFERRABLE
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -294,68 +294,68 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Drop FK (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT,
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT,
+			    FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			`,
 		},
 	},
 	{
 		name: "Alter FK not valid to valid (validate FK isn't dropped and re-added)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                NOT VALID;
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			`,
 		},
 		expectedPlanDDL: []string{
 			"ALTER TABLE \"public\".\"foobar fk\" VALIDATE CONSTRAINT \"some_fk\"",
@@ -365,70 +365,70 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (valid to not valid)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                NOT VALID;
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				NOT VALID;
+			`,
 		},
 	},
 	{
 		name: "Alter FK (columns)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (id)
-            );
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (id)
+			);
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                fk_foo VARCHAR(255)
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                NOT VALID;
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    fk_foo VARCHAR(255)
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (id)
-            );
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+			CREATE TABLE foobar(
+			    id INT,
+			    foo VARCHAR(255),
+			    PRIMARY KEY (id)
+			);
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                fk_foo VARCHAR(255)
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    fk_foo VARCHAR(255)
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+			    FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -438,30 +438,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (on update)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                  ON UPDATE CASCADE
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+				FOREIGN KEY (fk_id) REFERENCES foobar(id)
+				  ON UPDATE CASCADE
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -471,30 +471,30 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter FK (on delete)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-                    ON UPDATE CASCADE
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+					ON UPDATE CASCADE
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -504,29 +504,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter castable type change",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id BIGINT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id BIGINT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id INT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -537,29 +537,29 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Alter non-castable type change",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id BIGINT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id BIGINT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id BIGINT,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id BIGINT,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id TIMESTAMP,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id TIMESTAMP,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id TIMESTAMP,
-                FOREIGN KEY (fk_id) REFERENCES foobar(id)
-            );
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_id TIMESTAMP,
+			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
+			);
+			`,
 		},
 
 		expectedPlanErrorContains: errValidatingPlan.Error(),
@@ -568,45 +568,45 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK owning table (to partitioned table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
-            `,
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
-            `,
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -616,69 +616,69 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK owning table (analog tables in different schemas stay same)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
 
-            CREATE SCHEMA schema_1;    
-            CREATE TABLE schema_1.foobar(
-                id TEXT,
-                PRIMARY KEY (id)
-            );
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id TEXT
-            );
-            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
-            `,
+			CREATE SCHEMA schema_1;	
+			CREATE TABLE schema_1.foobar(
+			    id TEXT,
+			    PRIMARY KEY (id)
+			);
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id TEXT
+			);
+			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar fk"(
-                fk_id INT
-            );
+			CREATE TABLE "foobar fk"(
+			    fk_id INT
+			);
 
-            CREATE TABLE "foobar fk partitioned"(
-                foo varchar(255),
-                fk_id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+			CREATE TABLE "foobar fk partitioned"(
+			    foo varchar(255),
+			    fk_id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-            CREATE SCHEMA schema_1;    
-            -- Update schema_1.foobar_Fk to ensure there are some deps that reference it
-            CREATE TABLE schema_1.foobar(
-                id TEXT,
-                val TEXT,
-                PRIMARY KEY (id, val)
-            );
-            CREATE TABLE schema_1."foobar fk"(
-                fk_id TEXT,
-                fk_val TEXT
-            );
-            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
+			CREATE SCHEMA schema_1;	
+			-- Update schema_1.foobar_Fk to ensure there are some deps that reference it
+			CREATE TABLE schema_1.foobar(
+			    id TEXT,
+			    val TEXT,
+			    PRIMARY KEY (id, val)
+			);
+			CREATE TABLE schema_1."foobar fk"(
+			    fk_id TEXT,
+			    fk_val TEXT
+			);
+			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
 `},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -691,51 +691,51 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 		name: "Switch FK referenced table (to partitioned table with new unique index)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                foo varchar(255),
-                id INT,
-                PRIMARY KEY (id)
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
+			CREATE TABLE foobar(
+			    foo varchar(255),
+			    id INT,
+			    PRIMARY KEY (id)
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
 
-            CREATE TABLE "foobar partitioned"(
-                foo varchar(255),
-                id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+			CREATE TABLE "foobar partitioned"(
+			    foo varchar(255),
+			    id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
 
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                foo varchar(255),
-                id INT,
-                PRIMARY KEY (id)
-            );
+			CREATE TABLE foobar(
+			    foo varchar(255),
+			    id INT,
+			    PRIMARY KEY (id)
+			);
 
-            CREATE TABLE "foobar partitioned"(
-                foo varchar(255),
-                id INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
-            CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
+			CREATE TABLE "foobar partitioned"(
+			    foo varchar(255),
+			    id INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+			CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
 
-            CREATE TABLE "foobar fk"(
-                fk_foo VARCHAR(255),
-                fk_id INT
-            );
-            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-                FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
-            `,
+			CREATE TABLE "foobar fk"(
+			    fk_foo VARCHAR(255),
+			    fk_id INT
+			);
+			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+				FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -3,748 +3,748 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var foreignKeyConstraintCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id_part_1 INT,
-			    id_part_2 VARCHAR(255),
-			    PRIMARY KEY (id_part_1, id_part_2)
-			);
-			CREATE TABLE "foobar fk"(
-			    fk_part_1 BIGINT,
-			    fk_part_2 VARCHAR(255),
-			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id_part_1 INT,
-			    id_part_2 VARCHAR(255),
-			    PRIMARY KEY (id_part_1, id_part_2)
-			);
-			CREATE TABLE "foobar fk"(
-			    fk_part_1 BIGINT,
-			    fk_part_2 VARCHAR(255),
-			    FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id_part_1 INT,
+                id_part_2 VARCHAR(255),
+                PRIMARY KEY (id_part_1, id_part_2)
+            );
+            CREATE TABLE "foobar fk"(
+                fk_part_1 BIGINT,
+                fk_part_2 VARCHAR(255),
+                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id_part_1 INT,
+                id_part_2 VARCHAR(255),
+                PRIMARY KEY (id_part_1, id_part_2)
+            );
+            CREATE TABLE "foobar fk"(
+                fk_part_1 BIGINT,
+                fk_part_2 VARCHAR(255),
+                FOREIGN KEY (fk_part_1, fk_part_2) REFERENCES foobar(id_part_1, id_part_2)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
 
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Add FK with most options",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "foo bar"(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Add FK with most options",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "foo bar"(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "foo bar"(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "foo bar"(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Add FK (only referenced table is new)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES "foo bar"(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Add FK (only referenced table is new)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Add FK (owning table is not new)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Add FK (owning table is not new)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Add FK (tables new)",
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Add FK (tables new)",
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
-	},
-	{
-		name: "Add not-valid FK (neither table is new)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
+    },
+    {
+        name: "Add not-valid FK (neither table is new)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			        NOT VALID;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{},
-	},
-	{
-		name: "Add FK (partitioned table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT,
-			    FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Drop FK",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_foobar_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    NOT VALID;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{},
+    },
+    {
+        name: "Add FK (partitioned table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT,
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id)
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Drop FK",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			`,
-		},
-	},
-	{
-		name: "Add and drop FK (conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-          		id TEXT PRIMARY KEY
-			);
-			
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT,
-			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-          		id TEXT PRIMARY KEY
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            `,
+        },
+    },
+    {
+        name: "Add and drop FK (conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                  id TEXT PRIMARY KEY
+            );
+            
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT,
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                  id TEXT PRIMARY KEY
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."foobar fk"(
-			    fk_id TEXT,
-			    FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
-					ON DELETE SET NULL
-			        ON UPDATE SET NULL
-			        NOT DEFERRABLE
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Drop FK (partitioned table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT,
-			    FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			`,
-		},
-	},
-	{
-		name: "Alter FK not valid to valid (validate FK isn't dropped and re-added)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."foobar fk"(
+                fk_id TEXT,
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id)
+                    ON DELETE SET NULL
+                    ON UPDATE SET NULL
+                    NOT DEFERRABLE
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Drop FK (partitioned table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT,
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES schema_1.foobar(foo, id)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            `,
+        },
+    },
+    {
+        name: "Alter FK not valid to valid (validate FK isn't dropped and re-added)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
-			`,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar fk\" VALIDATE CONSTRAINT \"some_fk\"",
-		},
-	},
-	{
-		name: "Alter FK (valid to not valid)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            `,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar fk\" VALIDATE CONSTRAINT \"some_fk\"",
+        },
+    },
+    {
+        name: "Alter FK (valid to not valid)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
-			`,
-		},
-	},
-	{
-		name: "Alter FK (columns)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
+            `,
+        },
+    },
+    {
+        name: "Alter FK (columns)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    fk_foo VARCHAR(255)
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo VARCHAR(255),
-			    PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                fk_foo VARCHAR(255)
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo);
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    fk_foo VARCHAR(255)
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-			    FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Alter FK (on update)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                fk_foo VARCHAR(255)
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo) REFERENCES foobar(foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Alter FK (on update)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-				FOREIGN KEY (fk_id) REFERENCES foobar(id)
-				  ON UPDATE CASCADE
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Alter FK (on delete)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                  ON UPDATE CASCADE
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Alter FK (on delete)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-					ON UPDATE CASCADE
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Alter castable type change",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+                    ON UPDATE CASCADE
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Alter castable type change",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id BIGINT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id BIGINT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Alter non-castable type change",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id BIGINT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Alter non-castable type change",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id BIGINT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id BIGINT,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id TIMESTAMP,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id BIGINT,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id TIMESTAMP,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id TIMESTAMP,
-			    FOREIGN KEY (fk_id) REFERENCES foobar(id)
-			);
-			`,
-		},
+            CREATE TABLE "foobar fk"(
+                fk_id TIMESTAMP,
+                FOREIGN KEY (fk_id) REFERENCES foobar(id)
+            );
+            `,
+        },
 
-		expectedPlanErrorContains: errValidatingPlan.Error(),
-	},
-	{
-		name: "Switch FK owning table (to partitioned table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+        expectedPlanErrorContains: errValidatingPlan.Error(),
+    },
+    {
+        name: "Switch FK owning table (to partitioned table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
-	{
-		name: "Switch FK owning table (analog tables in different schemas stay same)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
+    {
+        name: "Switch FK owning table (analog tables in different schemas stay same)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned"  FOR VALUES IN ('2');
 
-			CREATE SCHEMA schema_1;	
-			CREATE TABLE schema_1.foobar(
-			    id TEXT,
-			    PRIMARY KEY (id)
-			);
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT
-			);
-			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE SCHEMA schema_1;    
+            CREATE TABLE schema_1.foobar(
+                id TEXT,
+                PRIMARY KEY (id)
+            );
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT
+            );
+            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES schema_1.foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar fk"(
-			    fk_id INT
-			);
+            CREATE TABLE "foobar fk"(
+                fk_id INT
+            );
 
-			CREATE TABLE "foobar fk partitioned"(
-			    foo varchar(255),
-			    fk_id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
-			ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id) REFERENCES foobar(id);
+            CREATE TABLE "foobar fk partitioned"(
+                foo varchar(255),
+                fk_id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar fk partitioned" FOR VALUES IN ('2');
+            ALTER TABLE "foobar fk partitioned" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id) REFERENCES foobar(id);
 
-			CREATE SCHEMA schema_1;	
-			-- Update schema_1.foobar_Fk to ensure there are some deps that reference it
-			CREATE TABLE schema_1.foobar(
-			    id TEXT,
-			    val TEXT,
-			    PRIMARY KEY (id, val)
-			);
-			CREATE TABLE schema_1."foobar fk"(
-			    fk_id TEXT,
-			    fk_val TEXT
-			);
-			ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
+            CREATE SCHEMA schema_1;    
+            -- Update schema_1.foobar_Fk to ensure there are some deps that reference it
+            CREATE TABLE schema_1.foobar(
+                id TEXT,
+                val TEXT,
+                PRIMARY KEY (id, val)
+            );
+            CREATE TABLE schema_1."foobar fk"(
+                fk_id TEXT,
+                fk_val TEXT
+            );
+            ALTER TABLE schema_1."foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_id, fk_val) REFERENCES schema_1.foobar(id, val);
 `},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Switch FK referenced table (to partitioned table with new unique index)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    foo varchar(255),
-			    id INT,
-			    PRIMARY KEY (id)
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Switch FK referenced table (to partitioned table with new unique index)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                foo varchar(255),
+                id INT,
+                PRIMARY KEY (id)
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, id);
 
-			CREATE TABLE "foobar partitioned"(
-			    foo varchar(255),
-			    id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+            CREATE TABLE "foobar partitioned"(
+                foo varchar(255),
+                id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
 
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    foo varchar(255),
-			    id INT,
-			    PRIMARY KEY (id)
-			);
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES foobar(foo, id) NOT VALID ;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                foo varchar(255),
+                id INT,
+                PRIMARY KEY (id)
+            );
 
-			CREATE TABLE "foobar partitioned"(
-			    foo varchar(255),
-			    id INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
-			CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
-			CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
+            CREATE TABLE "foobar partitioned"(
+                foo varchar(255),
+                id INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "foobar partitioned" FOR VALUES IN ('1');
+            CREATE TABLE foobar_2 PARTITION OF "foobar partitioned" FOR VALUES IN ('2');
+            CREATE UNIQUE INDEX unique_idx ON "foobar partitioned"(foo, id);
 
-			CREATE TABLE "foobar fk"(
-			    fk_foo VARCHAR(255),
-			    fk_id INT
-			);
-			ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
-				FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-		},
-	},
+            CREATE TABLE "foobar fk"(
+                fk_foo VARCHAR(255),
+                fk_id INT
+            );
+            ALTER TABLE "foobar fk" ADD CONSTRAINT some_fk
+                FOREIGN KEY (fk_foo, fk_id) REFERENCES "foobar partitioned"(foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestForeignKeyConstraintTestCases() {
-	suite.runTestCases(foreignKeyConstraintCases)
+    suite.runTestCases(foreignKeyConstraintCases)
 }

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -1,578 +1,578 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var functionAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-			`,
-		},
+            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+            `,
+        },
 
-		expectEmptyPlan: true,
-	},
-	{
-		name:         "Create functions (with conflicting names)",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+        expectEmptyPlan: true,
+    },
+    {
+        name:         "Create functions (with conflicting names)",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-	},
-	{
-		name:         "Create functions with quoted names (with conflicting names)",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-	},
-	{
-		name:         "Create non-sql function",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name:         "Create function with dependencies",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+    },
+    {
+        name:         "Create functions with quoted names (with conflicting names)",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+    },
+    {
+        name:         "Create non-sql function",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name:         "Create function with dependencies",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			-- identical function on a different schem
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b); 
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Create function with an extension that also creates functions installed",
-		oldSchemaDDL: []string{
-			`
-			CREATE EXTENSION amcheck;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE EXTENSION amcheck;
+            -- identical function on a different schem
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b); 
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Create function with an extension that also creates functions installed",
+        oldSchemaDDL: []string{
+            `
+            CREATE EXTENSION amcheck;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE EXTENSION amcheck;
 
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			`,
-		},
-	},
-	{
-		name: "Drop functions (with conflicting names)",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-		newSchemaDDL: nil,
-	},
-	{
-		name: "Drop functions with quoted names (with conflicting names)",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-		newSchemaDDL: nil,
-	},
-	{
-		name: "Drop non-sql function",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
-		newSchemaDDL:        nil,
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Drop function with dependencies",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            `,
+        },
+    },
+    {
+        name: "Drop functions (with conflicting names)",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+        newSchemaDDL: nil,
+    },
+    {
+        name: "Drop functions with quoted names (with conflicting names)",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+        newSchemaDDL: nil,
+    },
+    {
+        name: "Drop non-sql function",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
+        newSchemaDDL:        nil,
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Drop function with dependencies",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			-- identical function on a different schema to ensure schemas are specified correctly
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b); 
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Add and drop functions with dependencies (conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            -- identical function on a different schema to ensure schemas are specified correctly
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b); 
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Add and drop functions with dependencies (conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + schema_1."increment func"(a);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + schema_1."increment func"(a);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_2.add(a, b) + schema_2."increment func"(a);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Alter functions (with conflicting names)",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + a + b;
-			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(CONCAT(a, a), b);
-			`,
-		},
-	},
-	{
-		name: "Alter functions with quoted names (with conflicting names)",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + a + b;
-			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(CONCAT(a, a), b);
-			`,
-		},
-	},
-	{
-		name: "Alter non-sql function",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 5;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Alter sql function to be non-sql function",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURN i + 5;
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Alter non-sql function to be sql function (no dependency tracking error)",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURN i + 5;
-		`},
-	},
-	{
-		name: "Alter a function's dependencies",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_2.add(a, b) + schema_2."increment func"(a);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Alter functions (with conflicting names)",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + a + b;
+            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(CONCAT(a, a), b);
+            `,
+        },
+    },
+    {
+        name: "Alter functions with quoted names (with conflicting names)",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + a + b;
+            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(CONCAT(a, a), b);
+            `,
+        },
+    },
+    {
+        name: "Alter non-sql function",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 5;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Alter sql function to be non-sql function",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION some_func(i integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURN i + 5;
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Alter non-sql function to be sql function (no dependency tracking error)",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION some_func(i integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURN i + 5;
+        `},
+    },
+    {
+        name: "Alter a function's dependencies",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-		CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+        CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "decrement func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "decrement func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Alter a dependent function",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Alter a dependent function",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
-					BEGIN
-							RETURN i + 5;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
+                    BEGIN
+                            RETURN i + 5;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Alter a function to no longer depend on a function and drop that function",
-		oldSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Alter a function to no longer depend on a function and drop that function",
+        oldSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
 }
 
 func (suite *acceptanceTestSuite) TestFunctionTestCases() {
-	suite.runTestCases(functionAcceptanceTestCases)
+    suite.runTestCases(functionAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -9,33 +9,33 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-			`,
+            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-			`,
+            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+            `,
 		},
 
 		expectEmptyPlan: true,
@@ -45,29 +45,29 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 	},
 	{
@@ -75,17 +75,17 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 	},
 	{
@@ -93,12 +93,12 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
@@ -106,76 +106,76 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			-- identical function on a different schem
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b); 
-		`},
+            -- identical function on a different schem
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b); 
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Create function with an extension that also creates functions installed",
 		oldSchemaDDL: []string{
 			`
-			CREATE EXTENSION amcheck;
-			`,
+            CREATE EXTENSION amcheck;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE EXTENSION amcheck;
+            CREATE EXTENSION amcheck;
 
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			`,
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            `,
 		},
 	},
 	{
 		name: "Drop functions (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 		newSchemaDDL: nil,
 	},
@@ -183,17 +183,17 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop functions with quoted names (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 		newSchemaDDL: nil,
 	},
@@ -201,12 +201,12 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop non-sql function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
 		newSchemaDDL:        nil,
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -214,40 +214,40 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop function with dependencies",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			-- identical function on a different schema to ensure schemas are specified correctly
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b); 
-			`,
+            -- identical function on a different schema to ensure schemas are specified correctly
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b); 
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -255,47 +255,47 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop functions with dependencies (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + schema_1."increment func"(a);
-			`,
+            CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + schema_1."increment func"(a);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_2.add(a, b) + schema_2."increment func"(a);
-			`,
+            CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_2.add(a, b) + schema_2."increment func"(a);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -303,184 +303,184 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter functions (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + a + b;
-			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(CONCAT(a, a), b);
-			`,
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + a + b;
+            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(CONCAT(a, a), b);
+            `,
 		},
 	},
 	{
 		name: "Alter functions with quoted names (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + a + b;
-			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(CONCAT(a, a), b);
-			`,
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + a + b;
+            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(CONCAT(a, a), b);
+            `,
 		},
 	},
 	{
 		name: "Alter non-sql function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 5;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 5;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Alter sql function to be non-sql function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURN i + 5;
-		`},
+            CREATE FUNCTION some_func(i integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURN i + 5;
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
+            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Alter non-sql function to be sql function (no dependency tracking error)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
-		`},
+            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURN i + 5;
-		`},
+            CREATE FUNCTION some_func(i integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURN i + 5;
+        `},
 	},
 	{
 		name: "Alter a function's dependencies",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-		CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+        CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "decrement func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "decrement func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
-			`,
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -488,45 +488,45 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter a dependent function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
-			`,
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
-					BEGIN
-							RETURN i + 5;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
+                    BEGIN
+                            RETURN i + 5;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
-			`,
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -534,40 +534,40 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter a function to no longer depend on a function and drop that function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
-			`,
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b);
-			`,
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -1,578 +1,578 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var functionAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-            `,
-        },
+			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+			`,
+		},
 
-        expectEmptyPlan: true,
-    },
-    {
-        name:         "Create functions (with conflicting names)",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
+		expectEmptyPlan: true,
+	},
+	{
+		name:         "Create functions (with conflicting names)",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
 
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-    },
-    {
-        name:         "Create functions with quoted names (with conflicting names)",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION "some add"(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-    },
-    {
-        name:         "Create non-sql function",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name:         "Create function with dependencies",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+	},
+	{
+		name:         "Create functions with quoted names (with conflicting names)",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION "some add"(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+	},
+	{
+		name:         "Create non-sql function",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name:         "Create function with dependencies",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + "increment func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + "increment func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
 
-            -- identical function on a different schem
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b); 
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Create function with an extension that also creates functions installed",
-        oldSchemaDDL: []string{
-            `
-            CREATE EXTENSION amcheck;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE EXTENSION amcheck;
+			-- identical function on a different schem
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b); 
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Create function with an extension that also creates functions installed",
+		oldSchemaDDL: []string{
+			`
+			CREATE EXTENSION amcheck;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE EXTENSION amcheck;
 
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            `,
-        },
-    },
-    {
-        name: "Drop functions (with conflicting names)",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-        newSchemaDDL: nil,
-    },
-    {
-        name: "Drop functions with quoted names (with conflicting names)",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION "some add"(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-        newSchemaDDL: nil,
-    },
-    {
-        name: "Drop non-sql function",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
-        newSchemaDDL:        nil,
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Drop function with dependencies",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			`,
+		},
+	},
+	{
+		name: "Drop functions (with conflicting names)",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+		newSchemaDDL: nil,
+	},
+	{
+		name: "Drop functions with quoted names (with conflicting names)",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION "some add"(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+		newSchemaDDL: nil,
+	},
+	{
+		name: "Drop non-sql function",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
+		newSchemaDDL:        nil,
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Drop function with dependencies",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + "increment func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + "increment func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
 
-            -- identical function on a different schema to ensure schemas are specified correctly
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b); 
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Add and drop functions with dependencies (conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			-- identical function on a different schema to ensure schemas are specified correctly
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b); 
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Add and drop functions with dependencies (conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + schema_1."increment func"(a);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + schema_1."increment func"(a);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_2.add(a, b) + schema_2."increment func"(a);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Alter functions (with conflicting names)",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + a + b;
-            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(CONCAT(a, a), b);
-            `,
-        },
-    },
-    {
-        name: "Alter functions with quoted names (with conflicting names)",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + a + b;
-            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(CONCAT(a, a), b);
-            `,
-        },
-    },
-    {
-        name: "Alter non-sql function",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 5;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Alter sql function to be non-sql function",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION some_func(i integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURN i + 5;
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Alter non-sql function to be sql function (no dependency tracking error)",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION some_func(i integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURN i + 5;
-        `},
-    },
-    {
-        name: "Alter a function's dependencies",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_2.add(a, b) + schema_2."increment func"(a);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Alter functions (with conflicting names)",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + a + b;
+			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(CONCAT(a, a), b);
+			`,
+		},
+	},
+	{
+		name: "Alter functions with quoted names (with conflicting names)",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + a + b;
+			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(CONCAT(a, a), b);
+			`,
+		},
+	},
+	{
+		name: "Alter non-sql function",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 5;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Alter sql function to be non-sql function",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION some_func(i integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURN i + 5;
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Alter non-sql function to be sql function (no dependency tracking error)",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION some_func(i integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURN i + 5;
+		`},
+	},
+	{
+		name: "Alter a function's dependencies",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-        CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+		CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "decrement func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "decrement func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Alter a dependent function",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Alter a dependent function",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
-                    BEGIN
-                            RETURN i + 5;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
+					BEGIN
+							RETURN i + 5;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Alter a function to no longer depend on a function and drop that function",
-        oldSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Alter a function to no longer depend on a function and drop that function",
+		oldSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestFunctionTestCases() {
-    suite.runTestCases(functionAcceptanceTestCases)
+	suite.runTestCases(functionAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -9,33 +9,33 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-            `,
+			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-            `,
+			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+			`,
 		},
 
 		expectEmptyPlan: true,
@@ -45,29 +45,29 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
 
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 	},
 	{
@@ -75,17 +75,17 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION "some add"(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION "some add"(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 	},
 	{
@@ -93,12 +93,12 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
@@ -106,76 +106,76 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + "increment func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + "increment func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
 
-            -- identical function on a different schem
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b); 
-        `},
+			-- identical function on a different schem
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b); 
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Create function with an extension that also creates functions installed",
 		oldSchemaDDL: []string{
 			`
-            CREATE EXTENSION amcheck;
-            `,
+			CREATE EXTENSION amcheck;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE EXTENSION amcheck;
+			CREATE EXTENSION amcheck;
 
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            `,
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			`,
 		},
 	},
 	{
 		name: "Drop functions (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 		newSchemaDDL: nil,
 	},
@@ -183,17 +183,17 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop functions with quoted names (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION "some add"(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION "some add"(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 		newSchemaDDL: nil,
 	},
@@ -201,12 +201,12 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop non-sql function",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
 		newSchemaDDL:        nil,
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -214,40 +214,40 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop function with dependencies",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + "increment func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + "increment func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
 
-            -- identical function on a different schema to ensure schemas are specified correctly
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b); 
-            `,
+			-- identical function on a different schema to ensure schemas are specified correctly
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b); 
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -255,47 +255,47 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop functions with dependencies (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE SCHEMA schema_1;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + schema_1."increment func"(a);
-            `,
+			CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + schema_1."increment func"(a);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_2.add(a, b) + schema_2."increment func"(a);
-            `,
+			CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_2.add(a, b) + schema_2."increment func"(a);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -303,184 +303,184 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter functions (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + a + b;
-            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(CONCAT(a, a), b);
-            `,
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + a + b;
+			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(CONCAT(a, a), b);
+			`,
 		},
 	},
 	{
 		name: "Alter functions with quoted names (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
-            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
+			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + a + b;
-            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(CONCAT(a, a), b);
-            `,
+			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + a + b;
+			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(CONCAT(a, a), b);
+			`,
 		},
 	},
 	{
 		name: "Alter non-sql function",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 5;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
+			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 5;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Alter sql function to be non-sql function",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION some_func(i integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURN i + 5;
-        `},
+			CREATE FUNCTION some_func(i integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURN i + 5;
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
+			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Alter non-sql function to be sql function (no dependency tracking error)",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
-        `},
+			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION some_func(i integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURN i + 5;
-        `},
+			CREATE FUNCTION some_func(i integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURN i + 5;
+		`},
 	},
 	{
 		name: "Alter a function's dependencies",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-        CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+		CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "decrement func"(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "decrement func"(a);
 
-            -- function with conflicting name to ensure the deps specify param name
-            CREATE FUNCTION add(a text, b text) RETURNS text
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN CONCAT(a, b);
-            `,
+			-- function with conflicting name to ensure the deps specify param name
+			CREATE FUNCTION add(a text, b text) RETURNS text
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN CONCAT(a, b);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -488,45 +488,45 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter a dependent function",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
-            `,
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
-                    BEGIN
-                            RETURN i + 5;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
+					BEGIN
+							RETURN i + 5;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
-            `,
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -534,40 +534,40 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter a function to no longer depend on a function and drop that function",
 		oldSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b) + "increment func"(a);
-            `,
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b) + "increment func"(a);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE FUNCTION add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN add(a, b);
-            `,
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN add(a, b);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -9,32 +9,32 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 			`,
 		},
 
@@ -45,28 +45,28 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION schema_1.add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 	},
@@ -75,16 +75,16 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 	},
@@ -93,11 +93,11 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -106,39 +106,39 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			-- identical function on a different schem
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b); 
+            -- identical function on a different schem
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b); 
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -146,18 +146,18 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create function with an extension that also creates functions installed",
 		oldSchemaDDL: []string{
 			`
-			CREATE EXTENSION amcheck;
+            CREATE EXTENSION amcheck;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE EXTENSION amcheck;
+            CREATE EXTENSION amcheck;
 
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 			`,
 		},
 	},
@@ -165,16 +165,16 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop functions (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 		newSchemaDDL: nil,
@@ -183,16 +183,16 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop functions with quoted names (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 		newSchemaDDL: nil,
@@ -201,11 +201,11 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop non-sql function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 		`},
 		newSchemaDDL:        nil,
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -214,39 +214,39 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop function with dependencies",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 
-			-- identical function on a different schema to ensure schemas are specified correctly
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b); 
+            -- identical function on a different schema to ensure schemas are specified correctly
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b); 
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -255,46 +255,46 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop functions with dependencies (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_1;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION schema_1."increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + schema_1."increment func"(a);
+            CREATE FUNCTION schema_1.function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + schema_1."increment func"(a);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION schema_2."increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_2.add(a, b) + schema_2."increment func"(a);
+            CREATE FUNCTION schema_2.function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_2.add(a, b) + schema_2."increment func"(a);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -303,30 +303,30 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter functions (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + a + b;
-			CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(CONCAT(a, a), b);
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + a + b;
+            CREATE FUNCTION add(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(CONCAT(a, a), b);
 			`,
 		},
 	},
@@ -334,30 +334,30 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter functions with quoted names (with conflicting names)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
-			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
+            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + a + b;
-			CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(CONCAT(a, a), b);
+            CREATE FUNCTION "some add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + a + b;
+            CREATE FUNCTION "some add"(a TEXT, b TEXT) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(CONCAT(a, a), b);
 			`,
 		},
 	},
@@ -365,19 +365,19 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter non-sql function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 5;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION non_sql_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 5;
+                    END;
+            $$ LANGUAGE plpgsql;
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -385,18 +385,18 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter sql function to be non-sql function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURN i + 5;
+            CREATE FUNCTION some_func(i integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURN i + 5;
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -404,82 +404,82 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter non-sql function to be sql function (no dependency tracking error)",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION some_func(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION some_func(i integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURN i + 5;
+            CREATE FUNCTION some_func(i integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURN i + 5;
 		`},
 	},
 	{
 		name: "Alter a function's dependencies",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-		CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+        CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "decrement func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "decrement func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "decrement func"(a);
 
-			-- function with conflicting name to ensure the deps specify param name
-			CREATE FUNCTION add(a text, b text) RETURNS text
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN CONCAT(a, b);
+            -- function with conflicting name to ensure the deps specify param name
+            CREATE FUNCTION add(a text, b text) RETURNS text
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN CONCAT(a, b);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -488,44 +488,44 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter a dependent function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
-					BEGIN
-							RETURN i + 5;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS int AS $$
+                    BEGIN
+                            RETURN i + 5;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -534,39 +534,39 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter a function to no longer depend on a function and drop that function",
 		oldSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "increment func"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b) + "increment func"(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b) + "increment func"(a);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE FUNCTION add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN add(a, b);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN add(a, b);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -9,26 +9,26 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar TEXT UNIQUE ,
-				fizz INT
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar TEXT UNIQUE ,
+                fizz INT
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar TEXT UNIQUE ,
-				fizz INT
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar TEXT UNIQUE ,
+                fizz INT
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
 			`,
 		},
 
@@ -38,21 +38,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -63,19 +63,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a hash index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			CREATE INDEX some_idx ON foobar USING hash (id);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            CREATE INDEX some_idx ON foobar USING hash (id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -86,19 +86,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal index with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -109,19 +109,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -132,18 +132,18 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -154,16 +154,16 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
+            CREATE TABLE foobar(
+                id INT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT UNIQUE
-			);
+            CREATE TABLE foobar(
+                id INT UNIQUE
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -174,16 +174,16 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key on NOT NULL column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT NOT NULL PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -194,19 +194,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
 			`,
 		},
 	},
@@ -214,19 +214,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
 			`,
 		},
 	},
@@ -234,20 +234,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists but has a name different to the constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			-- This renames the index
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            -- This renames the index
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -259,20 +259,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists but has a name different to the constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			-- This renames the index
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            -- This renames the index
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -284,19 +284,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists but is not unique",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE INDEX foobar_idx ON foobar(id);
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE INDEX foobar_idx ON foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -308,19 +308,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists but is not unique",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE INDEX foobar_idx ON foobar(id);
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE INDEX foobar_idx ON foobar(id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -332,21 +332,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_inx ON schema_1.foobar(id, foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_inx ON schema_1.foobar(id, foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -357,18 +357,18 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index and columns (index dropped concurrently first)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar(foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -384,19 +384,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"Foo" VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -407,19 +407,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -430,16 +430,16 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
+            CREATE TABLE foobar(
+                id INT
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -451,16 +451,16 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT UNIQUE
-			);
+            CREATE TABLE foobar(
+                id INT UNIQUE
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
+            CREATE TABLE foobar(
+                id INT
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -472,34 +472,34 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and delete a normal index (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON schema_1.foobar(id, foo);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON schema_1.foobar(id, foo);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-				id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON schema_2.foobar(id, foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON schema_2.foobar(id, foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -511,22 +511,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index (with a really long name) columns",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -539,38 +539,38 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change indexes (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo BIGINT NOT NULL,
-				bar TEXt NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo BIGINT NOT NULL,
+                bar TEXt NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT PRIMARY KEY,
-				foo BIGINT NOT NULL,
-				bar TEXt NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo BIGINT NOT NULL,
+                bar TEXt NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -583,22 +583,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo)
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo)
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo)
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo)
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -611,22 +611,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index column ordering",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo, bar)
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo, bar)
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo DESC, bar)
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo DESC, bar)
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -639,19 +639,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-				bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT
-			);
+            CREATE TABLE foobar(
+                id INT
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -664,19 +664,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key and make old key nullable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL PRIMARY KEY,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT NOT NULL PRIMARY KEY,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo INT NOT NULL PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -690,18 +690,18 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key with quoted name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				"Id" INT NOT NULL PRIMARY KEY,
-				foo TEXT NOT NULL
-			);
+            CREATE TABLE "Foobar"(
+                "Id" INT NOT NULL PRIMARY KEY,
+                foo TEXT NOT NULL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				"Id" INT,
-				foo INT NOT NULL PRIMARY KEY
-			);
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -715,20 +715,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key when the original primary key constraint has a non-default name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo INT NOT NULL PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -742,22 +742,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter primary key columns (name stays same)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo INT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -770,20 +770,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				foo TEXT,
-				bar INT
-			);
-			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
-			CREATE INDEX old_idx ON foobar(bar);
+            CREATE TABLE foobar(
+                foo TEXT,
+                bar INT
+            );
+            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
+            CREATE INDEX old_idx ON foobar(bar);
 		`},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				foo TEXT,
-				bar INT
-			);
-			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
-			CREATE INDEX new_idx ON foobar(bar);
+            CREATE TABLE foobar(
+                foo TEXT,
+                bar INT
+            );
+            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
+            CREATE INDEX new_idx ON foobar(bar);
 		`},
 		expectedPlanDDL: []string{
 			"ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -1,804 +1,804 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var indexAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar TEXT UNIQUE ,
-				fizz INT
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar TEXT UNIQUE ,
-				fizz INT
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-			`,
-		},
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar TEXT UNIQUE ,
+                fizz INT
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar TEXT UNIQUE ,
+                fizz INT
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+            `,
+        },
 
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Add a normal index",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a hash index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			CREATE INDEX some_idx ON foobar USING hash (id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a normal index with quoted names",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a primary key",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT UNIQUE
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a primary key on NOT NULL column",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a primary key when the index already exists",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-			`,
-		},
-	},
-	{
-		name: "Add a unique constraint when the index already exists",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
-			`,
-		},
-	},
-	{
-		name: "Add a primary key when the index already exists but has a name different to the constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			-- This renames the index
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique constraint when the index already exists but has a name different to the constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			-- This renames the index
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a primary key when the index already exists but is not unique",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE INDEX foobar_idx ON foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique constraint when the index already exists but is not unique",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE INDEX foobar_idx ON foobar(id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Delete a normal index",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_inx ON schema_1.foobar(id, foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a normal index and columns (index dropped concurrently first)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar(foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-		expectedPlanDDL: []string{
-			"DROP INDEX CONCURRENTLY \"public\".\"some_idx\"",
-			"ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"foo\"",
-		},
-	},
-	{
-		name: "Delete a normal index with quoted names",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a unique index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a primary key",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a unique constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT UNIQUE
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Add and delete a normal index (conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON schema_1.foobar(id, foo);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON schema_2.foobar(id, foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Change an index (with a really long name) columns",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Change indexes (conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Add a normal index",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a hash index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            CREATE INDEX some_idx ON foobar USING hash (id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a normal index with quoted names",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a primary key",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT UNIQUE
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a primary key on NOT NULL column",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a primary key when the index already exists",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+            `,
+        },
+    },
+    {
+        name: "Add a unique constraint when the index already exists",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
+            `,
+        },
+    },
+    {
+        name: "Add a primary key when the index already exists but has a name different to the constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            -- This renames the index
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique constraint when the index already exists but has a name different to the constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            -- This renames the index
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a primary key when the index already exists but is not unique",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE INDEX foobar_idx ON foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique constraint when the index already exists but is not unique",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE INDEX foobar_idx ON foobar(id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Delete a normal index",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_inx ON schema_1.foobar(id, foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a normal index and columns (index dropped concurrently first)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar(foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+        expectedPlanDDL: []string{
+            "DROP INDEX CONCURRENTLY \"public\".\"some_idx\"",
+            "ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"foo\"",
+        },
+    },
+    {
+        name: "Delete a normal index with quoted names",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a unique index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a primary key",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a unique constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT UNIQUE
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Add and delete a normal index (conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON schema_1.foobar(id, foo);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON schema_2.foobar(id, foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Change an index (with a really long name) columns",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Change indexes (conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo BIGINT NOT NULL,
-			    bar TEXt NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo BIGINT NOT NULL,
+                bar TEXt NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo BIGINT NOT NULL,
-			    bar TEXt NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Change an index type",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo)
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo)
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Change an index column ordering",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo, bar)
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo DESC, bar)
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Delete columns and associated index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Switch primary key and make old key nullable",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL PRIMARY KEY,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Switch primary key with quoted name",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT NOT NULL PRIMARY KEY,
-				foo TEXT NOT NULL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT,
-			    foo INT NOT NULL PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Switch primary key when the original primary key constraint has a non-default name",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Alter primary key columns (name stays same)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Alter index columns (index replacement and prioritized builds)",
-		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-			    foo TEXT,
-			    bar INT
-			);
-			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
-			CREATE INDEX old_idx ON foobar(bar);
-		`},
-		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-			    foo TEXT,
-			    bar INT
-			);
-			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
-			CREATE INDEX new_idx ON foobar(bar);
-		`},
-		expectedPlanDDL: []string{
-			"ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
-			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar USING btree (bar)",
-			"CREATE INDEX CONCURRENTLY some_idx_with_a_very_long_name ON public.foobar USING btree (foo, bar)",
-			"DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
-			"DROP INDEX CONCURRENTLY \"public\".\"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo BIGINT NOT NULL,
+                bar TEXt NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Change an index type",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo)
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo)
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Change an index column ordering",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo, bar)
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo DESC, bar)
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Delete columns and associated index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Switch primary key and make old key nullable",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL PRIMARY KEY,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Switch primary key with quoted name",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                "Id" INT NOT NULL PRIMARY KEY,
+                foo TEXT NOT NULL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Switch primary key when the original primary key constraint has a non-default name",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Alter primary key columns (name stays same)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Alter index columns (index replacement and prioritized builds)",
+        oldSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                foo TEXT,
+                bar INT
+            );
+            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
+            CREATE INDEX old_idx ON foobar(bar);
+        `},
+        newSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                foo TEXT,
+                bar INT
+            );
+            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
+            CREATE INDEX new_idx ON foobar(bar);
+        `},
+        expectedPlanDDL: []string{
+            "ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
+            "CREATE INDEX CONCURRENTLY new_idx ON public.foobar USING btree (bar)",
+            "CREATE INDEX CONCURRENTLY some_idx_with_a_very_long_name ON public.foobar USING btree (foo, bar)",
+            "DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
+            "DROP INDEX CONCURRENTLY \"public\".\"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestIndexTestCases() {
-	suite.runTestCases(indexAcceptanceTestCases)
+    suite.runTestCases(indexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -9,27 +9,27 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar TEXT UNIQUE ,
-				fizz INT
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar TEXT UNIQUE ,
+                fizz INT
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar TEXT UNIQUE ,
-				fizz INT
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar TEXT UNIQUE ,
+                fizz INT
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+            `,
 		},
 
 		expectEmptyPlan: true,
@@ -38,22 +38,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -63,20 +63,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a hash index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			CREATE INDEX some_idx ON foobar USING hash (id);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            CREATE INDEX some_idx ON foobar USING hash (id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -86,20 +86,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal index with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -109,20 +109,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -132,19 +132,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -154,17 +154,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT UNIQUE
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT UNIQUE
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -174,17 +174,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key on NOT NULL column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT NOT NULL PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -194,61 +194,61 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+            `,
 		},
 	},
 	{
 		name: "Add a unique constraint when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
+            `,
 		},
 	},
 	{
 		name: "Add a primary key when the index already exists but has a name different to the constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			-- This renames the index
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            -- This renames the index
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -259,21 +259,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists but has a name different to the constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			-- This renames the index
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            -- This renames the index
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -284,20 +284,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists but is not unique",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE INDEX foobar_idx ON foobar(id);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE INDEX foobar_idx ON foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -308,20 +308,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists but is not unique",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE INDEX foobar_idx ON foobar(id);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE INDEX foobar_idx ON foobar(id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -332,22 +332,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_inx ON schema_1.foobar(id, foo);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_inx ON schema_1.foobar(id, foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255)
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -357,19 +357,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index and columns (index dropped concurrently first)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar(foo);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar(foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -384,20 +384,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255)
-			);
-			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255)
+            );
+            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -407,20 +407,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -430,17 +430,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -451,17 +451,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT UNIQUE
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT UNIQUE
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -472,35 +472,35 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and delete a normal index (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON schema_1.foobar(id, foo);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON schema_1.foobar(id, foo);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT PRIMARY KEY,
-				foo VARCHAR(255) NOT NULL
-			);
-			CREATE INDEX some_idx ON schema_2.foobar(id, foo);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255) NOT NULL
+            );
+            CREATE INDEX some_idx ON schema_2.foobar(id, foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -511,23 +511,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index (with a really long name) columns",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -539,39 +539,39 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change indexes (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo BIGINT NOT NULL,
-			    bar TEXt NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo BIGINT NOT NULL,
+                bar TEXt NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
-				foo BIGINT NOT NULL,
-			    bar TEXt NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo BIGINT NOT NULL,
+                bar TEXt NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -583,23 +583,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo)
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo)
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar USING hash (foo)
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar USING hash (foo)
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -611,23 +611,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index column ordering",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo, bar)
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo, bar)
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE INDEX some_idx ON foobar (foo DESC, bar)
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE INDEX some_idx ON foobar (foo DESC, bar)
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -639,20 +639,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo TEXT NOT NULL,
+                bar BIGINT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -664,20 +664,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key and make old key nullable",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL PRIMARY KEY,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foo);
-			`,
+            CREATE TABLE foobar(
+                id INT NOT NULL PRIMARY KEY,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -690,19 +690,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key with quoted name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT NOT NULL PRIMARY KEY,
-				foo TEXT NOT NULL
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                "Id" INT NOT NULL PRIMARY KEY,
+                foo TEXT NOT NULL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT,
-			    foo INT NOT NULL PRIMARY KEY
-			);
-			`,
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -715,21 +715,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key when the original primary key constraint has a non-default name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -742,23 +742,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter primary key columns (name stays same)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL
-			);
-			CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
-			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo INT NOT NULL
+            );
+            CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
+            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -770,21 +770,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-			    foo TEXT,
-			    bar INT
-			);
-			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
-			CREATE INDEX old_idx ON foobar(bar);
-		`},
+            CREATE TABLE foobar(
+                foo TEXT,
+                bar INT
+            );
+            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
+            CREATE INDEX old_idx ON foobar(bar);
+        `},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-			    foo TEXT,
-			    bar INT
-			);
-			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
-			CREATE INDEX new_idx ON foobar(bar);
-		`},
+            CREATE TABLE foobar(
+                foo TEXT,
+                bar INT
+            );
+            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
+            CREATE INDEX new_idx ON foobar(bar);
+        `},
 		expectedPlanDDL: []string{
 			"ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
 			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar USING btree (bar)",

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -9,27 +9,27 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar TEXT UNIQUE ,
-                fizz INT
-            );
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar TEXT UNIQUE ,
+				fizz INT
+			);
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar TEXT UNIQUE ,
-                fizz INT
-            );
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar TEXT UNIQUE ,
+				fizz INT
+			);
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+			`,
 		},
 
 		expectEmptyPlan: true,
@@ -38,22 +38,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal index",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -63,20 +63,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a hash index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            CREATE INDEX some_idx ON foobar USING hash (id);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			CREATE INDEX some_idx ON foobar USING hash (id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -86,20 +86,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal index with quoted names",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255)
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255)
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255)
-            );
-            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255)
+			);
+			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -109,20 +109,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -132,19 +132,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -154,17 +154,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT UNIQUE
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT UNIQUE
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -174,17 +174,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key on NOT NULL column",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT NOT NULL PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -194,61 +194,61 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+			`,
 		},
 	},
 	{
 		name: "Add a unique constraint when the index already exists",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
+			`,
 		},
 	},
 	{
 		name: "Add a primary key when the index already exists but has a name different to the constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            -- This renames the index
-            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			-- This renames the index
+			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -259,21 +259,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists but has a name different to the constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            -- This renames the index
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			-- This renames the index
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -284,20 +284,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists but is not unique",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE INDEX foobar_idx ON foobar(id);
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE INDEX foobar_idx ON foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -308,20 +308,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists but is not unique",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE INDEX foobar_idx ON foobar(id);
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE INDEX foobar_idx ON foobar(id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -332,22 +332,22 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_inx ON schema_1.foobar(id, foo);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_inx ON schema_1.foobar(id, foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -357,19 +357,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index and columns (index dropped concurrently first)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar(foo);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar(foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -384,20 +384,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal index with quoted names",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255)
-            );
-            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255)
+			);
+			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -407,20 +407,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -430,17 +430,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -451,17 +451,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT UNIQUE
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT UNIQUE
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -472,35 +472,35 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and delete a normal index (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_idx ON schema_1.foobar(id, foo);
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_idx ON schema_1.foobar(id, foo);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_idx ON schema_2.foobar(id, foo);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_idx ON schema_2.foobar(id, foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -511,23 +511,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index (with a really long name) columns",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -539,39 +539,39 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change indexes (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo BIGINT NOT NULL,
-                bar TEXt NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo BIGINT NOT NULL,
+			    bar TEXt NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo BIGINT NOT NULL,
-                bar TEXt NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo BIGINT NOT NULL,
+			    bar TEXt NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -583,23 +583,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index type",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar (foo)
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar (foo)
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar USING hash (foo)
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar USING hash (foo)
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -611,23 +611,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index column ordering",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar (foo, bar)
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar (foo, bar)
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar (foo DESC, bar)
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar (foo DESC, bar)
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -639,20 +639,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -664,20 +664,20 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key and make old key nullable",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL PRIMARY KEY,
-                foo TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo);
-            `,
+			CREATE TABLE foobar(
+			    id INT NOT NULL PRIMARY KEY,
+				foo TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo INT NOT NULL PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+			    foo INT NOT NULL PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -690,19 +690,19 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key with quoted name",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                "Id" INT NOT NULL PRIMARY KEY,
-                foo TEXT NOT NULL
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    "Id" INT NOT NULL PRIMARY KEY,
+				foo TEXT NOT NULL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                "Id" INT,
-                foo INT NOT NULL PRIMARY KEY
-            );
-            `,
+			CREATE TABLE "Foobar"(
+			    "Id" INT,
+			    foo INT NOT NULL PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -715,21 +715,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key when the original primary key constraint has a non-default name",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo INT NOT NULL PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+			    foo INT NOT NULL PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -742,23 +742,23 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter primary key columns (name stays same)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo INT NOT NULL
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
-            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+			    foo INT NOT NULL
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
+			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -770,21 +770,21 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds)",
 		oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                foo TEXT,
-                bar INT
-            );
-            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
-            CREATE INDEX old_idx ON foobar(bar);
-        `},
+			CREATE TABLE foobar(
+			    foo TEXT,
+			    bar INT
+			);
+			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
+			CREATE INDEX old_idx ON foobar(bar);
+		`},
 		newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                foo TEXT,
-                bar INT
-            );
-            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
-            CREATE INDEX new_idx ON foobar(bar);
-        `},
+			CREATE TABLE foobar(
+			    foo TEXT,
+			    bar INT
+			);
+			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
+			CREATE INDEX new_idx ON foobar(bar);
+		`},
 		expectedPlanDDL: []string{
 			"ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
 			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar USING btree (bar)",

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -1,804 +1,804 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var indexAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar TEXT UNIQUE ,
-                fizz INT
-            );
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar TEXT UNIQUE ,
-                fizz INT
-            );
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
-            `,
-        },
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar TEXT UNIQUE ,
+				fizz INT
+			);
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar TEXT UNIQUE ,
+				fizz INT
+			);
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar (bar DESC, fizz);
+			`,
+		},
 
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Add a normal index",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a hash index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            CREATE INDEX some_idx ON foobar USING hash (id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a normal index with quoted names",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255)
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255)
-            );
-            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a primary key",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT UNIQUE
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a primary key on NOT NULL column",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a primary key when the index already exists",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-            `,
-        },
-    },
-    {
-        name: "Add a unique constraint when the index already exists",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
-            `,
-        },
-    },
-    {
-        name: "Add a primary key when the index already exists but has a name different to the constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            -- This renames the index
-            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique constraint when the index already exists but has a name different to the constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            -- This renames the index
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a primary key when the index already exists but is not unique",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE INDEX foobar_idx ON foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique constraint when the index already exists but is not unique",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE INDEX foobar_idx ON foobar(id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            CREATE UNIQUE INDEX foobar_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Delete a normal index",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_inx ON schema_1.foobar(id, foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255)
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a normal index and columns (index dropped concurrently first)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar(foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-        expectedPlanDDL: []string{
-            "DROP INDEX CONCURRENTLY \"public\".\"some_idx\"",
-            "ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"foo\"",
-        },
-    },
-    {
-        name: "Delete a normal index with quoted names",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255)
-            );
-            CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a unique index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a primary key",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a unique constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT UNIQUE
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Add and delete a normal index (conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_idx ON schema_1.foobar(id, foo);
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT PRIMARY KEY,
-                foo VARCHAR(255) NOT NULL
-            );
-            CREATE INDEX some_idx ON schema_2.foobar(id, foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Change an index (with a really long name) columns",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Change indexes (conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Add a normal index",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a hash index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			CREATE INDEX some_idx ON foobar USING hash (id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a normal index with quoted names",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255)
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255)
+			);
+			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a primary key",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT UNIQUE
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a primary key on NOT NULL column",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a primary key when the index already exists",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+			`,
+		},
+	},
+	{
+		name: "Add a unique constraint when the index already exists",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
+			`,
+		},
+	},
+	{
+		name: "Add a primary key when the index already exists but has a name different to the constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			-- This renames the index
+			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_idx;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique constraint when the index already exists but has a name different to the constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			-- This renames the index
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_constraint UNIQUE USING INDEX foobar_idx;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a primary key when the index already exists but is not unique",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE INDEX foobar_idx ON foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique constraint when the index already exists but is not unique",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE INDEX foobar_idx ON foobar(id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Delete a normal index",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_inx ON schema_1.foobar(id, foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255)
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a normal index and columns (index dropped concurrently first)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar(foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+		expectedPlanDDL: []string{
+			"DROP INDEX CONCURRENTLY \"public\".\"some_idx\"",
+			"ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"foo\"",
+		},
+	},
+	{
+		name: "Delete a normal index with quoted names",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255)
+			);
+			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a unique index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foo VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a primary key",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a unique constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT UNIQUE
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Add and delete a normal index (conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_idx ON schema_1.foobar(id, foo);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
+			);
+			CREATE INDEX some_idx ON schema_2.foobar(id, foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Change an index (with a really long name) columns",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Change indexes (conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo BIGINT NOT NULL,
-                bar TEXt NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo BIGINT NOT NULL,
+			    bar TEXt NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT PRIMARY KEY,
-                foo BIGINT NOT NULL,
-                bar TEXt NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Change an index type",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar (foo)
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar USING hash (foo)
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Change an index column ordering",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar (foo, bar)
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE INDEX some_idx ON foobar (foo DESC, bar)
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Delete columns and associated index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foo TEXT NOT NULL,
-                bar BIGINT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Switch primary key and make old key nullable",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL PRIMARY KEY,
-                foo TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo INT NOT NULL PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Switch primary key with quoted name",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                "Id" INT NOT NULL PRIMARY KEY,
-                foo TEXT NOT NULL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                "Id" INT,
-                foo INT NOT NULL PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Switch primary key when the original primary key constraint has a non-default name",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo INT NOT NULL PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Alter primary key columns (name stays same)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(id);
-            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo INT NOT NULL
-            );
-            CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
-            ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Alter index columns (index replacement and prioritized builds)",
-        oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                foo TEXT,
-                bar INT
-            );
-            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
-            CREATE INDEX old_idx ON foobar(bar);
-        `},
-        newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                foo TEXT,
-                bar INT
-            );
-            CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
-            CREATE INDEX new_idx ON foobar(bar);
-        `},
-        expectedPlanDDL: []string{
-            "ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
-            "CREATE INDEX CONCURRENTLY new_idx ON public.foobar USING btree (bar)",
-            "CREATE INDEX CONCURRENTLY some_idx_with_a_very_long_name ON public.foobar USING btree (foo, bar)",
-            "DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
-            "DROP INDEX CONCURRENTLY \"public\".\"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT PRIMARY KEY,
+				foo BIGINT NOT NULL,
+			    bar TEXt NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Change an index type",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar (foo)
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar USING hash (foo)
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Change an index column ordering",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar (foo, bar)
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE INDEX some_idx ON foobar (foo DESC, bar)
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Delete columns and associated index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foo TEXT NOT NULL,
+			    bar BIGINT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Switch primary key and make old key nullable",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL PRIMARY KEY,
+				foo TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    foo INT NOT NULL PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Switch primary key with quoted name",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    "Id" INT NOT NULL PRIMARY KEY,
+				foo TEXT NOT NULL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    "Id" INT,
+			    foo INT NOT NULL PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Switch primary key when the original primary key constraint has a non-default name",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    foo INT NOT NULL PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Alter primary key columns (name stays same)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(id);
+			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+			    foo INT NOT NULL
+			);
+			CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
+			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Alter index columns (index replacement and prioritized builds)",
+		oldSchemaDDL: []string{`
+			CREATE TABLE foobar(
+			    foo TEXT,
+			    bar INT
+			);
+			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
+			CREATE INDEX old_idx ON foobar(bar);
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE foobar(
+			    foo TEXT,
+			    bar INT
+			);
+			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
+			CREATE INDEX new_idx ON foobar(bar);
+		`},
+		expectedPlanDDL: []string{
+			"ALTER INDEX \"public\".\"some_idx_with_a_very_long_name\" RENAME TO \"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
+			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar USING btree (bar)",
+			"CREATE INDEX CONCURRENTLY some_idx_with_a_very_long_name ON public.foobar USING btree (foo, bar)",
+			"DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
+			"DROP INDEX CONCURRENTLY \"public\".\"pgschemadiff_tmpidx_some_idx_with_a_very_EBESExQVRheYGRobHB0eHw\"",
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestIndexTestCases() {
-    suite.runTestCases(indexAcceptanceTestCases)
+	suite.runTestCases(indexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -10,7 +10,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar TEXT UNIQUE ,
 				fizz INT
@@ -22,7 +22,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255),
 				bar TEXT UNIQUE ,
 				fizz INT
@@ -40,7 +40,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			`,
@@ -49,7 +49,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
@@ -64,7 +64,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			`,
@@ -72,7 +72,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			CREATE INDEX some_idx ON foobar USING hash (id);
@@ -87,7 +87,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"Foo" VARCHAR(255)
 			);
 			`,
@@ -95,7 +95,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"Foo" VARCHAR(255)
 			);
 			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
@@ -110,16 +110,16 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
+				id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
+				id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
 			);
 			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
 			`,
@@ -134,7 +134,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT
+				id INT
 			);
 			`,
 		},
@@ -142,7 +142,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -155,14 +155,14 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT UNIQUE
+				id INT UNIQUE
 			);
 			`,
 		},
@@ -175,14 +175,14 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL
+				id INT NOT NULL
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL PRIMARY KEY
+				id INT NOT NULL PRIMARY KEY
 			);
 			`,
 		},
@@ -195,7 +195,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
 			`,
@@ -203,7 +203,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
@@ -215,7 +215,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
 			`,
@@ -223,7 +223,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(id);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_unique_idx;
@@ -235,7 +235,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
 			`,
@@ -243,7 +243,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
 			-- This renames the index
@@ -260,7 +260,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
 			`,
@@ -268,7 +268,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
 			-- This renames the index
@@ -285,7 +285,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE INDEX foobar_idx ON foobar(id);
 			`,
@@ -293,7 +293,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_primary_key ON foobar(id);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_primary_key PRIMARY KEY USING INDEX foobar_primary_key;
@@ -309,7 +309,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE INDEX foobar_idx ON foobar(id);
 			`,
@@ -317,7 +317,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			CREATE UNIQUE INDEX foobar_idx ON foobar(id);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_unique_idx UNIQUE USING INDEX foobar_idx;
@@ -334,7 +334,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) NOT NULL
 			);
 			CREATE INDEX some_inx ON schema_1.foobar(id, foo);
@@ -344,7 +344,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255)
 			);
 			`,
@@ -358,7 +358,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) NOT NULL
 			);
 			CREATE INDEX some_idx ON foobar(foo);
@@ -367,7 +367,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -385,7 +385,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"Foo" VARCHAR(255)
 			);
 			CREATE INDEX "Some_idx" ON "Foobar"(id, "Foo");
@@ -394,7 +394,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"Foo" VARCHAR(255) NOT NULL
 			);
 			`,
@@ -408,8 +408,8 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
+				id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
 			);
 			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo);
 			`,
@@ -417,8 +417,8 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foo VARCHAR(255) NOT NULL
+				id INT PRIMARY KEY,
+				foo VARCHAR(255) NOT NULL
 			);
 			`,
 		},
@@ -431,14 +431,14 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			`,
 		},
@@ -452,14 +452,14 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT UNIQUE
+				id INT UNIQUE
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			`,
 		},
@@ -474,14 +474,14 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) NOT NULL
 			);
 			CREATE INDEX some_idx ON schema_1.foobar(id, foo);
 			
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) NOT NULL
 			);
 			`,
@@ -490,13 +490,13 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) NOT NULL
 			);
 			
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo VARCHAR(255) NOT NULL
 			);
 			CREATE INDEX some_idx ON schema_2.foobar(id, foo);
@@ -512,9 +512,9 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo, bar)
 			`,
@@ -522,9 +522,9 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx_with_a_really_long_name_that_is_nearly_61_chars ON foobar(foo)
 			`,
@@ -540,17 +540,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo BIGINT NOT NULL,
-			    bar TEXt NOT NULL
+				bar TEXt NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo, bar)
 			`,
@@ -558,17 +558,17 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON foobar(foo);
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo BIGINT NOT NULL,
-			    bar TEXt NOT NULL
+				bar TEXt NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON schema_1.foobar(foo);
 			`,
@@ -584,9 +584,9 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE INDEX some_idx ON foobar (foo)
 			`,
@@ -594,9 +594,9 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE INDEX some_idx ON foobar USING hash (foo)
 			`,
@@ -612,9 +612,9 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE INDEX some_idx ON foobar (foo, bar)
 			`,
@@ -622,9 +622,9 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE INDEX some_idx ON foobar (foo DESC, bar)
 			`,
@@ -640,9 +640,9 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foo TEXT NOT NULL,
-			    bar BIGINT NOT NULL
+				bar BIGINT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON foobar(foo, bar);
 			`,
@@ -650,7 +650,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT
+				id INT
 			);
 			`,
 		},
@@ -665,7 +665,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL PRIMARY KEY,
+				id INT NOT NULL PRIMARY KEY,
 				foo TEXT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON foobar(foo);
@@ -674,8 +674,8 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL PRIMARY KEY
+				id INT,
+				foo INT NOT NULL PRIMARY KEY
 			);
 			`,
 		},
@@ -691,7 +691,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    "Id" INT NOT NULL PRIMARY KEY,
+				"Id" INT NOT NULL PRIMARY KEY,
 				foo TEXT NOT NULL
 			);
 			`,
@@ -699,8 +699,8 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    "Id" INT,
-			    foo INT NOT NULL PRIMARY KEY
+				"Id" INT,
+				foo INT NOT NULL PRIMARY KEY
 			);
 			`,
 		},
@@ -716,7 +716,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo TEXT NOT NULL
 			);
 			CREATE UNIQUE INDEX unique_idx ON foobar(id);
@@ -726,8 +726,8 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL PRIMARY KEY
+				id INT,
+				foo INT NOT NULL PRIMARY KEY
 			);
 			`,
 		},
@@ -743,7 +743,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo TEXT NOT NULL
 			);
 			CREATE UNIQUE INDEX unique_idx ON foobar(id);
@@ -753,8 +753,8 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
-			    foo INT NOT NULL
+				id INT,
+				foo INT NOT NULL
 			);
 			CREATE UNIQUE INDEX unique_idx ON foobar(id, foo);
 			ALTER TABLE foobar ADD CONSTRAINT non_default_primary_key PRIMARY KEY USING INDEX unique_idx;
@@ -771,16 +771,16 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter index columns (index replacement and prioritized builds)",
 		oldSchemaDDL: []string{`
 			CREATE TABLE foobar(
-			    foo TEXT,
-			    bar INT
+				foo TEXT,
+				bar INT
 			);
 			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo);
 			CREATE INDEX old_idx ON foobar(bar);
 		`},
 		newSchemaDDL: []string{`
 			CREATE TABLE foobar(
-			    foo TEXT,
-			    bar INT
+				foo TEXT,
+				bar INT
 			);
 			CREATE INDEX some_idx_with_a_very_long_name ON foobar(foo, bar);
 			CREATE INDEX new_idx ON foobar(bar);

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -10,11 +10,11 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT,
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -27,11 +27,11 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT,
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -51,10 +51,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE SCHEMA schema_1;
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
@@ -66,10 +66,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			CREATE SCHEMA schema_1;
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
@@ -89,7 +89,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -100,7 +100,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -120,10 +120,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -135,15 +135,15 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
 				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
@@ -163,10 +163,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -176,13 +176,13 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar(
 				CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
@@ -202,10 +202,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -221,10 +221,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -245,10 +245,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -262,10 +262,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -283,14 +283,14 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
 				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
@@ -304,14 +304,14 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
 				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
@@ -330,7 +330,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
@@ -342,7 +342,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_3;
 			CREATE TABLE schema_3.foobar(
-			    id TEXT,
+				id TEXT,
 				foo INT
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_4;
@@ -357,7 +357,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
@@ -369,7 +369,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_3;
 			CREATE TABLE schema_3.foobar(
-			    id TEXT,
+				id TEXT,
 				foo INT
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_4;
@@ -390,7 +390,7 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -420,13 +420,13 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar(
 				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
@@ -437,9 +437,9 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
@@ -449,13 +449,13 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar(
 				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
@@ -466,13 +466,13 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
 				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
@@ -493,10 +493,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
+				bar TEXT NOT NULL,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
@@ -504,32 +504,32 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a table in a different schema where the index does not exist
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
+				bar TEXT NOT NULL,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 
 			-- Create a table in a different schema where the index does not exist
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
+				bar TEXT NOT NULL,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			`,
 		},
@@ -542,10 +542,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
@@ -554,10 +554,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
+				bar TEXT,
+				fizz bytea
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
@@ -570,10 +570,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
@@ -583,10 +583,10 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
+				bar TEXT,
+				fizz BYTEA
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -1,606 +1,606 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-			`,
-		},
+            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+            `,
+        },
 
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Add local indexes",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Add local indexes",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique local index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique local index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add local primary keys",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add local unique constraints",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Delete a local index",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add local primary keys",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add local unique constraints",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Delete a local index",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a unique local index",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a unique local index",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a primary key",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Change an index columns (with conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a primary key",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Change an index columns (with conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-			    id TEXT,
-				foo INT
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                id TEXT,
+                foo INT
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-			    id TEXT,
-				foo INT
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                id TEXT,
+                foo INT
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Delete columns and associated index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Delete columns and associated index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Switch primary key (add and drop) (conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Switch primary key (add and drop) (conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a primary key when the index already exists",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
-			
-			-- Create a table in a different schema where the index does not exist
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a primary key when the index already exists",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
+            
+            -- Create a table in a different schema where the index does not exist
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema where the index does not exist
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add a unique constraint when the index already exists",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
+            -- Create a table in a different schema where the index does not exist
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add a unique constraint when the index already exists",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
 
-			`,
-		},
-	},
-	{
-		name: "Switch partitioned index to local index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+    },
+    {
+        name: "Switch partitioned index to local index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX foobar_some_idx ON foobar(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE INDEX foobar_some_idx ON foobar(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
+            CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestLocalPartitionIndexTestCases() {
-	suite.runTestCases(localPartitionIndexAcceptanceTestCases)
+    suite.runTestCases(localPartitionIndexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -1,606 +1,606 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-            `,
-        },
+			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+			`,
+		},
 
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Add local indexes",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Add local indexes",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique local index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique local index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add local primary keys",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add local unique constraints",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Delete a local index",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add local primary keys",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add local unique constraints",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Delete a local index",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a unique local index",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a unique local index",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a primary key",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Change an index columns (with conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a primary key",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Change an index columns (with conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
 
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3.foobar(
-                id TEXT,
-                foo INT
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_4;
-            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3.foobar(
+			    id TEXT,
+				foo INT
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_4;
+			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
+			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
 
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3.foobar(
-                id TEXT,
-                foo INT
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_4;
-            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3.foobar(
+			    id TEXT,
+				foo INT
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_4;
+			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Delete columns and associated index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Delete columns and associated index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Switch primary key (add and drop) (conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Switch primary key (add and drop) (conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a primary key when the index already exists",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255) NOT NULL,
-                bar TEXT NOT NULL,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
-            
-            -- Create a table in a different schema where the index does not exist
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) NOT NULL,
-                bar TEXT NOT NULL,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a primary key when the index already exists",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255) NOT NULL,
+			    bar TEXT NOT NULL,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
+			
+			-- Create a table in a different schema where the index does not exist
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) NOT NULL,
+			    bar TEXT NOT NULL,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
 
-            -- Create a table in a different schema where the index does not exist
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) NOT NULL,
-                bar TEXT NOT NULL,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add a unique constraint when the index already exists",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
+			-- Create a table in a different schema where the index does not exist
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) NOT NULL,
+			    bar TEXT NOT NULL,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add a unique constraint when the index already exists",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
 
-            `,
-        },
-    },
-    {
-        name: "Switch partitioned index to local index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+	},
+	{
+		name: "Switch partitioned index to local index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE INDEX foobar_some_idx ON foobar(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE INDEX foobar_some_idx ON foobar(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
+			CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestLocalPartitionIndexTestCases() {
-    suite.runTestCases(localPartitionIndexAcceptanceTestCases)
+	suite.runTestCases(localPartitionIndexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -9,36 +9,36 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
 			`,
 		},
 
@@ -48,36 +48,36 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local indexes",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -88,26 +88,26 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -118,39 +118,39 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local primary keys",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -162,34 +162,34 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local unique constraints",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -200,39 +200,39 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -243,34 +243,34 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -281,42 +281,42 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -328,56 +328,56 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index columns (with conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-				id TEXT,
-				foo INT
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                id TEXT,
+                foo INT
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-				id TEXT,
-				foo INT
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                id TEXT,
+                foo INT
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -389,25 +389,25 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
+            CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -419,67 +419,67 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key (add and drop) (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -492,45 +492,45 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255) NOT NULL,
-				bar TEXT NOT NULL,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
-			
-			-- Create a table in a different schema where the index does not exist
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255) NOT NULL,
-				bar TEXT NOT NULL,
-				fizz bytea
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
+            
+            -- Create a table in a different schema where the index does not exist
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema where the index does not exist
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255) NOT NULL,
-				bar TEXT NOT NULL,
-				fizz bytea
-			) PARTITION BY LIST (foo);
+            -- Create a table in a different schema where the index does not exist
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -541,26 +541,26 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
 
 			`,
 		},
@@ -569,28 +569,28 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch partitioned index to local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX foobar_some_idx ON foobar(foo, id);
+            CREATE INDEX foobar_some_idx ON foobar(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+            CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -9,37 +9,37 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-            `,
+			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-            `,
+			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+			`,
 		},
 
 		expectEmptyPlan: true,
@@ -48,37 +48,37 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local indexes",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-            `,
+			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -88,27 +88,27 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique local index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
-            `,
+			CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -118,40 +118,40 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local primary keys",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -162,35 +162,35 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local unique constraints",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -200,40 +200,40 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a local index",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-            `,
+			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-            `,
+			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -243,35 +243,35 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique local index",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
-            `,
+			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -281,43 +281,43 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -328,57 +328,57 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index columns (with conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
 
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3.foobar(
-                id TEXT,
-                foo INT
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_4;
-            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3.foobar(
+			    id TEXT,
+				foo INT
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_4;
+			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
-            `,
+			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
+			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
 
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3.foobar(
-                id TEXT,
-                foo INT
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_4;
-            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3.foobar(
+			    id TEXT,
+				foo INT
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_4;
+			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
-            `,
+			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -389,26 +389,26 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
-            `,
+			CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -419,68 +419,68 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key (add and drop) (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
-                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-            ) FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
+				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+			) FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -492,46 +492,46 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255) NOT NULL,
-                bar TEXT NOT NULL,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
-            
-            -- Create a table in a different schema where the index does not exist
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) NOT NULL,
-                bar TEXT NOT NULL,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255) NOT NULL,
+			    bar TEXT NOT NULL,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
+			
+			-- Create a table in a different schema where the index does not exist
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) NOT NULL,
+			    bar TEXT NOT NULL,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
 
-            -- Create a table in a different schema where the index does not exist
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) NOT NULL,
-                bar TEXT NOT NULL,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            `,
+			-- Create a table in a different schema where the index does not exist
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) NOT NULL,
+			    bar TEXT NOT NULL,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -541,57 +541,57 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz bytea
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz bytea
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
 
-            `,
+			`,
 		},
 	},
 	{
 		name: "Switch partitioned index to local index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE INDEX foobar_some_idx ON foobar(foo, id);
-            `,
+			CREATE INDEX foobar_some_idx ON foobar(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz BYTEA
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    bar TEXT,
+			    fizz BYTEA
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-            `,
+			CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -9,37 +9,37 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-			`,
+            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
-			`,
+            CREATE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            CREATE UNIQUE INDEX foobar_2_some_unique_idx ON foobar_2 (foo);
+            `,
 		},
 
 		expectEmptyPlan: true,
@@ -48,37 +48,37 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local indexes",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-			`,
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -88,27 +88,27 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
-			`,
+            CREATE UNIQUE INDEX foobar_1_some_idx ON foobar_1 (foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -118,40 +118,40 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local primary keys",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -162,35 +162,35 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add local unique constraints",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" UNIQUE (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -200,40 +200,40 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-			`,
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_2_some_idx ON schema_2.foobar_2(foo, bar);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
-			CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
-			`,
+            CREATE INDEX foobar_1_some_idx ON schema_2.foobar_1(foo, id);
+            CREATE INDEX foobar_3_some_idx ON schema_2.foobar_3(foo, fizz);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -243,35 +243,35 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
-			`,
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -281,43 +281,43 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -328,57 +328,57 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index columns (with conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(foo, id);
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-			    id TEXT,
-				foo INT
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                id TEXT,
+                foo INT
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
-			`,
+            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
+            CREATE UNIQUE INDEX some_unique_idx ON schema_2.foobar_1(id, foo);
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-			    id TEXT,
-				foo INT
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
-			CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                id TEXT,
+                foo INT
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_4.foobar_2 PARTITION OF schema_3.foobar FOR VALUES IN (2);
+            CREATE TABLE schema_4.foobar_3 PARTITION OF schema_3.foobar FOR VALUES IN (3);
 
-			CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
-			`,
+            CREATE UNIQUE INDEX some_unique_idx ON schema_4.foobar_1(id, foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -389,26 +389,26 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
-			`,
+            CREATE UNIQUE INDEX some_unique_idx ON foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -419,68 +419,68 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key (add and drop) (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
-				CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
-			) FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar2_PRIMARY_KEY" PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_1.foobar_3 PARTITION OF schema_1.foobar(
+                CONSTRAINT "foobar3_PRIMARY_KEY" PRIMARY KEY (foo, fizz)
+            ) FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -492,46 +492,46 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
-			
-			-- Create a table in a different schema where the index does not exist
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX "foobar1_PRIMARY_KEY" ON foobar_1(foo, id);
+            
+            -- Create a table in a different schema where the index does not exist
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                CONSTRAINT "foobar1_PRIMARY_KEY" PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema where the index does not exist
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) NOT NULL,
-			    bar TEXT NOT NULL,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			`,
+            -- Create a table in a different schema where the index does not exist
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) NOT NULL,
+                bar TEXT NOT NULL,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -541,57 +541,57 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint when the index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique ON foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz bytea
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz bytea
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_unique UNIQUE (foo, id);
 
-			`,
+            `,
 		},
 	},
 	{
 		name: "Switch partitioned index to local index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX foobar_some_idx ON foobar(foo, id);
-			`,
+            CREATE INDEX foobar_some_idx ON foobar(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    bar TEXT,
-			    fizz BYTEA
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz BYTEA
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-			`,
+            CREATE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -4,34 +4,34 @@ var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "no op",
 		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";
-			CREATE SCHEMA "schema 2";
-		`},
+            CREATE SCHEMA "schema 1";
+            CREATE SCHEMA "schema 2";
+        `},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";
-		`},
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";
+        `},
 		expectEmptyPlan: true,
 	},
 	{
 		name: "create schema",
 		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-		`},
+            CREATE SCHEMA "schema 1";    
+        `},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";	
-		`},
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";    
+        `},
 	},
 	{
 		name: "Drop schema",
 		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";	
-		`},
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";    
+        `},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-		`},
+            CREATE SCHEMA "schema 1";    
+        `},
 	},
 }
 

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -4,33 +4,33 @@ var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "no op",
 		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";
-			CREATE SCHEMA "schema 2";
+            CREATE SCHEMA "schema 1";
+            CREATE SCHEMA "schema 2";
 		`},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";
 		`},
 		expectEmptyPlan: true,
 	},
 	{
 		name: "create schema",
 		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
+            CREATE SCHEMA "schema 1";    
 		`},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";	
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";    
 		`},
 	},
 	{
 		name: "Drop schema",
 		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";	
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";    
 		`},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
+            CREATE SCHEMA "schema 1";    
 		`},
 	},
 }

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -1,40 +1,40 @@
 package migration_acceptance_tests
 
 var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "no op",
-		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";
-			CREATE SCHEMA "schema 2";
-		`},
-		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";
-		`},
-		expectEmptyPlan: true,
-	},
-	{
-		name: "create schema",
-		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-		`},
-		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";	
-		`},
-	},
-	{
-		name: "Drop schema",
-		oldSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-			CREATE SCHEMA "schema 2";	
-		`},
-		newSchemaDDL: []string{`
-			CREATE SCHEMA "schema 1";	
-		`},
-	},
+    {
+        name: "no op",
+        oldSchemaDDL: []string{`
+            CREATE SCHEMA "schema 1";
+            CREATE SCHEMA "schema 2";
+        `},
+        newSchemaDDL: []string{`
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";
+        `},
+        expectEmptyPlan: true,
+    },
+    {
+        name: "create schema",
+        oldSchemaDDL: []string{`
+            CREATE SCHEMA "schema 1";    
+        `},
+        newSchemaDDL: []string{`
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";    
+        `},
+    },
+    {
+        name: "Drop schema",
+        oldSchemaDDL: []string{`
+            CREATE SCHEMA "schema 1";    
+            CREATE SCHEMA "schema 2";    
+        `},
+        newSchemaDDL: []string{`
+            CREATE SCHEMA "schema 1";    
+        `},
+    },
 }
 
 func (suite *acceptanceTestSuite) TestNamedSchemaTestCases() {
-	suite.runTestCases(namedSchemaAcceptanceTestCases)
+    suite.runTestCases(namedSchemaAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -1,40 +1,40 @@
 package migration_acceptance_tests
 
 var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "no op",
-        oldSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";
-            CREATE SCHEMA "schema 2";
-        `},
-        newSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-            CREATE SCHEMA "schema 2";
-        `},
-        expectEmptyPlan: true,
-    },
-    {
-        name: "create schema",
-        oldSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-        `},
-        newSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-            CREATE SCHEMA "schema 2";    
-        `},
-    },
-    {
-        name: "Drop schema",
-        oldSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-            CREATE SCHEMA "schema 2";    
-        `},
-        newSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-        `},
-    },
+	{
+		name: "no op",
+		oldSchemaDDL: []string{`
+			CREATE SCHEMA "schema 1";
+			CREATE SCHEMA "schema 2";
+		`},
+		newSchemaDDL: []string{`
+			CREATE SCHEMA "schema 1";	
+			CREATE SCHEMA "schema 2";
+		`},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "create schema",
+		oldSchemaDDL: []string{`
+			CREATE SCHEMA "schema 1";	
+		`},
+		newSchemaDDL: []string{`
+			CREATE SCHEMA "schema 1";	
+			CREATE SCHEMA "schema 2";	
+		`},
+	},
+	{
+		name: "Drop schema",
+		oldSchemaDDL: []string{`
+			CREATE SCHEMA "schema 1";	
+			CREATE SCHEMA "schema 2";	
+		`},
+		newSchemaDDL: []string{`
+			CREATE SCHEMA "schema 1";	
+		`},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestNamedSchemaTestCases() {
-    suite.runTestCases(namedSchemaAcceptanceTestCases)
+	suite.runTestCases(namedSchemaAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -4,34 +4,34 @@ var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "no op",
 		oldSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";
-            CREATE SCHEMA "schema 2";
-        `},
+			CREATE SCHEMA "schema 1";
+			CREATE SCHEMA "schema 2";
+		`},
 		newSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-            CREATE SCHEMA "schema 2";
-        `},
+			CREATE SCHEMA "schema 1";	
+			CREATE SCHEMA "schema 2";
+		`},
 		expectEmptyPlan: true,
 	},
 	{
 		name: "create schema",
 		oldSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-        `},
+			CREATE SCHEMA "schema 1";	
+		`},
 		newSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-            CREATE SCHEMA "schema 2";    
-        `},
+			CREATE SCHEMA "schema 1";	
+			CREATE SCHEMA "schema 2";	
+		`},
 	},
 	{
 		name: "Drop schema",
 		oldSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-            CREATE SCHEMA "schema 2";    
-        `},
+			CREATE SCHEMA "schema 1";	
+			CREATE SCHEMA "schema 2";	
+		`},
 		newSchemaDDL: []string{`
-            CREATE SCHEMA "schema 1";    
-        `},
+			CREATE SCHEMA "schema 1";	
+		`},
 	},
 }
 

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -1,1233 +1,1233 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-			`,
-		},
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Add a normal partitioned index",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE schema schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE schema schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+            `,
+        },
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Add a normal partitioned index",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a hash index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a hash index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique partitioned index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a normal partitioned index with quotes names",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				"Foo" VARCHAR(255)
-			) PARTITION BY LIST ("Foo");
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				"Foo" VARCHAR(255)
-			) PARTITION BY LIST ("Foo");
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique partitioned index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a normal partitioned index with quotes names",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT,
+                "Foo" VARCHAR(255)
+            ) PARTITION BY LIST ("Foo");
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT,
+                "Foo" VARCHAR(255)
+            ) PARTITION BY LIST ("Foo");
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a primary key",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-				UNIQUE(foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a partitioned index that is used by a local primary key",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
-			ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-			ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
+            CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a primary key",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                UNIQUE(foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a partitioned index that is used by a local primary key",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
+            ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+            ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add a primary key with quoted names",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT,
-				"FOO" VARCHAR(255)
-			) PARTITION BY LIST ("FOO");
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT,
-				"FOO" VARCHAR(255)
-			) PARTITION BY LIST ("FOO");
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-			ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a partitioned primary key when the local index already exists",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add a primary key with quoted names",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                "FOO" VARCHAR(255)
+            ) PARTITION BY LIST ("FOO");
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                "FOO" VARCHAR(255)
+            ) PARTITION BY LIST ("FOO");
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a partitioned primary key when the local index already exists",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a partitioned unique constraint when the local index already exists",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a partitioned unique constraint when the local index already exists",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Add a unique index when the local index already exists",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Add a unique index when the local index already exists",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Delete a normal partitioned index",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON schema_1.foobar(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a unique partitioned index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a primary key",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Delete a unique constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    UNIQUE (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Local index and columns deleted (index dropped first)",
-		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Delete a normal partitioned index",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON schema_1.foobar(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a unique partitioned index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a primary key",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Delete a unique constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                UNIQUE (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Local index and columns deleted (index dropped first)",
+        oldSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-			
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE schema schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-		`},
-		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeDeletesData,
-		},
-		expectedPlanDDL: []string{
-			"DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
-			"DROP INDEX \"public\".\"some_idx\"",
-			"ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"id\"",
-			"DROP TABLE \"schema_1\".\"foobar\"",
-			"DROP SCHEMA \"schema_1\"",
-		},
-	},
-	{
-		name: "Alter index columns (index replacement and prioritized builds)",
-		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE schema schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+        `},
+        newSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeDeletesData,
+        },
+        expectedPlanDDL: []string{
+            "DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
+            "DROP INDEX \"public\".\"some_idx\"",
+            "ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"id\"",
+            "DROP TABLE \"schema_1\".\"foobar\"",
+            "DROP SCHEMA \"schema_1\"",
+        },
+    },
+    {
+        name: "Alter index columns (index replacement and prioritized builds)",
+        oldSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX old_idx ON foobar_1(foo, bar);
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-		`},
-		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+        `},
+        newSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-			CREATE INDEX new_idx ON foobar_1(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+            CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-		expectedPlanDDL: []string{
-			"ALTER INDEX \"public\".\"some_idx\" RENAME TO \"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"id\" IS NOT NULL) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\" CHECK(\"foo\" IS NOT NULL) NOT VALID",
-			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foo\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"id\" SET NOT NULL",
-			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
-			"ALTER TABLE ONLY \"public\".\"foobar\" ADD CONSTRAINT \"some_idx\" PRIMARY KEY (foo, id)",
-			"CREATE UNIQUE INDEX CONCURRENTLY foobar_1_pkey ON public.foobar_1 USING btree (foo, id)",
-			"ALTER TABLE \"public\".\"foobar_1\" ADD CONSTRAINT \"foobar_1_pkey\" PRIMARY KEY USING INDEX \"foobar_1_pkey\"",
-			"ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_1_pkey\"",
-			"CREATE INDEX CONCURRENTLY new_foobar_1_some_local_idx ON public.foobar_1 USING btree (foo, bar, id)",
-			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar_1 USING btree (foo, bar)",
-			"CREATE UNIQUE INDEX CONCURRENTLY foobar_2_pkey ON public.foobar_2 USING btree (foo, id)",
-			"ALTER TABLE \"public\".\"foobar_2\" ADD CONSTRAINT \"foobar_2_pkey\" PRIMARY KEY USING INDEX \"foobar_2_pkey\"",
-			"ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_2_pkey\"",
-			"DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
-			"DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
-			"DROP INDEX \"public\".\"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
-		},
-	},
-	{
-		name: "Alter index columns (index replacement and prioritized builds) (conflicting schemas)",
-		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+        expectedPlanDDL: []string{
+            "ALTER INDEX \"public\".\"some_idx\" RENAME TO \"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"id\" IS NOT NULL) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\" CHECK(\"foo\" IS NOT NULL) NOT VALID",
+            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foo\" SET NOT NULL",
+            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"id\" SET NOT NULL",
+            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
+            "ALTER TABLE ONLY \"public\".\"foobar\" ADD CONSTRAINT \"some_idx\" PRIMARY KEY (foo, id)",
+            "CREATE UNIQUE INDEX CONCURRENTLY foobar_1_pkey ON public.foobar_1 USING btree (foo, id)",
+            "ALTER TABLE \"public\".\"foobar_1\" ADD CONSTRAINT \"foobar_1_pkey\" PRIMARY KEY USING INDEX \"foobar_1_pkey\"",
+            "ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_1_pkey\"",
+            "CREATE INDEX CONCURRENTLY new_foobar_1_some_local_idx ON public.foobar_1 USING btree (foo, bar, id)",
+            "CREATE INDEX CONCURRENTLY new_idx ON public.foobar_1 USING btree (foo, bar)",
+            "CREATE UNIQUE INDEX CONCURRENTLY foobar_2_pkey ON public.foobar_2 USING btree (foo, id)",
+            "ALTER TABLE \"public\".\"foobar_2\" ADD CONSTRAINT \"foobar_2_pkey\" PRIMARY KEY USING INDEX \"foobar_2_pkey\"",
+            "ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_2_pkey\"",
+            "DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
+            "DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
+            "DROP INDEX \"public\".\"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
+        },
+    },
+    {
+        name: "Alter index columns (index replacement and prioritized builds) (conflicting schemas)",
+        oldSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX old_idx ON foobar_1(foo, bar);
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-			-- Create a mirror schema that is also doing a similar operation
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar VARCHAR(255),
-				foo INT
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+            -- Create a mirror schema that is also doing a similar operation
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar VARCHAR(255),
+                foo INT
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-			CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
-			CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
+            CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
+            CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
 
-			CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-		`},
-		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+        `},
+        newSchemaDDL: []string{`
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-			CREATE INDEX new_idx ON foobar_1(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+            CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar VARCHAR(255),
-				foo INT
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar VARCHAR(255),
+                foo INT
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
-			CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
+            CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Change an index type",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Change an index type",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar(foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar(foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Change an index column ordering",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Change an index column ordering",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar (foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar (foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar (bar, foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Delete columns and associated index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar (bar, foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Delete columns and associated index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar(id, foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-		},
-	},
-	{
-		name: "Switch primary key",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Attach an unnattached, invalid index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar(id, foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+        },
+    },
+    {
+        name: "Switch primary key",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Attach an unnattached, invalid index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
-			`,
-		},
-	},
-	{
-		name: "Add primary key constraint with existing matching base-table index (matching child index does not exist)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
+            `,
+        },
+    },
+    {
+        name: "Add primary key constraint with existing matching base-table index (matching child index does not exist)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
-			-- so the primary key index effectively does not already exist when migrating
-			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            -- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
+            -- so the primary key index effectively does not already exist when migrating
+            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			// The parent table index is dropped and rebuilt
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add unique constraint with existing matching base-table index (matching child index does not exist)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            // The parent table index is dropped and rebuilt
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add unique constraint with existing matching base-table index (matching child index does not exist)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
-			-- so the primary key index effectively does not already exist when migrating
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            -- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
+            -- so the primary key index effectively does not already exist when migrating
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			// The parent table index is dropped and rebuilt
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add primary key constraint with existing matching base-table index (local matching child index exists)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            // The parent table index is dropped and rebuilt
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add primary key constraint with existing matching base-table index (local matching child index exists)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			// The parent table index is dropped and rebuilt
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add primary key constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            // The parent table index is dropped and rebuilt
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add primary key constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
-		},
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			`,
-		},
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			`,
-		},
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			// Base table index is dropped
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add unique constraint with existing matching base-table index (matching local PK already exists backed by local index)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            // Base table index is dropped
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add unique constraint with existing matching base-table index (matching local PK already exists backed by local index)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			// Base table index is dropped
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-		},
-	},
-	{
-		name: "Add primary key to partition using existing index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            // Base table index is dropped
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+        },
+    },
+    {
+        name: "Add primary key to partition using existing index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-			ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
-			`,
-		},
-	},
-	{
-		name: "Add unique constraint to partition using existing index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+            ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
+            `,
+        },
+    },
+    {
+        name: "Add unique constraint to partition using existing index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			`,
-		},
-	},
+            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            `,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestPartitionedIndexTestCases() {
-	suite.runTestCases(partitionedIndexAcceptanceTestCases)
+    suite.runTestCases(partitionedIndexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -9,36 +9,36 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
 			`,
 		},
 		expectEmptyPlan: true,
@@ -47,30 +47,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE schema schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE schema schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -81,26 +81,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a hash index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE INDEX some_idx ON foobar USING hash (foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -111,25 +111,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -140,26 +140,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal partitioned index with quotes names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT,
-				"Foo" VARCHAR(255)
-			) PARTITION BY LIST ("Foo");
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                id INT,
+                "Foo" VARCHAR(255)
+            ) PARTITION BY LIST ("Foo");
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT,
-				"Foo" VARCHAR(255)
-			) PARTITION BY LIST ("Foo");
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                id INT,
+                "Foo" VARCHAR(255)
+            ) PARTITION BY LIST ("Foo");
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
+            CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -170,25 +170,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -199,29 +199,29 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				UNIQUE(foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                UNIQUE(foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -232,34 +232,34 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned index that is used by a local primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
-			ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-			ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
+            ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+            ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -271,25 +271,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				"Id" INT,
-				"FOO" VARCHAR(255)
-			) PARTITION BY LIST ("FOO");
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                "FOO" VARCHAR(255)
+            ) PARTITION BY LIST ("FOO");
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				"Id" INT,
-				"FOO" VARCHAR(255)
-			) PARTITION BY LIST ("FOO");
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-			ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                "FOO" VARCHAR(255)
+            ) PARTITION BY LIST ("FOO");
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -300,41 +300,41 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned primary key when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-				id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-				id INT,
-				foo VARCHAR(255)
-			); 
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -346,41 +346,41 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned unique constraint when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-				id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-				id INT,
-				foo VARCHAR(255)
-			); 
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -392,42 +392,42 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique index when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-				id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-				id INT,
-				foo VARCHAR(255)
-			); 
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -438,29 +438,29 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON schema_1.foobar(foo, id);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON schema_1.foobar(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -472,25 +472,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -502,29 +502,29 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -536,25 +536,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				UNIQUE (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                UNIQUE (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -565,33 +565,33 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Local index and columns deleted (index dropped first)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-			
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE schema schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE schema schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 		`},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -609,34 +609,34 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX old_idx ON foobar_1(foo, bar);
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 		`},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-			CREATE INDEX new_idx ON foobar_1(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+            CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -670,65 +670,65 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds) (conflicting schemas)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX old_idx ON foobar_1(foo, bar);
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-			-- Create a mirror schema that is also doing a similar operation
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar VARCHAR(255),
-				foo INT
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+            -- Create a mirror schema that is also doing a similar operation
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar VARCHAR(255),
+                foo INT
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-			CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
-			CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
+            CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
+            CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
 
-			CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+            CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
 		`},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-			CREATE INDEX new_idx ON foobar_1(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+            CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar VARCHAR(255),
-				foo INT
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar VARCHAR(255),
+                foo INT
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
-			CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
+            CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+            CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -740,30 +740,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar(foo);
+            CREATE INDEX some_idx ON foobar(foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE INDEX some_idx ON foobar USING hash (foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -776,30 +776,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index column ordering",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar (foo, bar);
+            CREATE INDEX some_idx ON foobar (foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar (bar, foo);
+            CREATE INDEX some_idx ON foobar (bar, foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -812,25 +812,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar(id, foo);
+            CREATE INDEX some_idx ON foobar(id, foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -843,26 +843,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -875,47 +875,47 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Attach an unnattached, invalid index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
+            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
 			`,
 		},
 	},
@@ -923,26 +923,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (matching child index does not exist)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
-			-- so the primary key index effectively does not already exist when migrating
-			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+            -- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
+            -- so the primary key index effectively does not already exist when migrating
+            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -956,26 +956,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching child index does not exist)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
-			-- so the primary key index effectively does not already exist when migrating
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+            -- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
+            -- so the primary key index effectively does not already exist when migrating
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -989,26 +989,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (local matching child index exists)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
+            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -1022,25 +1022,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
+            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
 			`,
 		},
 
@@ -1050,27 +1050,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
 			`,
 		},
 
@@ -1080,27 +1080,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
 			`,
 		},
 
@@ -1110,25 +1110,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
+            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -1141,25 +1141,25 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching local PK already exists backed by local index)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -1172,28 +1172,28 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key to partition using existing index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-			ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
+            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+            ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
 			`,
 		},
 	},
@@ -1201,28 +1201,28 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint to partition using existing index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
 			`,
 		},
 	},

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -10,11 +10,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT,
-			    PRIMARY KEY (foo, id),
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -27,12 +27,12 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT,
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -49,7 +49,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE schema schema_2;
@@ -62,7 +62,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE schema schema_2;
@@ -82,7 +82,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -93,7 +93,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -112,7 +112,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -123,7 +123,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -141,7 +141,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT,
+				id INT,
 				"Foo" VARCHAR(255)
 			) PARTITION BY LIST ("Foo");
 			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
@@ -152,7 +152,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT,
+				id INT,
 				"Foo" VARCHAR(255)
 			) PARTITION BY LIST ("Foo");
 			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
@@ -171,7 +171,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -182,9 +182,9 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -201,7 +201,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
@@ -214,7 +214,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				UNIQUE(foo, id)
 			) PARTITION BY LIST (foo);
@@ -234,7 +234,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -244,7 +244,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -256,7 +256,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a table in a different schema to ensure that dependencies are correctly set
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
@@ -272,7 +272,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    "Id" INT,
+				"Id" INT,
 				"FOO" VARCHAR(255)
 			) PARTITION BY LIST ("FOO");
 			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
@@ -283,7 +283,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    "Id" INT,
+				"Id" INT,
 				"FOO" VARCHAR(255)
 			) PARTITION BY LIST ("FOO");
 			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
@@ -301,7 +301,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -311,7 +311,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
@@ -320,7 +320,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a table in a different schema to ensure that dependencies are correctly set
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -328,11 +328,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a flattened version of the table in a different schema
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			); 
 			CREATE TABLE schema_2.foobar_1(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			); 
 			`,
@@ -347,7 +347,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -357,7 +357,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
@@ -366,7 +366,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a table in a different schema to ensure that dependencies are correctly set
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -374,11 +374,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a flattened version of the table in a different schema
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			); 
 			CREATE TABLE schema_2.foobar_1(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			); 
 			`,
@@ -393,7 +393,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -403,7 +403,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
@@ -413,7 +413,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a table in a different schema to ensure that dependencies are correctly set
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
@@ -421,11 +421,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			-- Create a flattened version of the table in a different schema
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			); 
 			CREATE TABLE schema_2.foobar_1(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			); 
 			`,
@@ -440,7 +440,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
@@ -454,7 +454,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
@@ -473,7 +473,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -485,7 +485,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -504,7 +504,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
@@ -518,7 +518,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE SCHEMA schema_2;
@@ -537,9 +537,9 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    UNIQUE (foo, id)
+				UNIQUE (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -549,7 +549,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -741,7 +741,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 			   	bar INT
 			) PARTITION BY LIST (foo);
@@ -755,7 +755,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 			   	bar INT
 			) PARTITION BY LIST (foo);
@@ -777,7 +777,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 			   	bar INT
 			) PARTITION BY LIST (foo);
@@ -791,7 +791,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 			   	bar INT
 			) PARTITION BY LIST (foo);
@@ -813,7 +813,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -844,9 +844,9 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
+				PRIMARY KEY (foo)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -856,9 +856,9 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
@@ -876,9 +876,9 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
+				PRIMARY KEY (foo)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
@@ -898,9 +898,9 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
+				PRIMARY KEY (foo)
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
@@ -924,7 +924,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -937,7 +937,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -957,7 +957,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -970,7 +970,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -990,7 +990,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1003,7 +1003,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1023,7 +1023,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1035,7 +1035,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1051,7 +1051,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1065,7 +1065,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1081,7 +1081,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1095,7 +1095,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1111,7 +1111,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1123,7 +1123,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1142,7 +1142,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1154,7 +1154,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1173,7 +1173,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1185,7 +1185,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1202,7 +1202,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
@@ -1214,7 +1214,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT NOT NULL,
+				id INT NOT NULL,
 				foo VARCHAR(255) NOT NULL
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -9,37 +9,37 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+			`,
 		},
 		expectEmptyPlan: true,
 	},
@@ -47,31 +47,31 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal partitioned index",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE schema schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE schema schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE schema schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE schema schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-            `,
+			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -81,27 +81,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a hash index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            `,
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -111,26 +111,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique partitioned index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -140,27 +140,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal partitioned index with quotes names",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT,
-                "Foo" VARCHAR(255)
-            ) PARTITION BY LIST ("Foo");
-            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT,
+				"Foo" VARCHAR(255)
+			) PARTITION BY LIST ("Foo");
+			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT,
-                "Foo" VARCHAR(255)
-            ) PARTITION BY LIST ("Foo");
-            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			CREATE TABLE "Foobar"(
+			    id INT,
+				"Foo" VARCHAR(255)
+			) PARTITION BY LIST ("Foo");
+			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-            CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
-            `,
+			CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -170,26 +170,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -199,30 +199,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                UNIQUE(foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+				UNIQUE(foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -232,35 +232,35 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned index that is used by a local primary key",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
-            ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-            ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
+			ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+			ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
-            `,
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -271,26 +271,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key with quoted names",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                "Id" INT,
-                "FOO" VARCHAR(255)
-            ) PARTITION BY LIST ("FOO");
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE "Foobar"(
+			    "Id" INT,
+				"FOO" VARCHAR(255)
+			) PARTITION BY LIST ("FOO");
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                "Id" INT,
-                "FOO" VARCHAR(255)
-            ) PARTITION BY LIST ("FOO");
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-            ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
-            `,
+			CREATE TABLE "Foobar"(
+			    "Id" INT,
+				"FOO" VARCHAR(255)
+			) PARTITION BY LIST ("FOO");
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -300,42 +300,42 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned primary key when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-            -- Create a flattened version of the table in a different schema
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            `,
+			-- Create a flattened version of the table in a different schema
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -346,42 +346,42 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned unique constraint when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-            -- Create a flattened version of the table in a different schema
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            `,
+			-- Create a flattened version of the table in a different schema
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -392,43 +392,43 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique index when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-            -- Create a flattened version of the table in a different schema
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            `,
+			-- Create a flattened version of the table in a different schema
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -438,30 +438,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal partitioned index",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            CREATE INDEX some_idx ON schema_1.foobar(foo, id);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON schema_1.foobar(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -472,26 +472,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique partitioned index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -502,30 +502,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -536,26 +536,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                UNIQUE (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    UNIQUE (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -565,34 +565,34 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Local index and columns deleted (index dropped first)",
 		oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE INDEX some_idx ON foobar(foo, id);
-            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-            
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE schema schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-        `},
+			CREATE INDEX some_idx ON foobar(foo, id);
+			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+			
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE schema schema_1;
+			CREATE TABLE schema_1.foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+		`},
 		newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-        `},
+			CREATE TABLE foobar(
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
@@ -609,35 +609,35 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds)",
 		oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            CREATE INDEX some_idx ON foobar(foo, id);
-            CREATE INDEX old_idx ON foobar_1(foo, bar);
+			CREATE INDEX some_idx ON foobar(foo, id);
+			CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-        `},
+			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+		`},
 		newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-            CREATE INDEX new_idx ON foobar_1(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+			CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-        `},
+			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
@@ -670,66 +670,66 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds) (conflicting schemas)",
 		oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            CREATE INDEX some_idx ON foobar(foo, id);
-            CREATE INDEX old_idx ON foobar_1(foo, bar);
+			CREATE INDEX some_idx ON foobar(foo, id);
+			CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-            -- Create a mirror schema that is also doing a similar operation
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                bar VARCHAR(255),
-                foo INT
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+			-- Create a mirror schema that is also doing a similar operation
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				id INT,
+				bar VARCHAR(255),
+				foo INT
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-            CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
-            CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
+			CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
+			CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
 
-            CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-        `},
+			CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+		`},
 		newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-            CREATE INDEX new_idx ON foobar_1(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+			CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                bar VARCHAR(255),
-                foo INT
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				id INT,
+				bar VARCHAR(255),
+				foo INT
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
-            CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
+			CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
 
-            CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-        `},
+			CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
@@ -740,31 +740,31 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index type",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar(foo);
-            `,
+			CREATE INDEX some_idx ON foobar(foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            `,
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -776,31 +776,31 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index column ordering",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar (foo, bar);
-            `,
+			CREATE INDEX some_idx ON foobar (foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar (bar, foo);
-            `,
+			CREATE INDEX some_idx ON foobar (bar, foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -812,26 +812,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar(id, foo);
-            `,
+			CREATE INDEX some_idx ON foobar(id, foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -843,27 +843,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -875,75 +875,75 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Attach an unnattached, invalid index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			CREATE TABLE "Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-            `,
+			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			CREATE TABLE "Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
-            `,
+			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
+			`,
 		},
 	},
 	{
 		name: "Add primary key constraint with existing matching base-table index (matching child index does not exist)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
-            -- so the primary key index effectively does not already exist when migrating
-            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-            `,
+			-- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
+			-- so the primary key index effectively does not already exist when migrating
+			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// The parent table index is dropped and rebuilt
@@ -956,27 +956,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching child index does not exist)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
-            -- so the primary key index effectively does not already exist when migrating
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
-            `,
+			-- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
+			-- so the primary key index effectively does not already exist when migrating
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// The parent table index is dropped and rebuilt
@@ -989,27 +989,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (local matching child index exists)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-            ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
-            `,
+			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+			ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// The parent table index is dropped and rebuilt
@@ -1022,26 +1022,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
-            `,
+			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1050,28 +1050,28 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
-            `,
+			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1080,28 +1080,28 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
-            `,
+			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1110,26 +1110,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
-            `,
+			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// Base table index is dropped
@@ -1141,26 +1141,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching local PK already exists backed by local index)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
-            `,
+			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            `,
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// Base table index is dropped
@@ -1172,58 +1172,58 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key to partition using existing index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-            `,
+			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-            ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
-            `,
+			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+			ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
+			`,
 		},
 	},
 	{
 		name: "Add unique constraint to partition using existing index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            `,
+			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
-            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-            `,
+			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
+			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+			`,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -1,1233 +1,1233 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-            `,
-        },
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Add a normal partitioned index",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE schema schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE schema schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT,
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Add a normal partitioned index",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE schema schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE schema schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a hash index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a hash index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique partitioned index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a normal partitioned index with quotes names",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT,
-                "Foo" VARCHAR(255)
-            ) PARTITION BY LIST ("Foo");
-            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT,
-                "Foo" VARCHAR(255)
-            ) PARTITION BY LIST ("Foo");
-            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique partitioned index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a normal partitioned index with quotes names",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT,
+				"Foo" VARCHAR(255)
+			) PARTITION BY LIST ("Foo");
+			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT,
+				"Foo" VARCHAR(255)
+			) PARTITION BY LIST ("Foo");
+			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-            CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a primary key",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                UNIQUE(foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a partitioned index that is used by a local primary key",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
-            ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-            ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
+			CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a primary key",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+				UNIQUE(foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a partitioned index that is used by a local primary key",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
+			ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+			ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add a primary key with quoted names",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                "Id" INT,
-                "FOO" VARCHAR(255)
-            ) PARTITION BY LIST ("FOO");
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                "Id" INT,
-                "FOO" VARCHAR(255)
-            ) PARTITION BY LIST ("FOO");
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-            ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a partitioned primary key when the local index already exists",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add a primary key with quoted names",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    "Id" INT,
+				"FOO" VARCHAR(255)
+			) PARTITION BY LIST ("FOO");
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    "Id" INT,
+				"FOO" VARCHAR(255)
+			) PARTITION BY LIST ("FOO");
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a partitioned primary key when the local index already exists",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-            -- Create a flattened version of the table in a different schema
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a partitioned unique constraint when the local index already exists",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			-- Create a flattened version of the table in a different schema
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a partitioned unique constraint when the local index already exists",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-            -- Create a flattened version of the table in a different schema
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Add a unique index when the local index already exists",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+			-- Create a flattened version of the table in a different schema
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a unique index when the local index already exists",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
 
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-            -- Create a flattened version of the table in a different schema
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                foo VARCHAR(255)
-            ); 
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Delete a normal partitioned index",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            CREATE INDEX some_idx ON schema_1.foobar(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a unique partitioned index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a primary key",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Delete a unique constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                UNIQUE (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Local index and columns deleted (index dropped first)",
-        oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			-- Create a flattened version of the table in a different schema
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				foo VARCHAR(255)
+			); 
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Delete a normal partitioned index",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON schema_1.foobar(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a unique partitioned index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a primary key",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255),
+				PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Delete a unique constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    UNIQUE (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Local index and columns deleted (index dropped first)",
+		oldSchemaDDL: []string{`
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE INDEX some_idx ON foobar(foo, id);
-            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-            
-            -- Create a table in a different schema to ensure that dependencies are correctly set
-            CREATE schema schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-        `},
-        newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeDeletesData,
-        },
-        expectedPlanDDL: []string{
-            "DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
-            "DROP INDEX \"public\".\"some_idx\"",
-            "ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"id\"",
-            "DROP TABLE \"schema_1\".\"foobar\"",
-            "DROP SCHEMA \"schema_1\"",
-        },
-    },
-    {
-        name: "Alter index columns (index replacement and prioritized builds)",
-        oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE INDEX some_idx ON foobar(foo, id);
+			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+			
+			-- Create a table in a different schema to ensure that dependencies are correctly set
+			CREATE schema schema_1;
+			CREATE TABLE schema_1.foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE foobar(
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeDeletesData,
+		},
+		expectedPlanDDL: []string{
+			"DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
+			"DROP INDEX \"public\".\"some_idx\"",
+			"ALTER TABLE \"public\".\"foobar\" DROP COLUMN \"id\"",
+			"DROP TABLE \"schema_1\".\"foobar\"",
+			"DROP SCHEMA \"schema_1\"",
+		},
+	},
+	{
+		name: "Alter index columns (index replacement and prioritized builds)",
+		oldSchemaDDL: []string{`
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            CREATE INDEX some_idx ON foobar(foo, id);
-            CREATE INDEX old_idx ON foobar_1(foo, bar);
+			CREATE INDEX some_idx ON foobar(foo, id);
+			CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-        `},
-        newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-            CREATE INDEX new_idx ON foobar_1(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+			CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-        expectedPlanDDL: []string{
-            "ALTER INDEX \"public\".\"some_idx\" RENAME TO \"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"id\" IS NOT NULL) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-            "ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\" CHECK(\"foo\" IS NOT NULL) NOT VALID",
-            "ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foo\" SET NOT NULL",
-            "ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"id\" SET NOT NULL",
-            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
-            "ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
-            "ALTER TABLE ONLY \"public\".\"foobar\" ADD CONSTRAINT \"some_idx\" PRIMARY KEY (foo, id)",
-            "CREATE UNIQUE INDEX CONCURRENTLY foobar_1_pkey ON public.foobar_1 USING btree (foo, id)",
-            "ALTER TABLE \"public\".\"foobar_1\" ADD CONSTRAINT \"foobar_1_pkey\" PRIMARY KEY USING INDEX \"foobar_1_pkey\"",
-            "ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_1_pkey\"",
-            "CREATE INDEX CONCURRENTLY new_foobar_1_some_local_idx ON public.foobar_1 USING btree (foo, bar, id)",
-            "CREATE INDEX CONCURRENTLY new_idx ON public.foobar_1 USING btree (foo, bar)",
-            "CREATE UNIQUE INDEX CONCURRENTLY foobar_2_pkey ON public.foobar_2 USING btree (foo, id)",
-            "ALTER TABLE \"public\".\"foobar_2\" ADD CONSTRAINT \"foobar_2_pkey\" PRIMARY KEY USING INDEX \"foobar_2_pkey\"",
-            "ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_2_pkey\"",
-            "DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
-            "DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
-            "DROP INDEX \"public\".\"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
-        },
-    },
-    {
-        name: "Alter index columns (index replacement and prioritized builds) (conflicting schemas)",
-        oldSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+		expectedPlanDDL: []string{
+			"ALTER INDEX \"public\".\"some_idx\" RENAME TO \"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\" CHECK(\"id\" IS NOT NULL) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+			"ALTER TABLE \"public\".\"foobar\" ADD CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\" CHECK(\"foo\" IS NOT NULL) NOT VALID",
+			"ALTER TABLE \"public\".\"foobar\" VALIDATE CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"foo\" SET NOT NULL",
+			"ALTER TABLE \"public\".\"foobar\" ALTER COLUMN \"id\" SET NOT NULL",
+			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_EBESExQVRheYGRobHB0eHw\"",
+			"ALTER TABLE \"public\".\"foobar\" DROP CONSTRAINT \"pgschemadiff_tmpnn_ICEiIyQlRieoKSorLC0uLw\"",
+			"ALTER TABLE ONLY \"public\".\"foobar\" ADD CONSTRAINT \"some_idx\" PRIMARY KEY (foo, id)",
+			"CREATE UNIQUE INDEX CONCURRENTLY foobar_1_pkey ON public.foobar_1 USING btree (foo, id)",
+			"ALTER TABLE \"public\".\"foobar_1\" ADD CONSTRAINT \"foobar_1_pkey\" PRIMARY KEY USING INDEX \"foobar_1_pkey\"",
+			"ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_1_pkey\"",
+			"CREATE INDEX CONCURRENTLY new_foobar_1_some_local_idx ON public.foobar_1 USING btree (foo, bar, id)",
+			"CREATE INDEX CONCURRENTLY new_idx ON public.foobar_1 USING btree (foo, bar)",
+			"CREATE UNIQUE INDEX CONCURRENTLY foobar_2_pkey ON public.foobar_2 USING btree (foo, id)",
+			"ALTER TABLE \"public\".\"foobar_2\" ADD CONSTRAINT \"foobar_2_pkey\" PRIMARY KEY USING INDEX \"foobar_2_pkey\"",
+			"ALTER INDEX \"public\".\"some_idx\" ATTACH PARTITION \"public\".\"foobar_2_pkey\"",
+			"DROP INDEX CONCURRENTLY \"public\".\"foobar_1_some_local_idx\"",
+			"DROP INDEX CONCURRENTLY \"public\".\"old_idx\"",
+			"DROP INDEX \"public\".\"pgschemadiff_tmpidx_some_idx_MDEyMzQ1Rje4OTo7PD0$Pw\"",
+		},
+	},
+	{
+		name: "Alter index columns (index replacement and prioritized builds) (conflicting schemas)",
+		oldSchemaDDL: []string{`
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            CREATE INDEX some_idx ON foobar(foo, id);
-            CREATE INDEX old_idx ON foobar_1(foo, bar);
+			CREATE INDEX some_idx ON foobar(foo, id);
+			CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-            -- Create a mirror schema that is also doing a similar operation
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                bar VARCHAR(255),
-                foo INT
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+			-- Create a mirror schema that is also doing a similar operation
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				id INT,
+				bar VARCHAR(255),
+				foo INT
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-            CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
-            CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
+			CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
+			CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
 
-            CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-        `},
-        newSchemaDDL: []string{`
-            CREATE TABLE foobar(
-                id INT,
-                bar INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE foobar(
+				id INT,
+				bar INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-            CREATE INDEX new_idx ON foobar_1(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+			CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                bar VARCHAR(255),
-                foo INT
-            ) PARTITION BY LIST (foo);
-            
-            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				id INT,
+				bar VARCHAR(255),
+				foo INT
+			) PARTITION BY LIST (foo);
+			
+			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
-            CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
+			CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
 
-            CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Change an index type",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Change an index type",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar(foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar(foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar USING hash (foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Change an index column ordering",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar USING hash (foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Change an index column ordering",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar (foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                   bar INT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar (foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			   	bar INT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar (bar, foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Delete columns and associated index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar (bar, foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Delete columns and associated index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-            CREATE INDEX some_idx ON foobar(id, foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-        },
-    },
-    {
-        name: "Switch primary key",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Attach an unnattached, invalid index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			CREATE INDEX some_idx ON foobar(id, foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+		},
+	},
+	{
+		name: "Switch primary key",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Attach an unnattached, invalid index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo)
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo)
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
-            `,
-        },
-    },
-    {
-        name: "Add primary key constraint with existing matching base-table index (matching child index does not exist)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
+			`,
+		},
+	},
+	{
+		name: "Add primary key constraint with existing matching base-table index (matching child index does not exist)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
-            -- so the primary key index effectively does not already exist when migrating
-            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			-- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
+			-- so the primary key index effectively does not already exist when migrating
+			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            // The parent table index is dropped and rebuilt
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add unique constraint with existing matching base-table index (matching child index does not exist)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			// The parent table index is dropped and rebuilt
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add unique constraint with existing matching base-table index (matching child index does not exist)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            -- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
-            -- so the primary key index effectively does not already exist when migrating
-            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			-- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
+			-- so the primary key index effectively does not already exist when migrating
+			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            // The parent table index is dropped and rebuilt
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add primary key constraint with existing matching base-table index (local matching child index exists)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			// The parent table index is dropped and rebuilt
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add primary key constraint with existing matching base-table index (local matching child index exists)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-            ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+			ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            // The parent table index is dropped and rebuilt
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add primary key constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			// The parent table index is dropped and rebuilt
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add primary key constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
-        },
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            `,
-        },
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            `,
-        },
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            // Base table index is dropped
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add unique constraint with existing matching base-table index (matching local PK already exists backed by local index)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			// Base table index is dropped
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add unique constraint with existing matching base-table index (matching local PK already exists backed by local index)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            // Base table index is dropped
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-        },
-    },
-    {
-        name: "Add primary key to partition using existing index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			// Base table index is dropped
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Add primary key to partition using existing index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-            ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
-            `,
-        },
-    },
-    {
-        name: "Add unique constraint to partition using existing index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+			ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
+			`,
+		},
+	},
+	{
+		name: "Add unique constraint to partition using existing index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT NOT NULL,
-                foo VARCHAR(255) NOT NULL
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT NOT NULL,
+				foo VARCHAR(255) NOT NULL
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
-            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-            `,
-        },
-    },
+			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
+			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+			`,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestPartitionedIndexTestCases() {
-    suite.runTestCases(partitionedIndexAcceptanceTestCases)
+	suite.runTestCases(partitionedIndexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -9,37 +9,37 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT,
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            CREATE UNIQUE INDEX some_other_idx ON foobar(foo DESC, fizz);
+            `,
 		},
 		expectEmptyPlan: true,
 	},
@@ -47,31 +47,31 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE schema schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE schema schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
-			`,
+            CREATE INDEX some_idx ON schema_1.foobar(id DESC, foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -81,27 +81,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a hash index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			`,
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -111,26 +111,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -140,27 +140,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a normal partitioned index with quotes names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				"Foo" VARCHAR(255)
-			) PARTITION BY LIST ("Foo");
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE "Foobar"(
+                id INT,
+                "Foo" VARCHAR(255)
+            ) PARTITION BY LIST ("Foo");
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				"Foo" VARCHAR(255)
-			) PARTITION BY LIST ("Foo");
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                id INT,
+                "Foo" VARCHAR(255)
+            ) PARTITION BY LIST ("Foo");
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
-			`,
+            CREATE INDEX "SOME_IDX" ON "Foobar"(id, "Foo");
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -170,26 +170,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -199,30 +199,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-				UNIQUE(foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                UNIQUE(foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -232,35 +232,35 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned index that is used by a local primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
-			ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-			ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX some_idx ON ONLY schema_1.foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON schema_1.foobar_1(foo, id);
+            ALTER TABLE schema_1.foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+            ALTER INDEX schema_1.some_idx ATTACH PARTITION schema_1.foobar_1_pkey;
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
-			`,
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_2.foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -271,26 +271,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a primary key with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT,
-				"FOO" VARCHAR(255)
-			) PARTITION BY LIST ("FOO");
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                "FOO" VARCHAR(255)
+            ) PARTITION BY LIST ("FOO");
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    "Id" INT,
-				"FOO" VARCHAR(255)
-			) PARTITION BY LIST ("FOO");
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
-			ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
-			`,
+            CREATE TABLE "Foobar"(
+                "Id" INT,
+                "FOO" VARCHAR(255)
+            ) PARTITION BY LIST ("FOO");
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            ALTER TABLE "Foobar" ADD CONSTRAINT "FOOBAR_PK" PRIMARY KEY("FOO", "Id")
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -300,42 +300,42 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned primary key when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			`,
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -346,42 +346,42 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a partitioned unique constraint when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_unique_idx ON foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			`,
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexDropped,
@@ -392,43 +392,43 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add a unique index when the local index already exists",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_1_foo_id_idx ON foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
 
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- Create a flattened version of the table in a different schema
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				foo VARCHAR(255)
-			); 
-			`,
+            -- Create a flattened version of the table in a different schema
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                foo VARCHAR(255)
+            ); 
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeIndexBuild,
@@ -438,30 +438,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a normal partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			CREATE INDEX some_idx ON schema_1.foobar(foo, id);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            CREATE INDEX some_idx ON schema_1.foobar(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -472,26 +472,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique partitioned index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE UNIQUE INDEX some_unique_idx ON foobar(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -502,30 +502,30 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -536,26 +536,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete a unique constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    UNIQUE (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                UNIQUE (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -565,34 +565,34 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Local index and columns deleted (index dropped first)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-			
-			-- Create a table in a different schema to ensure that dependencies are correctly set
-			CREATE schema schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-		`},
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            
+            -- Create a table in a different schema to ensure that dependencies are correctly set
+            CREATE schema schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+        `},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-		`},
+            CREATE TABLE foobar(
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
@@ -609,35 +609,35 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX old_idx ON foobar_1(foo, bar);
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-		`},
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+        `},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-			CREATE INDEX new_idx ON foobar_1(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+            CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-		`},
+            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
@@ -670,66 +670,66 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "Alter index columns (index replacement and prioritized builds) (conflicting schemas)",
 		oldSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			CREATE INDEX some_idx ON foobar(foo, id);
-			CREATE INDEX old_idx ON foobar_1(foo, bar);
+            CREATE INDEX some_idx ON foobar(foo, id);
+            CREATE INDEX old_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-			-- Create a mirror schema that is also doing a similar operation
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar VARCHAR(255),
-				foo INT
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+            -- Create a mirror schema that is also doing a similar operation
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar VARCHAR(255),
+                foo INT
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-			CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
-			CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
+            CREATE INDEX some_idx ON schema_1.foobar(foo, bar);
+            CREATE INDEX old_idx ON schema_1.foobar_1(foo, id);
 
-			CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-		`},
+            CREATE INDEX foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+        `},
 		newSchemaDDL: []string{`
-			CREATE TABLE foobar(
-				id INT,
-				bar INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar(
+                id INT,
+                bar INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
-			ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
-			CREATE INDEX new_idx ON foobar_1(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, id);
+            CREATE INDEX new_idx ON foobar_1(foo, bar);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
+            CREATE INDEX new_foobar_1_some_local_idx ON foobar_1(foo, bar, id);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				bar VARCHAR(255),
-				foo INT
-			) PARTITION BY LIST (foo);
-			
-			CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
-			CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                bar VARCHAR(255),
+                foo INT
+            ) PARTITION BY LIST (foo);
+            
+            CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
+            CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
-			CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT some_idx PRIMARY KEY (foo, bar);
+            CREATE INDEX new_idx ON schema_1.foobar_1(foo, id);
 
-			CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
-		`},
+            CREATE INDEX new_foobar_1_some_local_idx ON schema_1.foobar_1(foo, id, bar);
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
 			diff.MigrationHazardTypeIndexDropped,
@@ -740,31 +740,31 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar(foo);
-			`,
+            CREATE INDEX some_idx ON foobar(foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar USING hash (foo);
-			`,
+            CREATE INDEX some_idx ON foobar USING hash (foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -776,31 +776,31 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change an index column ordering",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar (foo, bar);
-			`,
+            CREATE INDEX some_idx ON foobar (foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			   	bar INT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                   bar INT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar (bar, foo);
-			`,
+            CREATE INDEX some_idx ON foobar (bar, foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -812,26 +812,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Delete columns and associated index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 
-			CREATE INDEX some_idx ON foobar(id, foo);
-			`,
+            CREATE INDEX some_idx ON foobar(id, foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -843,27 +843,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Switch primary key",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -875,75 +875,75 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Attach an unnattached, invalid index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-			`,
+            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo)
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
+            CREATE TABLE "Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo)
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF "Foobar" FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF "Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "Foobar_3" PARTITION OF "Foobar" FOR VALUES IN ('foo_3');
 
-			CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
+            CREATE INDEX "Partitioned_Idx" ON ONLY "Foobar"(foo);
 
-			CREATE INDEX "foobar_1_part" ON foobar_1(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
+            CREATE INDEX "foobar_1_part" ON foobar_1(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_1_part";
 
-			CREATE INDEX "foobar_2_part" ON foobar_2(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
+            CREATE INDEX "foobar_2_part" ON foobar_2(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "foobar_2_part";
 
-			CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
-			ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
-			`,
+            CREATE INDEX "Foobar_3_Part" ON "Foobar_3"(foo);
+            ALTER INDEX "Partitioned_Idx" ATTACH PARTITION "Foobar_3_Part";
+            `,
 		},
 	},
 	{
 		name: "Add primary key constraint with existing matching base-table index (matching child index does not exist)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
-			-- so the primary key index effectively does not already exist when migrating
-			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-			`,
+            -- A unique index for foobar_1 exists, but it does not have the default name as the primary key constraint (foobar_1_pkey),
+            -- so the primary key index effectively does not already exist when migrating
+            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// The parent table index is dropped and rebuilt
@@ -956,27 +956,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching child index does not exist)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			-- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
-			-- so the primary key index effectively does not already exist when migrating
-			CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
-			`,
+            -- A unique index for foobar_1 exists, but it does not have the default name as the unique constraint (foobar_1_foo_id_key),
+            -- so the primary key index effectively does not already exist when migrating
+            CREATE UNIQUE INDEX foobar_unique ON foobar(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_unique UNIQUE (foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// The parent table index is dropped and rebuilt
@@ -989,27 +989,27 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (local matching child index exists)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
-			`,
+            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            ALTER INDEX foobar_pkey ATTACH PARTITION foobar_1_pkey;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// The parent table index is dropped and rebuilt
@@ -1022,26 +1022,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
-			`,
+            CREATE UNIQUE INDEX foobar_pkey ON foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_idx;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1050,28 +1050,28 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching PK)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
-			`,
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_foo_id_key;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1080,28 +1080,28 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching non-local index exists that backs local matching unique constraint)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
-			`,
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey UNIQUE USING INDEX foobar_1_foo_id_key;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1110,26 +1110,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key constraint with existing matching base-table index (matching local PK already exists backed by local index)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
-			`,
+            CREATE UNIQUE INDEX foobar_pkey ON ONLY foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_pkey PRIMARY KEY (foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// Base table index is dropped
@@ -1141,26 +1141,26 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add unique constraint with existing matching base-table index (matching local PK already exists backed by local index)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
-			`,
+            CREATE UNIQUE INDEX foobar_foo_id_key ON ONLY foobar(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE (foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			`,
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			// Base table index is dropped
@@ -1172,58 +1172,58 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add primary key to partition using existing index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			`,
+            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
-			CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
-			ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
-			`,
+            ALTER TABLE ONLY foobar ADD CONSTRAINT some_pkey PRIMARY KEY (foo, id);
+            CREATE UNIQUE INDEX foobar_1_pkey ON foobar_1(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_pkey PRIMARY KEY USING INDEX foobar_1_pkey;
+            ALTER INDEX some_pkey ATTACH PARTITION foobar_1_pkey;
+            `,
 		},
 	},
 	{
 		name: "Add unique constraint to partition using existing index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			`,
+            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT NOT NULL,
-				foo VARCHAR(255) NOT NULL
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar(
+                id INT NOT NULL,
+                foo VARCHAR(255) NOT NULL
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
-			CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
-			ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
-			`,
+            ALTER TABLE ONLY foobar ADD CONSTRAINT foobar_foo_id_key UNIQUE (foo, id);
+            CREATE UNIQUE INDEX foobar_1_foo_id_key ON foobar_1(foo, id);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_foo_id_key UNIQUE USING INDEX foobar_1_foo_id_key;
+            ALTER INDEX foobar_foo_id_key ATTACH PARTITION foobar_1_foo_id_key;
+            `,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -1,1328 +1,1328 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
-		},
-		expectEmptyPlan: true,
-	},
-	{
-		name:         "Create partitioned table with shared primary key and RLS enabled globally",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
-
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-			`,
-		},
-
-		expectedDBSchemaDDL: []string{`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
-
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-				`,
-		},
-	},
-	{
-		name:         "Create partitioned table with local primary keys and RLS enabled locally",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-				id INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL,
-			    PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF "Foobar"(
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF "Foobar"(
-			    PRIMARY KEY (foo, fizz),
-			    UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
-			ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-		`,
-		},
-	},
-	{
-		name: "Drop table",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			-- partitions
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
-			ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
-			ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-		newSchemaDDL: nil,
-	},
-	{
-		name: "Add and drop partitioned table (conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-		newSchemaDDL: []string{`
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
-
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Alter replica identity of parent and children",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeCorrectness,
-		},
-	},
-	{
-		name: "Enable RLS of parent and children",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Disable RLS of parent and children",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Alter table: New primary key, new unique constraint, dropped unique constraint, change column types, delete partitioned index, new partitioned index, delete local index, add local index, validate check constraint, validate FK, delete FK",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "C",
-				fizz SERIAL,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			-- check constraints
-			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-			CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id TEXT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz TEXT,
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-			-- check constraint
-			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-			CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Changing partition key def errors",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (bar);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Unpartitioned to partitioned",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
-
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Unpartitioned to partitioned and child tables already exist",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			);
-
-			CREATE INDEX some_idx on schema_1.foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
-
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			);
-
-			CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
-
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_1.foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_2.foobar_1
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE TABLE foobar_fk_1(
-			   	foo VARCHAR(255),
-			    bar TEXT
-			);
-
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-
-			CREATE INDEX some_idx on schema_1.foobar( id);
-			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_1.foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Partitioned to unpartitioned",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
-
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Partitioned to unpartitioned and child tables still exist",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
-
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-			CREATE TABLE foobar_1(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
-
-			CREATE INDEX foobar_1_id_idx on foobar(id);
-
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar_1
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE TABLE foobar_fk_1(
-			   	foo VARCHAR(255),
-			    bar TEXT
-			);
-
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Adding a partition",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
-
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
-
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
-			ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
-			`,
-		},
-	},
-	{
-		name: "Adding a partition with local primary key that can back the unique index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-	},
-	{
-		name: "Adding a partition with local unique constraint that can back the unique index",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-			`,
-		},
-	},
-	{
-		name: "Deleting a partitioning errors",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			`,
-		},
-
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Altering a partition's 'FOR VALUES' errors",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			`,
-		},
-
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Re-creating base table causes partitions to be re-created",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    PRIMARY KEY (foo, bar),
-			    UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
-
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
-			-- local indexes
-			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
-
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar_new(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-
-			CREATE TABLE foobar_1 PARTITION OF foobar_new(
-			    PRIMARY KEY (foo, bar),
-			    UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
-
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
-			-- local indexes
-			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
-
-			CREATE TABLE foobar_fk_new(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
-			ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Can handle scenario where partition is not attached",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			);
-
-			-- partitioned indexes
-			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-			-- local indexes
-			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			);
-			ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
-
-			-- partitioned indexes
-			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-			-- local indexes
-			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
+        },
+        expectEmptyPlan: true,
+    },
+    {
+        name:         "Create partitioned table with shared primary key and RLS enabled globally",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            `,
+        },
+
+        expectedDBSchemaDDL: []string{`
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+                `,
+        },
+    },
+    {
+        name:         "Create partitioned table with local primary keys and RLS enabled locally",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
+                foo NOT NULL,
+                bar NOT NULL,
+                PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF "Foobar"(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF "Foobar"(
+                PRIMARY KEY (foo, fizz),
+                UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
+            ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+        `,
+        },
+    },
+    {
+        name: "Drop table",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            -- partitions
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
+            ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
+            ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+        newSchemaDDL: nil,
+    },
+    {
+        name: "Add and drop partitioned table (conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+        newSchemaDDL: []string{`
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Alter replica identity of parent and children",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeCorrectness,
+        },
+    },
+    {
+        name: "Enable RLS of parent and children",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Disable RLS of parent and children",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Alter table: New primary key, new unique constraint, dropped unique constraint, change column types, delete partitioned index, new partitioned index, delete local index, add local index, validate check constraint, validate FK, delete FK",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "C",
+                fizz SERIAL,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            -- check constraints
+            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+            CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id TEXT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz TEXT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+            -- check constraint
+            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+            CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Changing partition key def errors",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (bar);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Unpartitioned to partitioned",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
+
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Unpartitioned to partitioned and child tables already exist",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            );
+
+            CREATE INDEX some_idx on schema_1.foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
+
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            );
+
+            CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
+
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_1.foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_2.foobar_1
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE TABLE foobar_fk_1(
+                   foo VARCHAR(255),
+                bar TEXT
+            );
+
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+
+            CREATE INDEX some_idx on schema_1.foobar( id);
+            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_1.foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Partitioned to unpartitioned",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
+
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Partitioned to unpartitioned and child tables still exist",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
+
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+            CREATE TABLE foobar_1(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
+
+            CREATE INDEX foobar_1_id_idx on foobar(id);
+
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar_1
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE TABLE foobar_fk_1(
+                   foo VARCHAR(255),
+                bar TEXT
+            );
+
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Adding a partition",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
+            ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
+            `,
+        },
+    },
+    {
+        name: "Adding a partition with local primary key that can back the unique index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+    },
+    {
+        name: "Adding a partition with local unique constraint that can back the unique index",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            `,
+        },
+    },
+    {
+        name: "Deleting a partitioning errors",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            `,
+        },
+
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Altering a partition's 'FOR VALUES' errors",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            `,
+        },
+
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Re-creating base table causes partitions to be re-created",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                PRIMARY KEY (foo, bar),
+                UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
+
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
+            -- local indexes
+            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar_new(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+
+            CREATE TABLE foobar_1 PARTITION OF foobar_new(
+                PRIMARY KEY (foo, bar),
+                UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
+
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
+            -- local indexes
+            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+
+            CREATE TABLE foobar_fk_new(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
+            ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Can handle scenario where partition is not attached",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            );
+
+            -- partitioned indexes
+            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+            -- local indexes
+            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
+
+            -- partitioned indexes
+            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+            -- local indexes
+            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestPartitionedTableTestCases() {
-	suite.runTestCases(partitionedTableAcceptanceTestCases)
+    suite.runTestCases(partitionedTableAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -9,97 +9,97 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
 		},
 		expectEmptyPlan: true,
 	},
@@ -108,71 +108,71 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-			`,
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            `,
 		},
 
 		expectedDBSchemaDDL: []string{`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-				`,
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+                `,
 		},
 	},
 	{
@@ -180,103 +180,103 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL,
-			    PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF "Foobar"(
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF "Foobar"(
-			    PRIMARY KEY (foo, fizz),
-			    UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+            CREATE TABLE "Foobar"(
+                id INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
+                foo NOT NULL,
+                bar NOT NULL,
+                PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF "Foobar"(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF "Foobar"(
+                PRIMARY KEY (foo, fizz),
+                UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
-			ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-		`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
+            ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+        `,
 		},
 	},
 	{
 		name: "Drop table",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			-- partitions
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            -- partitions
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
-			ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
-			ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
+            ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
+            ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -287,24 +287,24 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop partitioned table (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-			`,
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
-			`,
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -314,34 +314,34 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity of parent and children",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
@@ -351,34 +351,34 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Enable RLS of parent and children",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
 
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -388,34 +388,34 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS of parent and children",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
 
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			`,
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -425,88 +425,88 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New primary key, new unique constraint, dropped unique constraint, change column types, delete partitioned index, new partitioned index, delete local index, add local index, validate check constraint, validate FK, delete FK",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "C",
-				fizz SERIAL,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			-- check constraints
-			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    foo NOT NULL,
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-			CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "C",
+                fizz SERIAL,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            -- check constraints
+            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+            CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id TEXT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz TEXT,
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-			-- check constraint
-			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-			    bar NOT NULL
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-			CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
+            CREATE TABLE foobar(
+                id TEXT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz TEXT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+            -- check constraint
+            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+            CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -520,27 +520,27 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Changing partition key def errors",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (bar);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -549,86 +549,86 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unpartitioned to partitioned",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 
-			`,
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -638,115 +638,115 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unpartitioned to partitioned and child tables already exist",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            );
 
-			CREATE INDEX some_idx on schema_1.foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
+            CREATE INDEX some_idx on schema_1.foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            );
 
-			CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
+            CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_1.foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_1.foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_2.foobar_1
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_2.foobar_1
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE TABLE foobar_fk_1(
-			   	foo VARCHAR(255),
-			    bar TEXT
-			);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE TABLE foobar_fk_1(
+                   foo VARCHAR(255),
+                bar TEXT
+            );
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on schema_1.foobar( id);
-			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE INDEX some_idx on schema_1.foobar( id);
+            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_1.foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_1.foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -756,85 +756,85 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Partitioned to unpartitioned",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -844,111 +844,111 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Partitioned to unpartitioned and child tables still exist",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar_1(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX foobar_1_id_idx on foobar(id);
+            CREATE INDEX foobar_1_id_idx on foobar(id);
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar_1
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar_1
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			);
-			CREATE TABLE foobar_fk_1(
-			   	foo VARCHAR(255),
-			    bar TEXT
-			);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE TABLE foobar_fk_1(
+                   foo VARCHAR(255),
+                bar TEXT
+            );
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -958,199 +958,199 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Adding a partition",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT,
-			    PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
-			ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
+            ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
+            `,
 		},
 	},
 	{
 		name: "Adding a partition with local primary key that can back the unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 	},
 	{
 		name: "Adding a partition with local unique constraint that can back the unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            `,
 		},
 	},
 	{
 		name: "Deleting a partitioning errors",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			`,
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1159,27 +1159,27 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Altering a partition's 'FOR VALUES' errors",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1188,79 +1188,79 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Re-creating base table causes partitions to be re-created",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    PRIMARY KEY (foo, bar),
-			    UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                PRIMARY KEY (foo, bar),
+                UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
-			-- local indexes
-			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
+            -- local indexes
+            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar_new(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_new(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar_new(
-			    PRIMARY KEY (foo, bar),
-			    UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar_new(
+                PRIMARY KEY (foo, bar),
+                UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
-			-- local indexes
-			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
+            -- local indexes
+            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
-			CREATE TABLE foobar_fk_new(
-			    foo VARCHAR(255),
-			    bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
-			ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-			`,
+            CREATE TABLE foobar_fk_new(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
+            ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -1270,52 +1270,52 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Can handle scenario where partition is not attached",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            );
 
-			-- partitioned indexes
-			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-			-- local indexes
-			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-			`,
+            -- partitioned indexes
+            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+            -- local indexes
+            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-			    id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			);
-			ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-			-- local indexes
-			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-			`,
+            -- partitioned indexes
+            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+            -- local indexes
+            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -10,12 +10,12 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX",
 				fizz SERIAL,
 				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
@@ -34,8 +34,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 			-- partitioned indexes
@@ -54,12 +54,12 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX",
 				fizz SERIAL,
 				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
@@ -82,8 +82,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			-- partitions
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
@@ -110,13 +110,13 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
 				fizz SERIAL,
 				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 			
@@ -126,8 +126,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			-- partitions
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
+				foo NOT NULL,
+				bar NOT NULL
 			) FOR VALUES IN ('foo_1');
 			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
@@ -144,13 +144,13 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		expectedDBSchemaDDL: []string{`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
 				fizz SERIAL,
 				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
@@ -160,8 +160,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			-- partitions
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
+				foo NOT NULL,
+				bar NOT NULL
 			) FOR VALUES IN ('foo_1');
 			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
@@ -189,18 +189,18 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) PARTITION BY LIST (foo);
 			-- partitions
 			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL,
-			    PRIMARY KEY (foo, id)
+				foo NOT NULL,
+				bar NOT NULL,
+				PRIMARY KEY (foo, id)
 			) FOR VALUES IN ('foo_1');
 			ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
 			CREATE TABLE foobar_2 PARTITION OF "Foobar"(
-			    PRIMARY KEY (foo, bar)
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foo_2');
 			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
 			CREATE TABLE foobar_3 PARTITION OF "Foobar"(
-			    PRIMARY KEY (foo, fizz),
-			    UNIQUE (foo, bar)
+				PRIMARY KEY (foo, fizz),
+				UNIQUE (foo, bar)
 			) FOR VALUES IN ('foo_3');
 			-- partitioned indexes
 			CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
@@ -209,8 +209,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			-- partitions
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
@@ -235,19 +235,19 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz SERIAL,
 				CHECK ( fizz > 0 ),
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, bar)
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-			    foo NOT NULL,
-			    bar NOT NULL
+				foo NOT NULL,
+				bar NOT NULL
 			) FOR VALUES IN ('foo_1');
 			-- partitions
 			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
@@ -259,8 +259,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			-- partitions
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
@@ -315,9 +315,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
 			-- partitions
@@ -330,9 +330,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
 			-- partitions
@@ -352,9 +352,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 
 			-- partitions
@@ -366,9 +366,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
 			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
@@ -389,9 +389,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
 			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
@@ -406,9 +406,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
-			    PRIMARY KEY (foo, id)
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 
 			-- partitions
@@ -426,19 +426,19 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "C",
 				fizz SERIAL,
-			    PRIMARY KEY (foo, id),
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST (foo);
 			-- check constraints
 			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
 			-- partitions
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    foo NOT NULL,
-			    bar NOT NULL
+				foo NOT NULL,
+				bar NOT NULL
 			) FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
@@ -449,8 +449,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 			-- partitioned indexes
@@ -470,19 +470,19 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id TEXT,
+				id TEXT,
 				foo VARCHAR(255),
 				bar TEXT COLLATE "POSIX",
 				fizz TEXT,
-			    PRIMARY KEY (foo, id),
-			    UNIQUE (foo, fizz)
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, fizz)
 			) PARTITION BY LIST (foo);
 			-- check constraint
 			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
 			-- partitions
 			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			CREATE TABLE foobar_2 PARTITION OF foobar(
-			    bar NOT NULL
+				bar NOT NULL
 			) FOR VALUES IN ('foo_2');
 			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			-- partitioned indexes
@@ -492,8 +492,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 			-- partitioned indexes
@@ -521,7 +521,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT
@@ -533,7 +533,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT
@@ -550,7 +550,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -575,8 +575,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
@@ -590,7 +590,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -617,8 +617,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
@@ -640,7 +640,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar( 
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -653,7 +653,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -684,12 +684,12 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			);
 			CREATE TABLE foobar_fk_1(
 			   	foo VARCHAR(255),
-			    bar TEXT
+				bar TEXT
 			);
 
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
@@ -706,7 +706,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar( 
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -735,8 +735,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
@@ -757,7 +757,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -784,8 +784,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
@@ -800,7 +800,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -825,8 +825,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
@@ -845,7 +845,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -873,8 +873,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
@@ -889,7 +889,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -901,7 +901,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
 			CREATE TABLE foobar_1(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -932,12 +932,12 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 				EXECUTE PROCEDURE increment_version();
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			);
 			CREATE TABLE foobar_fk_1(
 			   	foo VARCHAR(255),
-			    bar TEXT
+				bar TEXT
 			);
 
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
@@ -960,7 +960,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -975,9 +975,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE TABLE foobar_fk(
 				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT,
-			    PRIMARY KEY (foo, id)
+				foo VARCHAR(255),
+				bar TEXT,
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
@@ -991,7 +991,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -1009,9 +1009,9 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE TABLE foobar_fk(
 				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT,
-			    PRIMARY KEY (foo, id)
+				foo VARCHAR(255),
+				bar TEXT,
+				PRIMARY KEY (foo, id)
 			) PARTITION BY LIST (foo);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
@@ -1031,7 +1031,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -1043,8 +1043,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE TABLE foobar_fk(
 				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			-- partitioned indexes
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
@@ -1058,7 +1058,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -1067,19 +1067,19 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) PARTITION BY LIST (foo);
 			-- partitions
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    PRIMARY KEY (foo, bar)
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foo_1');
 			-- partitioned indexes
 			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 
 			CREATE TABLE foobar_fk(
 				id INT,
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			-- partitions
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
-			    PRIMARY KEY (foo, bar)
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foo_1');
 			-- partitioned indexes
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
@@ -1096,7 +1096,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -1110,7 +1110,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -1119,7 +1119,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) PARTITION BY LIST (foo);
 			-- partitions
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    UNIQUE (foo, bar)
+				UNIQUE (foo, bar)
 			) FOR VALUES IN ('foo_1');
 			-- partitioned indexes
 			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
@@ -1131,7 +1131,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -1144,7 +1144,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				version INT,
 				fizz SERIAL,
 				foo VARCHAR(255),
@@ -1160,7 +1160,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT
@@ -1172,7 +1172,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255),
 				bar TEXT,
 				fizz INT
@@ -1189,7 +1189,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT,
+				id INT,
 				fizz INT,
 				foo VARCHAR(255),
 				bar TEXT,
@@ -1197,8 +1197,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) PARTITION BY LIST (foo);
 
 			CREATE TABLE foobar_1 PARTITION OF foobar(
-			    PRIMARY KEY (foo, bar),
-			    UNIQUE (foo, id)
+				PRIMARY KEY (foo, bar),
+				UNIQUE (foo, id)
 			) FOR VALUES IN ('foo_1');
 
 			-- partitioned indexes
@@ -1207,11 +1207,11 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
 			CREATE TABLE foobar_fk(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
-			    PRIMARY KEY (foo, bar)
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foo_1');
 			-- partitioned indexes
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
@@ -1227,7 +1227,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar_new(
-			    id INT,
+				id INT,
 				fizz INT,
 				foo VARCHAR(255),
 				bar TEXT,
@@ -1235,8 +1235,8 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			) PARTITION BY LIST (foo);
 
 			CREATE TABLE foobar_1 PARTITION OF foobar_new(
-			    PRIMARY KEY (foo, bar),
-			    UNIQUE (foo, id)
+				PRIMARY KEY (foo, bar),
+				UNIQUE (foo, id)
 			) FOR VALUES IN ('foo_1');
 
 			-- partitioned indexes
@@ -1245,11 +1245,11 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
 			CREATE TABLE foobar_fk_new(
-			    foo VARCHAR(255),
-			    bar TEXT
+				foo VARCHAR(255),
+				bar TEXT
 			) PARTITION BY LIST (foo);
 			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
-			    PRIMARY KEY (foo, bar)
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foo_1');
 			-- partitioned indexes
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
@@ -1272,7 +1272,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar( 
-			    id INT,
+				id INT,
 				fizz INT,
 				foo VARCHAR(255),
 				bar TEXT
@@ -1280,7 +1280,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1(
-			    id INT,
+				id INT,
 				fizz INT,
 				foo VARCHAR(255),
 				bar TEXT
@@ -1296,7 +1296,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar( 
-			    id INT,
+				id INT,
 				fizz INT,
 				foo VARCHAR(255),
 				bar TEXT
@@ -1304,7 +1304,7 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2.foobar_1(
-			    id INT,
+				id INT,
 				fizz INT,
 				foo VARCHAR(255),
 				bar TEXT

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -9,97 +9,97 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX",
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX",
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX",
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            -- partitions
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX",
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			-- partitions
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
 		},
 		expectEmptyPlan: true,
 	},
@@ -108,71 +108,71 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-            
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-            `,
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-                `,
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+				`,
 		},
 	},
 	{
@@ -180,103 +180,103 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
-                foo NOT NULL,
-                bar NOT NULL,
-                PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF "Foobar"(
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF "Foobar"(
-                PRIMARY KEY (foo, fizz),
-                UNIQUE (foo, bar)
-            ) FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+			CREATE TABLE "Foobar"(
+				id INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL,
+			    PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF "Foobar"(
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF "Foobar"(
+			    PRIMARY KEY (foo, fizz),
+			    UNIQUE (foo, bar)
+			) FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
-            ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-            ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-        `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
+			ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+			ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+		`,
 		},
 	},
 	{
 		name: "Drop table",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            -- partitions
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			-- partitions
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
-            ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
-            ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
+			ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
+			ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -287,24 +287,24 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop partitioned table (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            `,
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 		newSchemaDDL: []string{`
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3.foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3.foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
 
-            CREATE SCHEMA schema_4;
-            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
-            `,
+			CREATE SCHEMA schema_4;
+			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -314,34 +314,34 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity of parent and children",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
@@ -351,34 +351,34 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Enable RLS of parent and children",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
 
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -388,34 +388,34 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS of parent and children",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
 
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -425,88 +425,88 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New primary key, new unique constraint, dropped unique constraint, change column types, delete partitioned index, new partitioned index, delete local index, add local index, validate check constraint, validate FK, delete FK",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "C",
-                fizz SERIAL,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            -- check constraints
-            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-            CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "C",
+				fizz SERIAL,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			-- check constraints
+			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+			CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id TEXT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX",
-                fizz TEXT,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
-            -- check constraint
-            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-            CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
+			CREATE TABLE foobar(
+			    id TEXT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX",
+				fizz TEXT,
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
+			-- check constraint
+			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+			CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -520,27 +520,27 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Changing partition key def errors",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (foo);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (bar);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (bar);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -549,86 +549,86 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unpartitioned to partitioned",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
 
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 
-            `,
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
 
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -638,115 +638,115 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unpartitioned to partitioned and child tables already exist",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			);
 
-            CREATE INDEX some_idx on schema_1.foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
+			CREATE INDEX some_idx on schema_1.foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            );
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			);
 
-            CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
+			CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
 
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON schema_1.foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON schema_1.foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON schema_2.foobar_1
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON schema_2.foobar_1
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE TABLE foobar_fk_1(
-                   foo VARCHAR(255),
-                bar TEXT
-            );
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE TABLE foobar_fk_1(
+			   	foo VARCHAR(255),
+			    bar TEXT
+			);
 
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
 
-            CREATE INDEX some_idx on schema_1.foobar( id);
-            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE INDEX some_idx on schema_1.foobar( id);
+			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON schema_1.foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON schema_1.foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -756,85 +756,85 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Partitioned to unpartitioned",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
 
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
 
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -844,111 +844,111 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Partitioned to unpartitioned and child tables still exist",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
 
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
 
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-            CREATE TABLE foobar_1(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
+			CREATE TABLE foobar_1(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
 
-            CREATE INDEX foobar_1_id_idx on foobar(id);
+			CREATE INDEX foobar_1_id_idx on foobar(id);
 
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar_1
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar_1
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE TABLE foobar_fk_1(
-                   foo VARCHAR(255),
-                bar TEXT
-            );
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE TABLE foobar_fk_1(
+			   	foo VARCHAR(255),
+			    bar TEXT
+			);
 
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -958,199 +958,199 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Adding a partition",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 ),
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
 
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 ),
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
-            ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
+			ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
+			`,
 		},
 	},
 	{
 		name: "Adding a partition with local primary key that can back the unique index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 	},
 	{
 		name: "Adding a partition with local unique constraint that can back the unique index",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                UNIQUE (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    UNIQUE (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+			`,
 		},
 	},
 	{
 		name: "Deleting a partitioning errors",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            `,
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1159,27 +1159,27 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Altering a partition's 'FOR VALUES' errors",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (foo);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (foo);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -1188,79 +1188,79 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Re-creating base table causes partitions to be re-created",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                PRIMARY KEY (foo, bar),
-                UNIQUE (foo, id)
-            ) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    PRIMARY KEY (foo, bar),
+			    UNIQUE (foo, id)
+			) FOR VALUES IN ('foo_1');
 
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
-            -- local indexes
-            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
+			-- local indexes
+			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar_new(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_new(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar_new(
-                PRIMARY KEY (foo, bar),
-                UNIQUE (foo, id)
-            ) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_1 PARTITION OF foobar_new(
+			    PRIMARY KEY (foo, bar),
+			    UNIQUE (foo, id)
+			) FOR VALUES IN ('foo_1');
 
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
-            -- local indexes
-            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
+			-- local indexes
+			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
-            CREATE TABLE foobar_fk_new(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
-            ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-            `,
+			CREATE TABLE foobar_fk_new(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
+			ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -1270,52 +1270,52 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Can handle scenario where partition is not attached",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            );
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			);
 
-            -- partitioned indexes
-            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-            -- local indexes
-            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-            `,
+			-- partitioned indexes
+			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+			-- local indexes
+			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
 
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			);
+			ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
 
-            -- partitioned indexes
-            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-            -- local indexes
-            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-            `,
+			-- partitioned indexes
+			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+			-- local indexes
+			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -1,1328 +1,1328 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX",
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX",
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            -- partitions
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
-        },
-        expectEmptyPlan: true,
-    },
-    {
-        name:         "Create partitioned table with shared primary key and RLS enabled globally",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-            
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
-
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-            `,
-        },
-
-        expectedDBSchemaDDL: []string{`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-
-            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
-
-            -- partitions
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-                `,
-        },
-    },
-    {
-        name:         "Create partitioned table with local primary keys and RLS enabled locally",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
-                foo NOT NULL,
-                bar NOT NULL,
-                PRIMARY KEY (foo, id)
-            ) FOR VALUES IN ('foo_1');
-            ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF "Foobar"(
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF "Foobar"(
-                PRIMARY KEY (foo, fizz),
-                UNIQUE (foo, bar)
-            ) FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
-            ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-            ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-        `,
-        },
-    },
-    {
-        name: "Drop table",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz SERIAL,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            -- partitions
-            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
-            ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
-            ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-        newSchemaDDL: nil,
-    },
-    {
-        name: "Add and drop partitioned table (conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-        newSchemaDDL: []string{`
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3.foobar(
-                foo VARCHAR(255)
-            ) PARTITION BY LIST (foo);
-
-            CREATE SCHEMA schema_4;
-            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Alter replica identity of parent and children",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeCorrectness,
-        },
-    },
-    {
-        name: "Enable RLS of parent and children",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Disable RLS of parent and children",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Alter table: New primary key, new unique constraint, dropped unique constraint, change column types, delete partitioned index, new partitioned index, delete local index, add local index, validate check constraint, validate FK, delete FK",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "C",
-                fizz SERIAL,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-            -- check constraints
-            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                foo NOT NULL,
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-            CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id TEXT,
-                foo VARCHAR(255),
-                bar TEXT COLLATE "POSIX",
-                fizz TEXT,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
-            -- check constraint
-            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            CREATE TABLE foobar_2 PARTITION OF foobar(
-                bar NOT NULL
-            ) FOR VALUES IN ('foo_2');
-            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-            CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- local indexes
-            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Changing partition key def errors",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (foo);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (bar);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Unpartitioned to partitioned",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
-
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Unpartitioned to partitioned and child tables already exist",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            );
-
-            CREATE INDEX some_idx on schema_1.foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
-
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            );
-
-            CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
-
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON schema_1.foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON schema_2.foobar_1
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE TABLE foobar_fk_1(
-                   foo VARCHAR(255),
-                bar TEXT
-            );
-
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
-
-            CREATE INDEX some_idx on schema_1.foobar( id);
-            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
-            
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON schema_1.foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Partitioned to unpartitioned",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
-
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Partitioned to unpartitioned and child tables still exist",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST (foo);
-
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
-
-            CREATE INDEX some_idx on foobar(id);
-            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
-
-            CREATE TABLE foobar_1(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, bar)
-            );
-
-            CREATE INDEX foobar_1_id_idx on foobar(id);
-
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foobar_1
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            CREATE TABLE foobar_fk_1(
-                   foo VARCHAR(255),
-                bar TEXT
-            );
-
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Adding a partition",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
-
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
-
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 ),
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
-
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
-
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
-
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                PRIMARY KEY (foo, id)
-            ) PARTITION BY LIST (foo);
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
-            ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
-            `,
-        },
-    },
-    {
-        name: "Adding a partition with local primary key that can back the unique index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-
-            CREATE TABLE foobar_fk(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-    },
-    {
-        name: "Adding a partition with local unique constraint that can back the unique index",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT,
-                CHECK ( fizz > 0 )
-            ) PARTITION BY LIST (foo);
-            -- partitions
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                UNIQUE (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
-            `,
-        },
-    },
-    {
-        name: "Deleting a partitioning errors",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                version INT,
-                fizz SERIAL,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            `,
-        },
-
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Altering a partition's 'FOR VALUES' errors",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (foo);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                fizz INT
-            ) PARTITION BY LIST (foo);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
-            `,
-        },
-
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Re-creating base table causes partitions to be re-created",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar(
-                PRIMARY KEY (foo, bar),
-                UNIQUE (foo, id)
-            ) FOR VALUES IN ('foo_1');
-
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
-            -- local indexes
-            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
-
-            CREATE TABLE foobar_fk(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar_new(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT,
-                UNIQUE (foo, fizz)
-            ) PARTITION BY LIST (foo);
-
-            CREATE TABLE foobar_1 PARTITION OF foobar_new(
-                PRIMARY KEY (foo, bar),
-                UNIQUE (foo, id)
-            ) FOR VALUES IN ('foo_1');
-
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
-            -- local indexes
-            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
-
-            CREATE TABLE foobar_fk_new(
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foo_1');
-            -- partitioned indexes
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
-            -- foreign keys
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
-            ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
-            -- local local foreign keys
-            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Can handle scenario where partition is not attached",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            );
-
-            -- partitioned indexes
-            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-            -- local indexes
-            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar( 
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            ) PARTITION BY LIST (foo);
-
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2.foobar_1(
-                id INT,
-                fizz INT,
-                foo VARCHAR(255),
-                bar TEXT
-            );
-            ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
-
-            -- partitioned indexes
-            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-            -- local indexes
-            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX",
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX",
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			-- partitions
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name:         "Create partitioned table with shared primary key and RLS enabled globally",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+			`,
+		},
+
+		expectedDBSchemaDDL: []string{`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+
+			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+
+			-- partitions
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+				`,
+		},
+	},
+	{
+		name:         "Create partitioned table with local primary keys and RLS enabled locally",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+				id INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL,
+			    PRIMARY KEY (foo, id)
+			) FOR VALUES IN ('foo_1');
+			ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF "Foobar"(
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF "Foobar"(
+			    PRIMARY KEY (foo, fizz),
+			    UNIQUE (foo, bar)
+			) FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
+			ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+			ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+		`,
+		},
+	},
+	{
+		name: "Drop table",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz SERIAL,
+				CHECK ( fizz > 0 ),
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			-- partitions
+			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
+			ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
+			ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+		newSchemaDDL: nil,
+	},
+	{
+		name: "Add and drop partitioned table (conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+		newSchemaDDL: []string{`
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3.foobar(
+				foo VARCHAR(255)
+			) PARTITION BY LIST (foo);
+
+			CREATE SCHEMA schema_4;
+			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Alter replica identity of parent and children",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeCorrectness,
+		},
+	},
+	{
+		name: "Enable RLS of parent and children",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Disable RLS of parent and children",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter table: New primary key, new unique constraint, dropped unique constraint, change column types, delete partitioned index, new partitioned index, delete local index, add local index, validate check constraint, validate FK, delete FK",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "C",
+				fizz SERIAL,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+			-- check constraints
+			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    foo NOT NULL,
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+			CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id TEXT,
+				foo VARCHAR(255),
+				bar TEXT COLLATE "POSIX",
+				fizz TEXT,
+			    PRIMARY KEY (foo, id),
+			    UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
+			-- check constraint
+			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			CREATE TABLE foobar_2 PARTITION OF foobar(
+			    bar NOT NULL
+			) FOR VALUES IN ('foo_2');
+			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+			CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- local indexes
+			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Changing partition key def errors",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (foo);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (bar);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Unpartitioned to partitioned",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
+
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Unpartitioned to partitioned and child tables already exist",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			);
+
+			CREATE INDEX some_idx on schema_1.foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
+
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			);
+
+			CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
+
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON schema_1.foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON schema_2.foobar_1
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE TABLE foobar_fk_1(
+			   	foo VARCHAR(255),
+			    bar TEXT
+			);
+
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
+
+			CREATE INDEX some_idx on schema_1.foobar( id);
+			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
+			
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON schema_1.foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Partitioned to unpartitioned",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
+
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Partitioned to unpartitioned and child tables still exist",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST (foo);
+
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
+
+			CREATE INDEX some_idx on foobar(id);
+			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+
+			CREATE TABLE foobar_1(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, bar)
+			);
+
+			CREATE INDEX foobar_1_id_idx on foobar(id);
+
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foobar_1
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			);
+			CREATE TABLE foobar_fk_1(
+			   	foo VARCHAR(255),
+			    bar TEXT
+			);
+
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Adding a partition",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 ),
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
+
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 ),
+				PRIMARY KEY (foo, id),
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
+
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT,
+			    PRIMARY KEY (foo, id)
+			) PARTITION BY LIST (foo);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
+			ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
+			`,
+		},
+	},
+	{
+		name: "Adding a partition with local primary key that can back the unique index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+
+			CREATE TABLE foobar_fk(
+				id INT,
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+	},
+	{
+		name: "Adding a partition with local unique constraint that can back the unique index",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT,
+				CHECK ( fizz > 0 )
+			) PARTITION BY LIST (foo);
+			-- partitions
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    UNIQUE (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+			`,
+		},
+	},
+	{
+		name: "Deleting a partitioning errors",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				version INT,
+				fizz SERIAL,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
+			`,
+		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Altering a partition's 'FOR VALUES' errors",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (foo);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				fizz INT
+			) PARTITION BY LIST (foo);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
+			`,
+		},
+
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Re-creating base table causes partitions to be re-created",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar(
+			    PRIMARY KEY (foo, bar),
+			    UNIQUE (foo, id)
+			) FOR VALUES IN ('foo_1');
+
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
+			-- local indexes
+			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+
+			CREATE TABLE foobar_fk(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar_new(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT,
+				UNIQUE (foo, fizz)
+			) PARTITION BY LIST (foo);
+
+			CREATE TABLE foobar_1 PARTITION OF foobar_new(
+			    PRIMARY KEY (foo, bar),
+			    UNIQUE (foo, id)
+			) FOR VALUES IN ('foo_1');
+
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
+			-- local indexes
+			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+
+			CREATE TABLE foobar_fk_new(
+			    foo VARCHAR(255),
+			    bar TEXT
+			) PARTITION BY LIST (foo);
+			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foo_1');
+			-- partitioned indexes
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
+			-- foreign keys
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
+			ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
+			-- local local foreign keys
+			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Can handle scenario where partition is not attached",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
+
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			);
+
+			-- partitioned indexes
+			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+			-- local indexes
+			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar( 
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			) PARTITION BY LIST (foo);
+
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2.foobar_1(
+			    id INT,
+				fizz INT,
+				foo VARCHAR(255),
+				bar TEXT
+			);
+			ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
+
+			-- partitioned indexes
+			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+			-- local indexes
+			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestPartitionedTableTestCases() {
-    suite.runTestCases(partitionedTableAcceptanceTestCases)
+	suite.runTestCases(partitionedTableAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -9,96 +9,96 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY DEFAULT ;
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
 			`,
 		},
 		expectEmptyPlan: true,
@@ -108,70 +108,70 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-				foo NOT NULL,
-				bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 			`,
 		},
 
 		expectedDBSchemaDDL: []string{`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX" NOT NULL DEFAULT 'some default',
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 
-			ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1."Foobar" FORCE ROW LEVEL SECURITY;
 
-			-- partitions
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-				foo NOT NULL,
-				bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            -- partitions
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE schema_2."FOOBAR_1" REPLICA IDENTITY NOTHING ;
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            ALTER TABLE schema_2.foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 				`,
 		},
 	},
@@ -180,52 +180,52 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
-				foo NOT NULL,
-				bar NOT NULL,
-				PRIMARY KEY (foo, id)
-			) FOR VALUES IN ('foo_1');
-			ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF "Foobar"(
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF "Foobar"(
-				PRIMARY KEY (foo, fizz),
-				UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
+            CREATE TABLE "Foobar"(
+                id INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE "FOOBAR_1" PARTITION OF "Foobar"(
+                foo NOT NULL,
+                bar NOT NULL,
+                PRIMARY KEY (foo, id)
+            ) FOR VALUES IN ('foo_1');
+            ALTER TABLE "FOOBAR_1" ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF "Foobar"(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF "Foobar"(
+                PRIMARY KEY (foo, fizz),
+                UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON "Foobar"(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON "FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
-			ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
-			ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES "Foobar"(foo, bar);
+            ALTER TABLE "Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_2(foo);
+            ALTER TABLE "FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
 		`,
 		},
 	},
@@ -233,49 +233,49 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop table",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz SERIAL,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz SERIAL,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
-				foo NOT NULL,
-				bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			-- partitions
-			CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
-			CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
-			CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."FOOBAR_1" PARTITION OF schema_1."Foobar"(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            -- partitions
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1."Foobar" FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1."Foobar"(foo, bar);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_2."FOOBAR_1"(foo);
+            CREATE UNIQUE INDEX foobar_2_local_unique_idx ON schema_2.foobar_2(foo);
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
-			ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
-			ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1."Foobar"(foo, bar);
+            ALTER TABLE schema_1."Foobar" ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES schema_2.foobar_2(foo);
+            ALTER TABLE schema_2."FOOBAR_1" ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -287,23 +287,23 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop partitioned table (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 		newSchemaDDL: []string{`
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3.foobar(
-				foo VARCHAR(255)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3.foobar(
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_4;
-			CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_4;
+            CREATE TABLE schema_4.foobar_1 PARTITION OF schema_3.foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -314,33 +314,33 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity of parent and children",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY NOTHING;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar REPLICA IDENTITY DEFAULT;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 REPLICA IDENTITY FULL;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 REPLICA IDENTITY FULL;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -351,33 +351,33 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Enable RLS of parent and children",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
 
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -388,33 +388,33 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS of parent and children",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            ALTER TABLE foobar_1 ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            ALTER TABLE foobar_2 FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
 
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -425,87 +425,87 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New primary key, new unique constraint, dropped unique constraint, change column types, delete partitioned index, new partitioned index, delete local index, add local index, validate check constraint, validate FK, delete FK",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "C",
-				fizz SERIAL,
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
-			-- check constraints
-			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				foo NOT NULL,
-				bar NOT NULL
-			) FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-			CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "C",
+                fizz SERIAL,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
+            -- check constraints
+            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( fizz > 0 ) NOT VALID;
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                foo NOT NULL,
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+            CREATE INDEX foobar_2_local_idx ON foobar_1(foo);
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo) NOT VALID;
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo) NOT VALID;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id TEXT,
-				foo VARCHAR(255),
-				bar TEXT COLLATE "POSIX",
-				fizz TEXT,
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
-			-- check constraint
-			ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
-			CREATE TABLE foobar_2 PARTITION OF foobar(
-				bar NOT NULL
-			) FOR VALUES IN ('foo_2');
-			CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
-			CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
+            CREATE TABLE foobar(
+                id TEXT,
+                foo VARCHAR(255),
+                bar TEXT COLLATE "POSIX",
+                fizz TEXT,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
+            -- check constraint
+            ALTER TABLE foobar ADD CONSTRAINT some_check_constraint CHECK ( LENGTH(fizz) > 0 );
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_2 PARTITION OF foobar(
+                bar NOT NULL
+            ) FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_3 PARTITION OF foobar FOR VALUES IN ('foo_3');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_some_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_1_local_unique_idx ON foobar_1(foo);
+            CREATE INDEX foobar_3_local_idx ON foobar_3(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- local indexes
-			CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- local indexes
+            CREATE UNIQUE INDEX foobar_fk_1_local_unique_idx ON foobar_fk_1(foo);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo) REFERENCES foobar_1(foo);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo) REFERENCES foobar_fk_1(foo);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -520,26 +520,26 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Changing partition key def errors",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (bar);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 
@@ -549,85 +549,85 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unpartitioned to partitioned",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -638,114 +638,114 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unpartitioned to partitioned and child tables already exist",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            );
 
-			CREATE INDEX some_idx on schema_1.foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
+            CREATE INDEX some_idx on schema_1.foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar(foo, bar);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            );
 
-			CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
+            CREATE INDEX foobar_1_id_idx on schema_1.foobar(id);
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_1.foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_1.foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_2.foobar_1
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_2.foobar_1
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			);
-			CREATE TABLE foobar_fk_1(
-			   	foo VARCHAR(255),
-				bar TEXT
-			);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE TABLE foobar_fk_1(
+                   foo VARCHAR(255),
+                bar TEXT
+            );
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on schema_1.foobar( id);
-			CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
-			
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE INDEX some_idx on schema_1.foobar( id);
+            CREATE UNIQUE INDEX foobar_unique_idx on schema_1.foobar( foo, bar);
+            
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON schema_1.foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON schema_1.foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar( foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -756,84 +756,84 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Partitioned to unpartitioned",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -844,110 +844,110 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Partitioned to unpartitioned and child tables still exist",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST (foo);
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX some_idx on foobar(id);
-			CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
+            CREATE INDEX some_idx on foobar(id);
+            CREATE UNIQUE INDEX foobar_unique_idx on foobar(foo, bar);
 
-			CREATE TABLE foobar_1(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, bar)
-			);
+            CREATE TABLE foobar_1(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, bar)
+            );
 
-			CREATE INDEX foobar_1_id_idx on foobar(id);
+            CREATE INDEX foobar_1_id_idx on foobar(id);
 
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foobar_1
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foobar_1
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			);
-			CREATE TABLE foobar_fk_1(
-			   	foo VARCHAR(255),
-				bar TEXT
-			);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            CREATE TABLE foobar_fk_1(
+                   foo VARCHAR(255),
+                bar TEXT
+            );
 
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_foo_bar_fkey FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -958,71 +958,71 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Adding a partition",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 ),
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 ),
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON schema_1.foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				PRIMARY KEY (foo, id)
-			) PARTITION BY LIST (foo);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                PRIMARY KEY (foo, id)
+            ) PARTITION BY LIST (foo);
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk FOR VALUES IN ('foo_1');
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
-			ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
-			ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar(foo, bar);
+            ALTER TABLE schema_1.foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, id) REFERENCES schema_2.foobar_1(foo, id);
+            ALTER TABLE schema_2.foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, id) REFERENCES foobar_fk_1(foo, id);
 			`,
 		},
 	},
@@ -1030,64 +1030,64 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Adding a partition with local primary key that can back the unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk(
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 	},
@@ -1095,34 +1095,34 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Adding a partition with local unique constraint that can back the unique index",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT,
-				CHECK ( fizz > 0 )
-			) PARTITION BY LIST (foo);
-			-- partitions
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				UNIQUE (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT,
+                CHECK ( fizz > 0 )
+            ) PARTITION BY LIST (foo);
+            -- partitions
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                UNIQUE (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX some_partitioned_idx ON foobar(foo, bar);
 			`,
 		},
 	},
@@ -1130,26 +1130,26 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Deleting a partitioning errors",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				version INT,
-				fizz SERIAL,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                version INT,
+                fizz SERIAL,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
 			`,
 		},
 
@@ -1159,26 +1159,26 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Altering a partition's 'FOR VALUES' errors",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				fizz INT
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                fizz INT
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_2');
 			`,
 		},
 
@@ -1188,78 +1188,78 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Re-creating base table causes partitions to be re-created",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar(
-				PRIMARY KEY (foo, bar),
-				UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar(
+                PRIMARY KEY (foo, bar),
+                UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
-			-- local indexes
-			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo);
+            -- local indexes
+            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+            CREATE TABLE foobar_fk(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk (
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar(foo);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk(foo);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar_new(
-				id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT,
-				UNIQUE (foo, fizz)
-			) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_new(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT,
+                UNIQUE (foo, fizz)
+            ) PARTITION BY LIST (foo);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar_new(
-				PRIMARY KEY (foo, bar),
-				UNIQUE (foo, id)
-			) FOR VALUES IN ('foo_1');
+            CREATE TABLE foobar_1 PARTITION OF foobar_new(
+                PRIMARY KEY (foo, bar),
+                UNIQUE (foo, id)
+            ) FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
-			-- local indexes
-			CREATE INDEX some_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar_new(foo);
+            -- local indexes
+            CREATE INDEX some_local_idx ON foobar_1(foo, bar);
 
-			CREATE TABLE foobar_fk_new(
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
-			CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foo_1');
-			-- partitioned indexes
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
-			-- foreign keys
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
-			ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
-			-- local local foreign keys
-			ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
-			ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
+            CREATE TABLE foobar_fk_new(
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
+            CREATE TABLE foobar_fk_1 PARTITION OF foobar_fk_new (
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foo_1');
+            -- partitioned indexes
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk_new(foo);
+            -- foreign keys
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk_new ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo) REFERENCES foobar_new(foo);
+            ALTER TABLE foobar_new ADD CONSTRAINT foobar_fk FOREIGN KEY (foo) REFERENCES foobar_fk_new(foo);
+            -- local local foreign keys
+            ALTER TABLE foobar_fk_1 ADD CONSTRAINT foobar_fk_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_1(foo, bar);
+            ALTER TABLE foobar_1 ADD CONSTRAINT foobar_1_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk_1(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -1270,51 +1270,51 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Can handle scenario where partition is not attached",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-				id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-				id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            );
 
-			-- partitioned indexes
-			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-			-- local indexes
-			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+            -- local indexes
+            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar( 
-				id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			) PARTITION BY LIST (foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar( 
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            ) PARTITION BY LIST (foo);
 
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2.foobar_1(
-				id INT,
-				fizz INT,
-				foo VARCHAR(255),
-				bar TEXT
-			);
-			ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2.foobar_1(
+                id INT,
+                fizz INT,
+                foo VARCHAR(255),
+                bar TEXT
+            );
+            ALTER TABLE schema_1.foobar ATTACH PARTITION schema_2.foobar_1 FOR VALUES IN ('foo_1');
 
-			-- partitioned indexes
-			CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
-			-- local indexes
-			CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX some_partitioned_idx ON schema_1.foobar( foo, bar);
+            -- local indexes
+            CREATE INDEX some_local_idx ON schema_2.foobar_1(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -504,8 +504,8 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    category TEXT,
-			    val TEXT
+				category TEXT,
+				val TEXT
 			);
 			CREATE POLICY foobar_policy ON schema_1.foobar 
 				AS PERMISSIVE 
@@ -519,8 +519,8 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    category TEXT NOT NULL,
-			    new_val TEXT
+				category TEXT NOT NULL,
+				new_val TEXT
 			);
 			CREATE POLICY foobar_policy ON schema_1.foobar 
 				AS PERMISSIVE 
@@ -541,8 +541,8 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    category TEXT,
-			    val TEXT
+				category TEXT,
+				val TEXT
 			);
 			CREATE POLICY foobar_policy ON schema_1.foobar 
 				AS PERMISSIVE 
@@ -556,8 +556,8 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    category TEXT NOT NULL,
-			    new_val TEXT
+				category TEXT NOT NULL,
+				new_val TEXT
 			);
 			CREATE POLICY foobar_policy ON schema_1.foobar 
 				AS RESTRICTIVE -- force-recreate the policy 
@@ -577,7 +577,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 				CREATE TABLE foobar(
-				    category TEXT
+					category TEXT
 				) partition by list (category);
 				CREATE POLICY foobar_policy ON foobar 
 					AS PERMISSIVE 
@@ -589,7 +589,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 				CREATE TABLE foobar(
-				    category TEXT,
+					category TEXT,
 					some_new_column TEXT
 				); -- Re-create by removing partitioning
 				CREATE POLICY foobar_policy ON foobar 
@@ -608,14 +608,14 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 				CREATE TABLE foobar(
-				    category TEXT
+					category TEXT
 				) partition by list (category);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 				CREATE TABLE foobar(
-				    category TEXT
+					category TEXT
 				) partition by list (category);
 				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
 				CREATE POLICY foobar_1_policy ON foobar_1 
@@ -633,7 +633,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 				CREATE TABLE foobar(
-				    category TEXT
+					category TEXT
 				) partition by list (category);
 				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
 			`,
@@ -641,7 +641,7 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 				CREATE TABLE foobar(
-				    category TEXT
+					category TEXT
 				) partition by list (category);
 				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
 				CREATE POLICY foobar_1_policy ON foobar_1 

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -3,659 +3,659 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var policyAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "no-op",
-		roles: []string{
-			"role_1",
-			"role_2",
-		},
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2 
-					USING (true)
-					WITH CHECK (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2 
-					USING (true)
-					WITH CHECK (true);
-			`,
-		},
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Add permissive ALL policy target on non-public schema",
-		roles: []string{
-			"role_1",
-			"role_2",
-		},
-		oldSchemaDDL: []string{
-			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2
-					USING (true)
-					WITH CHECK (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Create SELECT policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Create INSERT policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Create UPDATE policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR UPDATE 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Create DELETE policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Add policy on new table",
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-	},
-	{
-		name: "Add policy then enable RLS",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-		expectedPlanDDL: []string{
-			// Ensure that the policy is created before enabling RLS.
-			"CREATE POLICY \"foobar_policy\" ON \"public\".\"foobar\"\n\tAS RESTRICTIVE\n\tFOR SELECT\n\tTO PUBLIC\n\tUSING (true)",
-			"ALTER TABLE \"public\".\"foobar\" ENABLE ROW LEVEL SECURITY",
-			"ALTER TABLE \"public\".\"foobar\" FORCE ROW LEVEL SECURITY",
-		},
-	},
-	{
-		name: "Drop non-public schema policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Drop policy and table",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Disable RLS then drop policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"foobar\" DISABLE ROW LEVEL SECURITY",
-			"ALTER TABLE \"public\".\"foobar\" NO FORCE ROW LEVEL SECURITY",
-			"DROP POLICY \"foobar_policy\" ON \"public\".\"foobar\"",
-		},
-	},
-	{
-		name: "Drop policy and columns",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar(
-						category TEXT,
-						val TEXT
-				);
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (category = 'category' AND val = 'value');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Restrictive to permissive policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Alter policy target",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR DELETE 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name:  "Alter policy applies to",
-		roles: []string{"role_1", "role_2"},
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO role_1, role_2
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Alter policy using",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (false);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Alter policy check",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (false);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Remove using check for ALL policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true)
-					WITH CHECK (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Remove check for ALL policy",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true)
-					WITH CHECK (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Alter all alterable attributes on non-public schema",
-		roles: []string{
-			"role_1",
-			"role_2",
-		},
-		oldSchemaDDL: []string{
-			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO role_1, role_2
-					USING (true)
-					WITH CHECK (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (false)
-					WITH CHECK (false);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Alter policy that references deleted columns and new columns (non-public schema)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT,
-			    val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (val = 'value' AND category = 'category')
-				WITH CHECK (val = 'value');
-		`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT NOT NULL,
-			    new_val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (new_val = 'value' AND category = 'category')
-				WITH CHECK (new_val = 'value');
-		`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Re-create policy that references deleted columns and new columns (non-public schema)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT,
-			    val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (val = 'value' AND category = 'category')
-				WITH CHECK (val = 'value');
-		`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT NOT NULL,
-			    new_val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS RESTRICTIVE -- force-recreate the policy 
-				FOR ALL 
-				TO PUBLIC
-				USING (new_val = 'value' AND category = 'category')
-				WITH CHECK (new_val = 'value');
-		`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Alter policy (table is re-created)",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar(
-				    category TEXT,
-					some_new_column TEXT
-				); -- Re-create by removing partitioning
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (category = 'category' AND some_new_column = 'value');
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Policy on new partition (not implemented)",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-				CREATE POLICY foobar_1_policy ON foobar_1 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
-		},
+    {
+        name: "no-op",
+        roles: []string{
+            "role_1",
+            "role_2",
+        },
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2 
+                    USING (true)
+                    WITH CHECK (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2 
+                    USING (true)
+                    WITH CHECK (true);
+            `,
+        },
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Add permissive ALL policy target on non-public schema",
+        roles: []string{
+            "role_1",
+            "role_2",
+        },
+        oldSchemaDDL: []string{
+            `
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2
+                    USING (true)
+                    WITH CHECK (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Create SELECT policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Create INSERT policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Create UPDATE policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR UPDATE 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Create DELETE policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Add policy on new table",
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+    },
+    {
+        name: "Add policy then enable RLS",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+        expectedPlanDDL: []string{
+            // Ensure that the policy is created before enabling RLS.
+            "CREATE POLICY \"foobar_policy\" ON \"public\".\"foobar\"\n\tAS RESTRICTIVE\n\tFOR SELECT\n\tTO PUBLIC\n\tUSING (true)",
+            "ALTER TABLE \"public\".\"foobar\" ENABLE ROW LEVEL SECURITY",
+            "ALTER TABLE \"public\".\"foobar\" FORCE ROW LEVEL SECURITY",
+        },
+    },
+    {
+        name: "Drop non-public schema policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Drop policy and table",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Disable RLS then drop policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+        expectedPlanDDL: []string{
+            "ALTER TABLE \"public\".\"foobar\" DISABLE ROW LEVEL SECURITY",
+            "ALTER TABLE \"public\".\"foobar\" NO FORCE ROW LEVEL SECURITY",
+            "DROP POLICY \"foobar_policy\" ON \"public\".\"foobar\"",
+        },
+    },
+    {
+        name: "Drop policy and columns",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar(
+                        category TEXT,
+                        val TEXT
+                );
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (category = 'category' AND val = 'value');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Restrictive to permissive policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Alter policy target",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR DELETE 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name:  "Alter policy applies to",
+        roles: []string{"role_1", "role_2"},
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO role_1, role_2
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Alter policy using",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (false);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Alter policy check",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (false);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Remove using check for ALL policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Remove check for ALL policy",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Alter all alterable attributes on non-public schema",
+        roles: []string{
+            "role_1",
+            "role_2",
+        },
+        oldSchemaDDL: []string{
+            `
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO role_1, role_2
+                    USING (true)
+                    WITH CHECK (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (false)
+                    WITH CHECK (false);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Alter policy that references deleted columns and new columns (non-public schema)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT,
+                val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (val = 'value' AND category = 'category')
+                WITH CHECK (val = 'value');
+        `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT NOT NULL,
+                new_val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (new_val = 'value' AND category = 'category')
+                WITH CHECK (new_val = 'value');
+        `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Re-create policy that references deleted columns and new columns (non-public schema)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT,
+                val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (val = 'value' AND category = 'category')
+                WITH CHECK (val = 'value');
+        `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT NOT NULL,
+                new_val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS RESTRICTIVE -- force-recreate the policy 
+                FOR ALL 
+                TO PUBLIC
+                USING (new_val = 'value' AND category = 'category')
+                WITH CHECK (new_val = 'value');
+        `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Alter policy (table is re-created)",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar(
+                    category TEXT,
+                    some_new_column TEXT
+                ); -- Re-create by removing partitioning
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (category = 'category' AND some_new_column = 'value');
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Policy on new partition (not implemented)",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+                CREATE POLICY foobar_1_policy ON foobar_1 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Add policy on existing partition (not implemented)",
-		oldSchemaDDL: []string{
-			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-				CREATE POLICY foobar_1_policy ON foobar_1 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
-		},
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Add policy on existing partition (not implemented)",
+        oldSchemaDDL: []string{
+            `
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+                CREATE POLICY foobar_1_policy ON foobar_1 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
 }
 
 func (suite *acceptanceTestSuite) TestPolicyCases() {
-	suite.runTestCases(policyAcceptanceTestCases)
+    suite.runTestCases(policyAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -3,659 +3,659 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var policyAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "no-op",
-        roles: []string{
-            "role_1",
-            "role_2",
-        },
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE
-                    FOR ALL 
-                    TO role_1, role_2 
-                    USING (true)
-                    WITH CHECK (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE
-                    FOR ALL 
-                    TO role_1, role_2 
-                    USING (true)
-                    WITH CHECK (true);
-            `,
-        },
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Add permissive ALL policy target on non-public schema",
-        roles: []string{
-            "role_1",
-            "role_2",
-        },
-        oldSchemaDDL: []string{
-            `
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS PERMISSIVE
-                    FOR ALL 
-                    TO role_1, role_2
-                    USING (true)
-                    WITH CHECK (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Create SELECT policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Create INSERT policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Create UPDATE policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR UPDATE 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Create DELETE policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Add policy on new table",
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-    },
-    {
-        name: "Add policy then enable RLS",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-        expectedPlanDDL: []string{
-            // Ensure that the policy is created before enabling RLS.
-            "CREATE POLICY \"foobar_policy\" ON \"public\".\"foobar\"\n\tAS RESTRICTIVE\n\tFOR SELECT\n\tTO PUBLIC\n\tUSING (true)",
-            "ALTER TABLE \"public\".\"foobar\" ENABLE ROW LEVEL SECURITY",
-            "ALTER TABLE \"public\".\"foobar\" FORCE ROW LEVEL SECURITY",
-        },
-    },
-    {
-        name: "Drop non-public schema policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Drop policy and table",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Disable RLS then drop policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-        expectedPlanDDL: []string{
-            "ALTER TABLE \"public\".\"foobar\" DISABLE ROW LEVEL SECURITY",
-            "ALTER TABLE \"public\".\"foobar\" NO FORCE ROW LEVEL SECURITY",
-            "DROP POLICY \"foobar_policy\" ON \"public\".\"foobar\"",
-        },
-    },
-    {
-        name: "Drop policy and columns",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar(
-                        category TEXT,
-                        val TEXT
-                );
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (category = 'category' AND val = 'value');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Restrictive to permissive policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Alter policy target",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR DELETE 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name:  "Alter policy applies to",
-        roles: []string{"role_1", "role_2"},
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO role_1, role_2
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Alter policy using",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (false);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Alter policy check",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (false);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Remove using check for ALL policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (true)
-                    WITH CHECK (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Remove check for ALL policy",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (true)
-                    WITH CHECK (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (true);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Alter all alterable attributes on non-public schema",
-        roles: []string{
-            "role_1",
-            "role_2",
-        },
-        oldSchemaDDL: []string{
-            `
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO role_1, role_2
-                    USING (true)
-                    WITH CHECK (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (false)
-                    WITH CHECK (false);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Alter policy that references deleted columns and new columns (non-public schema)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT,
-                val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS PERMISSIVE 
-                FOR ALL 
-                TO PUBLIC
-                USING (val = 'value' AND category = 'category')
-                WITH CHECK (val = 'value');
-        `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT NOT NULL,
-                new_val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS PERMISSIVE 
-                FOR ALL 
-                TO PUBLIC
-                USING (new_val = 'value' AND category = 'category')
-                WITH CHECK (new_val = 'value');
-        `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Re-create policy that references deleted columns and new columns (non-public schema)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT,
-                val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS PERMISSIVE 
-                FOR ALL 
-                TO PUBLIC
-                USING (val = 'value' AND category = 'category')
-                WITH CHECK (val = 'value');
-        `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT NOT NULL,
-                new_val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS RESTRICTIVE -- force-recreate the policy 
-                FOR ALL 
-                TO PUBLIC
-                USING (new_val = 'value' AND category = 'category')
-                WITH CHECK (new_val = 'value');
-        `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Alter policy (table is re-created)",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar(
-                    category TEXT,
-                    some_new_column TEXT
-                ); -- Re-create by removing partitioning
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (category = 'category' AND some_new_column = 'value');
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Policy on new partition (not implemented)",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-                CREATE POLICY foobar_1_policy ON foobar_1 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
-        },
+	{
+		name: "no-op",
+		roles: []string{
+			"role_1",
+			"role_2",
+		},
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE
+					FOR ALL 
+					TO role_1, role_2 
+					USING (true)
+					WITH CHECK (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE
+					FOR ALL 
+					TO role_1, role_2 
+					USING (true)
+					WITH CHECK (true);
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Add permissive ALL policy target on non-public schema",
+		roles: []string{
+			"role_1",
+			"role_2",
+		},
+		oldSchemaDDL: []string{
+			`
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS PERMISSIVE
+					FOR ALL 
+					TO role_1, role_2
+					USING (true)
+					WITH CHECK (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Create SELECT policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Create INSERT policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Create UPDATE policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR UPDATE 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Create DELETE policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Add policy on new table",
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+	},
+	{
+		name: "Add policy then enable RLS",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+		expectedPlanDDL: []string{
+			// Ensure that the policy is created before enabling RLS.
+			"CREATE POLICY \"foobar_policy\" ON \"public\".\"foobar\"\n\tAS RESTRICTIVE\n\tFOR SELECT\n\tTO PUBLIC\n\tUSING (true)",
+			"ALTER TABLE \"public\".\"foobar\" ENABLE ROW LEVEL SECURITY",
+			"ALTER TABLE \"public\".\"foobar\" FORCE ROW LEVEL SECURITY",
+		},
+	},
+	{
+		name: "Drop non-public schema policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Drop policy and table",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Disable RLS then drop policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+		expectedPlanDDL: []string{
+			"ALTER TABLE \"public\".\"foobar\" DISABLE ROW LEVEL SECURITY",
+			"ALTER TABLE \"public\".\"foobar\" NO FORCE ROW LEVEL SECURITY",
+			"DROP POLICY \"foobar_policy\" ON \"public\".\"foobar\"",
+		},
+	},
+	{
+		name: "Drop policy and columns",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar(
+						category TEXT,
+						val TEXT
+				);
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (category = 'category' AND val = 'value');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Restrictive to permissive policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter policy target",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR DELETE 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name:  "Alter policy applies to",
+		roles: []string{"role_1", "role_2"},
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO role_1, role_2
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter policy using",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (false);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter policy check",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (false);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Remove using check for ALL policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (true)
+					WITH CHECK (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Remove check for ALL policy",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (true)
+					WITH CHECK (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter all alterable attributes on non-public schema",
+		roles: []string{
+			"role_1",
+			"role_2",
+		},
+		oldSchemaDDL: []string{
+			`
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO role_1, role_2
+					USING (true)
+					WITH CHECK (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (false)
+					WITH CHECK (false);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter policy that references deleted columns and new columns (non-public schema)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT,
+			    val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS PERMISSIVE 
+				FOR ALL 
+				TO PUBLIC
+				USING (val = 'value' AND category = 'category')
+				WITH CHECK (val = 'value');
+		`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT NOT NULL,
+			    new_val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS PERMISSIVE 
+				FOR ALL 
+				TO PUBLIC
+				USING (new_val = 'value' AND category = 'category')
+				WITH CHECK (new_val = 'value');
+		`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Re-create policy that references deleted columns and new columns (non-public schema)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT,
+			    val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS PERMISSIVE 
+				FOR ALL 
+				TO PUBLIC
+				USING (val = 'value' AND category = 'category')
+				WITH CHECK (val = 'value');
+		`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT NOT NULL,
+			    new_val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS RESTRICTIVE -- force-recreate the policy 
+				FOR ALL 
+				TO PUBLIC
+				USING (new_val = 'value' AND category = 'category')
+				WITH CHECK (new_val = 'value');
+		`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Alter policy (table is re-created)",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar(
+				    category TEXT,
+					some_new_column TEXT
+				); -- Re-create by removing partitioning
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (category = 'category' AND some_new_column = 'value');
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Policy on new partition (not implemented)",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+				CREATE POLICY foobar_1_policy ON foobar_1 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Add policy on existing partition (not implemented)",
-        oldSchemaDDL: []string{
-            `
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-                CREATE POLICY foobar_1_policy ON foobar_1 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
-        },
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Add policy on existing partition (not implemented)",
+		oldSchemaDDL: []string{
+			`
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+				CREATE POLICY foobar_1_policy ON foobar_1 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
 }
 
 func (suite *acceptanceTestSuite) TestPolicyCases() {
-    suite.runTestCases(policyAcceptanceTestCases)
+	suite.runTestCases(policyAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -11,25 +11,25 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE
-                    FOR ALL 
-                    TO role_1, role_2 
-                    USING (true)
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE
+					FOR ALL 
+					TO role_1, role_2 
+					USING (true)
+					WITH CHECK (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE
-                    FOR ALL 
-                    TO role_1, role_2 
-                    USING (true)
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE
+					FOR ALL 
+					TO role_1, role_2 
+					USING (true)
+					WITH CHECK (true);
+			`,
 		},
 		expectEmptyPlan: true,
 	},
@@ -41,21 +41,21 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-            `,
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS PERMISSIVE
-                    FOR ALL 
-                    TO role_1, role_2
-                    USING (true)
-                    WITH CHECK (true);
-            `,
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS PERMISSIVE
+					FOR ALL 
+					TO role_1, role_2
+					USING (true)
+					WITH CHECK (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -65,18 +65,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create SELECT policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-            `,
+				CREATE TABLE foobar();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -86,18 +86,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create INSERT policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-            `,
+				CREATE TABLE foobar();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -107,18 +107,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create UPDATE policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-            `,
+				CREATE TABLE foobar();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR UPDATE 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR UPDATE 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -128,18 +128,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create DELETE policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-            `,
+				CREATE TABLE foobar();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -149,33 +149,33 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add policy on new table",
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 	},
 	{
 		name: "Add policy then enable RLS",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-            `,
+				CREATE TABLE foobar();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -191,20 +191,20 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop non-public schema policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-            `,
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -214,13 +214,13 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop policy and table",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -230,20 +230,20 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS then drop policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-            `,
+				CREATE TABLE foobar();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -258,21 +258,21 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop policy and columns",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar(
-                        category TEXT,
-                        val TEXT
-                );
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (category = 'category' AND val = 'value');
-            `,
+				CREATE TABLE foobar(
+						category TEXT,
+						val TEXT
+				);
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE
+					FOR SELECT 
+					TO PUBLIC
+					USING (category = 'category' AND val = 'value');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-            `,
+				CREATE TABLE foobar();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -283,23 +283,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Restrictive to permissive policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS RESTRICTIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS RESTRICTIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -309,23 +309,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy target",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR DELETE 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR DELETE 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -336,23 +336,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		roles: []string{"role_1", "role_2"},
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO role_1, role_2
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO role_1, role_2
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -362,23 +362,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy using",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR SELECT 
-                    TO PUBLIC
-                    USING (false);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR SELECT 
+					TO PUBLIC
+					USING (false);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -388,23 +388,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy check",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (false);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (false);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -414,24 +414,24 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove using check for ALL policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (true)
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (true)
+					WITH CHECK (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -441,24 +441,24 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove check for ALL policy",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (true)
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (true)
+					WITH CHECK (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar();
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (true);
-            `,
+				CREATE TABLE foobar();
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (true);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -472,27 +472,27 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO role_1, role_2
-                    USING (true)
-                    WITH CHECK (true);
-            `,
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO role_1, role_2
+					USING (true)
+					WITH CHECK (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE SCHEMA schema_1;
-                CREATE TABLE schema_1.foobar();
-                CREATE POLICY foobar_policy ON schema_1.foobar 
-                    AS PERMISSIVE 
-                    FOR ALL 
-                    TO PUBLIC
-                    USING (false)
-                    WITH CHECK (false);
-            `,
+				CREATE SCHEMA schema_1;
+				CREATE TABLE schema_1.foobar();
+				CREATE POLICY foobar_policy ON schema_1.foobar 
+					AS PERMISSIVE 
+					FOR ALL 
+					TO PUBLIC
+					USING (false)
+					WITH CHECK (false);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -502,33 +502,33 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy that references deleted columns and new columns (non-public schema)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT,
-                val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS PERMISSIVE 
-                FOR ALL 
-                TO PUBLIC
-                USING (val = 'value' AND category = 'category')
-                WITH CHECK (val = 'value');
-        `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT,
+			    val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS PERMISSIVE 
+				FOR ALL 
+				TO PUBLIC
+				USING (val = 'value' AND category = 'category')
+				WITH CHECK (val = 'value');
+		`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT NOT NULL,
-                new_val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS PERMISSIVE 
-                FOR ALL 
-                TO PUBLIC
-                USING (new_val = 'value' AND category = 'category')
-                WITH CHECK (new_val = 'value');
-        `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT NOT NULL,
+			    new_val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS PERMISSIVE 
+				FOR ALL 
+				TO PUBLIC
+				USING (new_val = 'value' AND category = 'category')
+				WITH CHECK (new_val = 'value');
+		`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -539,33 +539,33 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Re-create policy that references deleted columns and new columns (non-public schema)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT,
-                val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS PERMISSIVE 
-                FOR ALL 
-                TO PUBLIC
-                USING (val = 'value' AND category = 'category')
-                WITH CHECK (val = 'value');
-        `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT,
+			    val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS PERMISSIVE 
+				FOR ALL 
+				TO PUBLIC
+				USING (val = 'value' AND category = 'category')
+				WITH CHECK (val = 'value');
+		`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                category TEXT NOT NULL,
-                new_val TEXT
-            );
-            CREATE POLICY foobar_policy ON schema_1.foobar 
-                AS RESTRICTIVE -- force-recreate the policy 
-                FOR ALL 
-                TO PUBLIC
-                USING (new_val = 'value' AND category = 'category')
-                WITH CHECK (new_val = 'value');
-        `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    category TEXT NOT NULL,
+			    new_val TEXT
+			);
+			CREATE POLICY foobar_policy ON schema_1.foobar 
+				AS RESTRICTIVE -- force-recreate the policy 
+				FOR ALL 
+				TO PUBLIC
+				USING (new_val = 'value' AND category = 'category')
+				WITH CHECK (new_val = 'value');
+		`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -576,28 +576,28 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy (table is re-created)",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar(
-                    category TEXT,
-                    some_new_column TEXT
-                ); -- Re-create by removing partitioning
-                CREATE POLICY foobar_policy ON foobar 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (category = 'category' AND some_new_column = 'value');
-            `,
+				CREATE TABLE foobar(
+				    category TEXT,
+					some_new_column TEXT
+				); -- Re-create by removing partitioning
+				CREATE POLICY foobar_policy ON foobar 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (category = 'category' AND some_new_column = 'value');
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -607,23 +607,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Policy on new partition (not implemented)",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-            `,
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-                CREATE POLICY foobar_1_policy ON foobar_1 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+				CREATE POLICY foobar_1_policy ON foobar_1 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -632,24 +632,24 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add policy on existing partition (not implemented)",
 		oldSchemaDDL: []string{
 			`
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-            `,
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-                CREATE TABLE foobar(
-                    category TEXT
-                ) partition by list (category);
-                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-                CREATE POLICY foobar_1_policy ON foobar_1 
-                    AS PERMISSIVE 
-                    FOR INSERT 
-                    TO PUBLIC
-                    WITH CHECK (true);
-            `,
+				CREATE TABLE foobar(
+				    category TEXT
+				) partition by list (category);
+				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+				CREATE POLICY foobar_1_policy ON foobar_1 
+					AS PERMISSIVE 
+					FOR INSERT 
+					TO PUBLIC
+					WITH CHECK (true);
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -11,25 +11,25 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2 
-					USING (true)
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2 
+                    USING (true)
+                    WITH CHECK (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2 
-					USING (true)
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2 
+                    USING (true)
+                    WITH CHECK (true);
+            `,
 		},
 		expectEmptyPlan: true,
 	},
@@ -41,21 +41,21 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-			`,
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2
-					USING (true)
-					WITH CHECK (true);
-			`,
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2
+                    USING (true)
+                    WITH CHECK (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -65,18 +65,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create SELECT policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-			`,
+                CREATE TABLE foobar();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -86,18 +86,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create INSERT policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-			`,
+                CREATE TABLE foobar();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -107,18 +107,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create UPDATE policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-			`,
+                CREATE TABLE foobar();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR UPDATE 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR UPDATE 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -128,18 +128,18 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create DELETE policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-			`,
+                CREATE TABLE foobar();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -149,33 +149,33 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add policy on new table",
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 	},
 	{
 		name: "Add policy then enable RLS",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-			`,
+                CREATE TABLE foobar();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -191,20 +191,20 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop non-public schema policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-			`,
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -214,13 +214,13 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop policy and table",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -230,20 +230,20 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS then drop policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-			`,
+                CREATE TABLE foobar();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -258,21 +258,21 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop policy and columns",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-						category TEXT,
-						val TEXT
-				);
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (category = 'category' AND val = 'value');
-			`,
+                CREATE TABLE foobar(
+                        category TEXT,
+                        val TEXT
+                );
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (category = 'category' AND val = 'value');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-			`,
+                CREATE TABLE foobar();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -283,23 +283,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Restrictive to permissive policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -309,23 +309,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy target",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR DELETE 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR DELETE 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -336,23 +336,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		roles: []string{"role_1", "role_2"},
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO role_1, role_2
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO role_1, role_2
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -362,23 +362,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy using",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (false);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (false);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -388,23 +388,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy check",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (false);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (false);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -414,24 +414,24 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove using check for ALL policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true)
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -441,24 +441,24 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove check for ALL policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true)
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true);
-			`,
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -472,27 +472,27 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO role_1, role_2
-					USING (true)
-					WITH CHECK (true);
-			`,
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO role_1, role_2
+                    USING (true)
+                    WITH CHECK (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (false)
-					WITH CHECK (false);
-			`,
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (false)
+                    WITH CHECK (false);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -502,33 +502,33 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy that references deleted columns and new columns (non-public schema)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT,
-			    val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (val = 'value' AND category = 'category')
-				WITH CHECK (val = 'value');
-		`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT,
+                val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (val = 'value' AND category = 'category')
+                WITH CHECK (val = 'value');
+        `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT NOT NULL,
-			    new_val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (new_val = 'value' AND category = 'category')
-				WITH CHECK (new_val = 'value');
-		`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT NOT NULL,
+                new_val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (new_val = 'value' AND category = 'category')
+                WITH CHECK (new_val = 'value');
+        `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -539,33 +539,33 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Re-create policy that references deleted columns and new columns (non-public schema)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT,
-			    val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (val = 'value' AND category = 'category')
-				WITH CHECK (val = 'value');
-		`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT,
+                val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (val = 'value' AND category = 'category')
+                WITH CHECK (val = 'value');
+        `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    category TEXT NOT NULL,
-			    new_val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS RESTRICTIVE -- force-recreate the policy 
-				FOR ALL 
-				TO PUBLIC
-				USING (new_val = 'value' AND category = 'category')
-				WITH CHECK (new_val = 'value');
-		`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT NOT NULL,
+                new_val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS RESTRICTIVE -- force-recreate the policy 
+                FOR ALL 
+                TO PUBLIC
+                USING (new_val = 'value' AND category = 'category')
+                WITH CHECK (new_val = 'value');
+        `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -576,28 +576,28 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy (table is re-created)",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-				    category TEXT,
-					some_new_column TEXT
-				); -- Re-create by removing partitioning
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (category = 'category' AND some_new_column = 'value');
-			`,
+                CREATE TABLE foobar(
+                    category TEXT,
+                    some_new_column TEXT
+                ); -- Re-create by removing partitioning
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (category = 'category' AND some_new_column = 'value');
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -607,23 +607,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Policy on new partition (not implemented)",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-			`,
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-				CREATE POLICY foobar_1_policy ON foobar_1 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+                CREATE POLICY foobar_1_policy ON foobar_1 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -632,24 +632,24 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add policy on existing partition (not implemented)",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-			`,
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-				    category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-				CREATE POLICY foobar_1_policy ON foobar_1 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
-			`,
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+                CREATE POLICY foobar_1_policy ON foobar_1 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -11,24 +11,24 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2 
-					USING (true)
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2 
+                    USING (true)
+                    WITH CHECK (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2 
-					USING (true)
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2 
+                    USING (true)
+                    WITH CHECK (true);
 			`,
 		},
 		expectEmptyPlan: true,
@@ -41,20 +41,20 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE
-					FOR ALL 
-					TO role_1, role_2
-					USING (true)
-					WITH CHECK (true);
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE
+                    FOR ALL 
+                    TO role_1, role_2
+                    USING (true)
+                    WITH CHECK (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -65,17 +65,17 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create SELECT policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
+                CREATE TABLE foobar();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -86,17 +86,17 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create INSERT policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
+                CREATE TABLE foobar();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -107,17 +107,17 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create UPDATE policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
+                CREATE TABLE foobar();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR UPDATE 
-					TO PUBLIC
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR UPDATE 
+                    TO PUBLIC
+                    WITH CHECK (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -128,17 +128,17 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create DELETE policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
+                CREATE TABLE foobar();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -149,12 +149,12 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add policy on new table",
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 	},
@@ -162,19 +162,19 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add policy then enable RLS",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
+                CREATE TABLE foobar();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -191,19 +191,19 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop non-public schema policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -214,12 +214,12 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop policy and table",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -230,19 +230,19 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS then drop policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
-				ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-				ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
+                ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+                ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
+                CREATE TABLE foobar();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -258,20 +258,20 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop policy and columns",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-						category TEXT,
-						val TEXT
-				);
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE
-					FOR SELECT 
-					TO PUBLIC
-					USING (category = 'category' AND val = 'value');
+                CREATE TABLE foobar(
+                        category TEXT,
+                        val TEXT
+                );
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (category = 'category' AND val = 'value');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
+                CREATE TABLE foobar();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -283,22 +283,22 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Restrictive to permissive policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS RESTRICTIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS RESTRICTIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -309,22 +309,22 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy target",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR DELETE 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR DELETE 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -336,22 +336,22 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		roles: []string{"role_1", "role_2"},
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO role_1, role_2
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO role_1, role_2
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -362,22 +362,22 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy using",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR SELECT 
-					TO PUBLIC
-					USING (false);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR SELECT 
+                    TO PUBLIC
+                    USING (false);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -388,22 +388,22 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy check",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (false);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (false);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -414,23 +414,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove using check for ALL policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true)
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    WITH CHECK (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -441,23 +441,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Remove check for ALL policy",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true)
-					WITH CHECK (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar();
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (true);
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (true);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -472,26 +472,26 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		},
 		oldSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO role_1, role_2
-					USING (true)
-					WITH CHECK (true);
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO role_1, role_2
+                    USING (true)
+                    WITH CHECK (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE SCHEMA schema_1;
-				CREATE TABLE schema_1.foobar();
-				CREATE POLICY foobar_policy ON schema_1.foobar 
-					AS PERMISSIVE 
-					FOR ALL 
-					TO PUBLIC
-					USING (false)
-					WITH CHECK (false);
+                CREATE SCHEMA schema_1;
+                CREATE TABLE schema_1.foobar();
+                CREATE POLICY foobar_policy ON schema_1.foobar 
+                    AS PERMISSIVE 
+                    FOR ALL 
+                    TO PUBLIC
+                    USING (false)
+                    WITH CHECK (false);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -502,32 +502,32 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy that references deleted columns and new columns (non-public schema)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				category TEXT,
-				val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (val = 'value' AND category = 'category')
-				WITH CHECK (val = 'value');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT,
+                val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (val = 'value' AND category = 'category')
+                WITH CHECK (val = 'value');
 		`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				category TEXT NOT NULL,
-				new_val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (new_val = 'value' AND category = 'category')
-				WITH CHECK (new_val = 'value');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT NOT NULL,
+                new_val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (new_val = 'value' AND category = 'category')
+                WITH CHECK (new_val = 'value');
 		`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -539,32 +539,32 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Re-create policy that references deleted columns and new columns (non-public schema)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				category TEXT,
-				val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS PERMISSIVE 
-				FOR ALL 
-				TO PUBLIC
-				USING (val = 'value' AND category = 'category')
-				WITH CHECK (val = 'value');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT,
+                val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS PERMISSIVE 
+                FOR ALL 
+                TO PUBLIC
+                USING (val = 'value' AND category = 'category')
+                WITH CHECK (val = 'value');
 		`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				category TEXT NOT NULL,
-				new_val TEXT
-			);
-			CREATE POLICY foobar_policy ON schema_1.foobar 
-				AS RESTRICTIVE -- force-recreate the policy 
-				FOR ALL 
-				TO PUBLIC
-				USING (new_val = 'value' AND category = 'category')
-				WITH CHECK (new_val = 'value');
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                category TEXT NOT NULL,
+                new_val TEXT
+            );
+            CREATE POLICY foobar_policy ON schema_1.foobar 
+                AS RESTRICTIVE -- force-recreate the policy 
+                FOR ALL 
+                TO PUBLIC
+                USING (new_val = 'value' AND category = 'category')
+                WITH CHECK (new_val = 'value');
 		`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -576,27 +576,27 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter policy (table is re-created)",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-					category TEXT
-				) partition by list (category);
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-					category TEXT,
-					some_new_column TEXT
-				); -- Re-create by removing partitioning
-				CREATE POLICY foobar_policy ON foobar 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (category = 'category' AND some_new_column = 'value');
+                CREATE TABLE foobar(
+                    category TEXT,
+                    some_new_column TEXT
+                ); -- Re-create by removing partitioning
+                CREATE POLICY foobar_policy ON foobar 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (category = 'category' AND some_new_column = 'value');
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -607,22 +607,22 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Policy on new partition (not implemented)",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-					category TEXT
-				) partition by list (category);
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-					category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-				CREATE POLICY foobar_1_policy ON foobar_1 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+                CREATE POLICY foobar_1_policy ON foobar_1 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
 			`,
 		},
 
@@ -632,23 +632,23 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add policy on existing partition (not implemented)",
 		oldSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-					category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-				CREATE TABLE foobar(
-					category TEXT
-				) partition by list (category);
-				CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
-				CREATE POLICY foobar_1_policy ON foobar_1 
-					AS PERMISSIVE 
-					FOR INSERT 
-					TO PUBLIC
-					WITH CHECK (true);
+                CREATE TABLE foobar(
+                    category TEXT
+                ) partition by list (category);
+                CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('category');
+                CREATE POLICY foobar_1_policy ON foobar_1 
+                    AS PERMISSIVE 
+                    FOR INSERT 
+                    TO PUBLIC
+                    WITH CHECK (true);
 			`,
 		},
 

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -1,433 +1,433 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 // These are tests for "public" schema" alterations (full migrations)
 var schemaAcceptanceTests = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-            CREATE SEQUENCE schema_1.foobar_sequence
-                AS BIGINT
-                INCREMENT BY 2
-                MINVALUE 5 MAXVALUE 100
-                START WITH 10 CACHE 5 CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_1.foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + increment(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + increment(a);
 
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                bar SERIAL NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                color schema_1.color DEFAULT 'green',
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
-            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    bar SERIAL NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				color schema_1.color DEFAULT 'green',
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-            CREATE table bar(
-                id  INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            ALTER TABLE bar REPLICA IDENTITY FULL;
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
+			CREATE table bar(
+			    id  INT PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			ALTER TABLE bar REPLICA IDENTITY FULL;
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-            CREATE SEQUENCE schema_1.foobar_sequence
-                AS BIGINT
-                INCREMENT BY 2
-                MINVALUE 5 MAXVALUE 100
-                START WITH 10 CACHE 5 CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_1.foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + increment(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + increment(a);
 
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                bar SERIAL NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                color schema_1.color DEFAULT 'green',
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
-            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    bar SERIAL NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				color schema_1.color DEFAULT 'green',
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-            CREATE table bar(
-                id  INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            ALTER TABLE bar REPLICA IDENTITY FULL;
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-            `,
-        },
-        expectEmptyPlan: true,
-    },
-    {
-        name:  "Add schema, drop schema, Add enum, Drop enum, Drop table, Add Table, Drop Seq, Add Seq, Drop Funcs, Add Funcs, Drop Triggers, Add Triggers, Create Extension, Drop Extension, Create Index Using Extension, Add policies, Drop policies",
-        roles: []string{"role_1"},
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-            
-            CREATE SCHEMA schema_2;
+			CREATE table bar(
+			    id  INT PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			ALTER TABLE bar REPLICA IDENTITY FULL;
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name:  "Add schema, drop schema, Add enum, Drop enum, Drop table, Add Table, Drop Seq, Add Seq, Drop Funcs, Add Funcs, Drop Triggers, Add Triggers, Create Extension, Drop Extension, Create Index Using Extension, Add policies, Drop policies",
+		roles: []string{"role_1"},
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+			
+			CREATE SCHEMA schema_2;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-            CREATE SEQUENCE schema_2.foobar_sequence
-                AS BIGINT
-                INCREMENT BY 2
-                MINVALUE 5 MAXVALUE 100
-                START WITH 10 CACHE 5 CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_2.foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_2.add(a, b) + increment(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_2.add(a, b) + increment(a);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = increment(OLD.version);
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = increment(OLD.version);
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                color schema_1.color DEFAULT 'green',
-                UNIQUE (foo, bar)
-            );
-            CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				color schema_1.color DEFAULT 'green',
+				UNIQUE (foo, bar)
+			);
+			CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
 
-            CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+			CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE table schema_2.bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL,
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
-            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-            CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
+			CREATE table schema_2.bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL,
+				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
+			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+			CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
 
-            CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
-            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE EXTENSION pg_trgm;
-            
-            CREATE SCHEMA schema_2;
-            CREATE SCHEMA schema_3;
+			CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
+			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE EXTENSION pg_trgm;
+			
+			CREATE SCHEMA schema_2;
+			CREATE SCHEMA schema_3;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
+			CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
 
-            CREATE SEQUENCE schema_3.new_foobar_sequence
-                AS SMALLINT
-                INCREMENT BY 4
-                MINVALUE 10 MAXVALUE 200
-                START WITH 20 CACHE 10 NO CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_3.new_foobar_sequence
+			    AS SMALLINT
+				INCREMENT BY 4
+				MINVALUE 10 MAXVALUE 200
+				START WITH 20 CACHE 10 NO CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b + a;
+			CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b + a;
 
-            CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 2;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 2;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_3."new add"(a, b) + "new increment"(a);
+			CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_3."new add"(a, b) + "new increment"(a);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = "new increment"(OLD.version);
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = "new increment"(OLD.version);
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TABLE "New_table"(
-                new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY,
-                version INT NOT NULL DEFAULT 0,
-                new_color new_color DEFAULT 'cyan',
-                new_bar SMALLSERIAL NOT NULL,
-                new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
-                UNIQUE (new_foo, new_bar)
-            );
-            ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
-            CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
+			CREATE TABLE "New_table"(
+			    new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    id INT PRIMARY KEY,
+			    version INT NOT NULL DEFAULT 0,
+			    new_color new_color DEFAULT 'cyan',
+			    new_bar SMALLSERIAL NOT NULL,
+				new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
+				UNIQUE (new_foo, new_bar)
+			);
+			ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
+			CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
 
-            CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
+			CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "New_table"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "New_table"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TABLE schema_2.bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL,
-                quux TEXT,
-                FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
-            );
-            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
-            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-            CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
-            CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
+			CREATE TABLE schema_2.bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL,
+				quux TEXT,
+				FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
+			);
+			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
+			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+			CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
+			CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
 
-            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
+			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
 
-            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-                BEGIN
-                    IF LENGTH(NEW.id) == 0 THEN
-                        RAISE EXCEPTION 'content is empty';
-                    END IF;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+				BEGIN
+				    IF LENGTH(NEW.id) == 0 THEN
+				        RAISE EXCEPTION 'content is empty';
+				    END IF;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_check_trigger
-                BEFORE UPDATE ON schema_2.bar
-                FOR EACH ROW
-                EXECUTE FUNCTION check_content();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeAuthzUpdate,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeHasUntrackableDependencies,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Drop partitioned table, Add partitioned table with local keys",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE fizz();
-        
-            CREATE TABLE foobar(
-                id INT,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TRIGGER some_check_trigger
+				BEFORE UPDATE ON schema_2.bar
+				FOR EACH ROW
+				EXECUTE FUNCTION check_content();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeAuthzUpdate,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeHasUntrackableDependencies,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Drop partitioned table, Add partitioned table with local keys",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE fizz();
+		
+			CREATE TABLE foobar(
+			    id INT,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE fizz();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE fizz();
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                bar TIMESTAMPTZ NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				bar TIMESTAMPTZ NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-            
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestSchemaTestCases() {
-    suite.runTestCases(schemaAcceptanceTests)
+	suite.runTestCases(schemaAcceptanceTests)
 }

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -10,151 +10,151 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-            CREATE SEQUENCE schema_1.foobar_sequence
-                AS BIGINT
-                INCREMENT BY 2
-                MINVALUE 5 MAXVALUE 100
-                START WITH 10 CACHE 5 CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_1.foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + increment(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + increment(a);
 
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                bar SERIAL NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                color schema_1.color DEFAULT 'green',
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
-            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    bar SERIAL NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				color schema_1.color DEFAULT 'green',
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-            CREATE table bar(
-                id  INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            ALTER TABLE bar REPLICA IDENTITY FULL;
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-            `,
+			CREATE table bar(
+			    id  INT PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			ALTER TABLE bar REPLICA IDENTITY FULL;
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION amcheck;
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION amcheck;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-            CREATE SEQUENCE schema_1.foobar_sequence
-                AS BIGINT
-                INCREMENT BY 2
-                MINVALUE 5 MAXVALUE 100
-                START WITH 10 CACHE 5 CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_1.foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_1.add(a, b) + increment(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_1.add(a, b) + increment(a);
 
-            CREATE TABLE schema_1.foobar(
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                bar SERIAL NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                color schema_1.color DEFAULT 'green',
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
-            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+			CREATE TABLE schema_1.foobar(
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    bar SERIAL NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				color schema_1.color DEFAULT 'green',
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
+			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-            CREATE table bar(
-                id  INT PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            ALTER TABLE bar REPLICA IDENTITY FULL;
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-            `,
+			CREATE table bar(
+			    id  INT PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			ALTER TABLE bar REPLICA IDENTITY FULL;
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+			`,
 		},
 		expectEmptyPlan: true,
 	},
@@ -163,178 +163,178 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		roles: []string{"role_1"},
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-            
-            CREATE SCHEMA schema_2;
+			CREATE SCHEMA schema_1;
+			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+			
+			CREATE SCHEMA schema_2;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-            CREATE SEQUENCE schema_2.foobar_sequence
-                AS BIGINT
-                INCREMENT BY 2
-                MINVALUE 5 MAXVALUE 100
-                START WITH 10 CACHE 5 CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_2.foobar_sequence
+			    AS BIGINT
+				INCREMENT BY 2
+				MINVALUE 5 MAXVALUE 100
+				START WITH 10 CACHE 5 CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b;
+			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b;
 
-            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 1;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 1;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_2.add(a, b) + increment(a);
+			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_2.add(a, b) + increment(a);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = increment(OLD.version);
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = increment(OLD.version);
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                color schema_1.color DEFAULT 'green',
-                UNIQUE (foo, bar)
-            );
-            CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				color schema_1.color DEFAULT 'green',
+				UNIQUE (foo, bar)
+			);
+			CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
 
-            CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+			CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON foobar
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON foobar
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE table schema_2.bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL,
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
-            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-            CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
+			CREATE table schema_2.bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL,
+				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
+			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+			CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
 
-            CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
-            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
-            `,
+			CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
+			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE EXTENSION pg_trgm;
-            
-            CREATE SCHEMA schema_2;
-            CREATE SCHEMA schema_3;
+			CREATE EXTENSION pg_trgm;
+			
+			CREATE SCHEMA schema_2;
+			CREATE SCHEMA schema_3;
 
-            CREATE TABLE fizz(
-            );
+			CREATE TABLE fizz(
+			);
 
-            CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
+			CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
 
-            CREATE SEQUENCE schema_3.new_foobar_sequence
-                AS SMALLINT
-                INCREMENT BY 4
-                MINVALUE 10 MAXVALUE 200
-                START WITH 20 CACHE 10 NO CYCLE
-                OWNED BY NONE;
+			CREATE SEQUENCE schema_3.new_foobar_sequence
+			    AS SMALLINT
+				INCREMENT BY 4
+				MINVALUE 10 MAXVALUE 200
+				START WITH 20 CACHE 10 NO CYCLE
+				OWNED BY NONE;
 
-            CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN a + b + a;
+			CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN a + b + a;
 
-            CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
-                    BEGIN
-                            RETURN i + 2;
-                    END;
-            $$ LANGUAGE plpgsql;
+			CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
+					BEGIN
+							RETURN i + 2;
+					END;
+			$$ LANGUAGE plpgsql;
 
-            CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
-                LANGUAGE SQL
-                IMMUTABLE
-                RETURNS NULL ON NULL INPUT
-                RETURN schema_3."new add"(a, b) + "new increment"(a);
+			CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
+				LANGUAGE SQL
+				IMMUTABLE
+				RETURNS NULL ON NULL INPUT
+				RETURN schema_3."new add"(a, b) + "new increment"(a);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = "new increment"(OLD.version);
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = "new increment"(OLD.version);
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TABLE "New_table"(
-                new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY,
-                version INT NOT NULL DEFAULT 0,
-                new_color new_color DEFAULT 'cyan',
-                new_bar SMALLSERIAL NOT NULL,
-                new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
-                UNIQUE (new_foo, new_bar)
-            );
-            ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
-            CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
+			CREATE TABLE "New_table"(
+			    new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    id INT PRIMARY KEY,
+			    version INT NOT NULL DEFAULT 0,
+			    new_color new_color DEFAULT 'cyan',
+			    new_bar SMALLSERIAL NOT NULL,
+				new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
+				UNIQUE (new_foo, new_bar)
+			);
+			ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
+			CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
 
-            CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
+			CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "New_table"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "New_table"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TABLE schema_2.bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL,
-                quux TEXT,
-                FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
-            );
-            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
-            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-            CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
-            CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
+			CREATE TABLE schema_2.bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL,
+				quux TEXT,
+				FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
+			);
+			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
+			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+			CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
+			CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
 
-            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
+			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
 
-            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-                BEGIN
-                    IF LENGTH(NEW.id) == 0 THEN
-                        RAISE EXCEPTION 'content is empty';
-                    END IF;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+				BEGIN
+				    IF LENGTH(NEW.id) == 0 THEN
+				        RAISE EXCEPTION 'content is empty';
+				    END IF;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_check_trigger
-                BEFORE UPDATE ON schema_2.bar
-                FOR EACH ROW
-                EXECUTE FUNCTION check_content();
-            `,
+			CREATE TRIGGER some_check_trigger
+				BEFORE UPDATE ON schema_2.bar
+				FOR EACH ROW
+				EXECUTE FUNCTION check_content();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -348,78 +348,78 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE fizz();
-        
-            CREATE TABLE foobar(
-                id INT,
-                bar SERIAL NOT NULL,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (foo, id),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE TABLE fizz();
+		
+			CREATE TABLE foobar(
+			    id INT,
+			    bar SERIAL NOT NULL,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    PRIMARY KEY (foo, id),
+				UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE foobar_1 PARTITION of foobar(
-                fizz NOT NULL
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE foobar_1 PARTITION of foobar(
+			    fizz NOT NULL
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-            `,
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE fizz();
+			CREATE TABLE fizz();
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                bar TIMESTAMPTZ NOT NULL,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                id INT,
-                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-                UNIQUE (foo, bar)
-            ) PARTITION BY LIST(foo);
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+				bar TIMESTAMPTZ NOT NULL,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    id INT,
+				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+			    UNIQUE (foo, bar)
+			) PARTITION BY LIST(foo);
 
-            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-                fizz NOT NULL,
-                PRIMARY KEY (foo, bar)
-            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+			    fizz NOT NULL,
+			    PRIMARY KEY (foo, bar)
+			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-            -- local indexes
-            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-            -- partitioned indexes
-            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+			-- local indexes
+			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+			-- partitioned indexes
+			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-            CREATE table bar(
-                id VARCHAR(255) PRIMARY KEY,
-                foo VARCHAR(255),
-                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-            );
-            CREATE INDEX bar_normal_idx ON bar(bar);
-            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-            
-            `,
+			CREATE table bar(
+			    id VARCHAR(255) PRIMARY KEY,
+			    foo VARCHAR(255),
+			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+			);
+			CREATE INDEX bar_normal_idx ON bar(bar);
+			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+			
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -10,150 +10,150 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_1.foobar_sequence
-				AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_1.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + increment(a);
 
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				bar SERIAL NOT NULL,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                bar SERIAL NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
+            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-				fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE table bar(
-				id  INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+            CREATE table bar(
+                id  INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            ALTER TABLE bar REPLICA IDENTITY FULL;
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_1.foobar_sequence
-				AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_1.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + increment(a);
 
-			CREATE TABLE schema_1.foobar(
-				id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				bar SERIAL NOT NULL,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                bar SERIAL NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
+            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-				fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE table bar(
-				id  INT PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+            CREATE table bar(
+                id  INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            ALTER TABLE bar REPLICA IDENTITY FULL;
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
 			`,
 		},
 		expectEmptyPlan: true,
@@ -163,177 +163,177 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		roles: []string{"role_1"},
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-			
-			CREATE SCHEMA schema_2;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+            
+            CREATE SCHEMA schema_2;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_2.foobar_sequence
-				AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_2.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_2.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_2.add(a, b) + increment(a);
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = increment(OLD.version);
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = increment(OLD.version);
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-				UNIQUE (foo, bar)
-			);
-			CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                UNIQUE (foo, bar)
+            );
+            CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
 
-			CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE table schema_2.bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL,
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
-			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-			CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
+            CREATE table schema_2.bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL,
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
+            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+            CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
 
-			CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
-			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
+            CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
+            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE EXTENSION pg_trgm;
-			
-			CREATE SCHEMA schema_2;
-			CREATE SCHEMA schema_3;
+            CREATE EXTENSION pg_trgm;
+            
+            CREATE SCHEMA schema_2;
+            CREATE SCHEMA schema_3;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
+            CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
 
-			CREATE SEQUENCE schema_3.new_foobar_sequence
-				AS SMALLINT
-				INCREMENT BY 4
-				MINVALUE 10 MAXVALUE 200
-				START WITH 20 CACHE 10 NO CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_3.new_foobar_sequence
+                AS SMALLINT
+                INCREMENT BY 4
+                MINVALUE 10 MAXVALUE 200
+                START WITH 20 CACHE 10 NO CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b + a;
+            CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b + a;
 
-			CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 2;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 2;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_3."new add"(a, b) + "new increment"(a);
+            CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_3."new add"(a, b) + "new increment"(a);
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = "new increment"(OLD.version);
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = "new increment"(OLD.version);
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TABLE "New_table"(
-				new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY,
-				version INT NOT NULL DEFAULT 0,
-				new_color new_color DEFAULT 'cyan',
-				new_bar SMALLSERIAL NOT NULL,
-				new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
-				UNIQUE (new_foo, new_bar)
-			);
-			ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
-			CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
+            CREATE TABLE "New_table"(
+                new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                version INT NOT NULL DEFAULT 0,
+                new_color new_color DEFAULT 'cyan',
+                new_bar SMALLSERIAL NOT NULL,
+                new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
+                UNIQUE (new_foo, new_bar)
+            );
+            ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
+            CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
 
-			CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
+            CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "New_table"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "New_table"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TABLE schema_2.bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL,
-				quux TEXT,
-				FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
-			);
-			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
-			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-			CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
-			CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
+            CREATE TABLE schema_2.bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL,
+                quux TEXT,
+                FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
+            );
+            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
+            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+            CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
+            CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
 
-			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
+            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
 
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-					IF LENGTH(NEW.id) == 0 THEN
-						RAISE EXCEPTION 'content is empty';
-					END IF;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.id) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON schema_2.bar
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON schema_2.bar
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -348,77 +348,77 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
-		
-			CREATE TABLE foobar(
-				id INT,
-				bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE fizz();
+        
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-				fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
+            CREATE TABLE fizz();
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				bar TIMESTAMPTZ NOT NULL,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                bar TIMESTAMPTZ NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-				fizz NOT NULL,
-				PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-			CREATE table bar(
-				id VARCHAR(255) PRIMARY KEY,
-				foo VARCHAR(255),
-				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-			
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -1,433 +1,433 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 // These are tests for "public" schema" alterations (full migrations)
 var schemaAcceptanceTests = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_1.foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_1.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + increment(a);
 
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                bar SERIAL NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
+            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE table bar(
+                id  INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            ALTER TABLE bar REPLICA IDENTITY FULL;
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_1.foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_1.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + increment(a);
 
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                bar SERIAL NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
+            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-			`,
-		},
-		expectEmptyPlan: true,
-	},
-	{
-		name:  "Add schema, drop schema, Add enum, Drop enum, Drop table, Add Table, Drop Seq, Add Seq, Drop Funcs, Add Funcs, Drop Triggers, Add Triggers, Create Extension, Drop Extension, Create Index Using Extension, Add policies, Drop policies",
-		roles: []string{"role_1"},
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-			
-			CREATE SCHEMA schema_2;
+            CREATE table bar(
+                id  INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            ALTER TABLE bar REPLICA IDENTITY FULL;
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+            `,
+        },
+        expectEmptyPlan: true,
+    },
+    {
+        name:  "Add schema, drop schema, Add enum, Drop enum, Drop table, Add Table, Drop Seq, Add Seq, Drop Funcs, Add Funcs, Drop Triggers, Add Triggers, Create Extension, Drop Extension, Create Index Using Extension, Add policies, Drop policies",
+        roles: []string{"role_1"},
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+            
+            CREATE SCHEMA schema_2;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_2.foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_2.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_2.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_2.add(a, b) + increment(a);
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = increment(OLD.version);
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = increment(OLD.version);
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-				UNIQUE (foo, bar)
-			);
-			CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                UNIQUE (foo, bar)
+            );
+            CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
 
-			CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE table schema_2.bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL,
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
-			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-			CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
+            CREATE table schema_2.bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL,
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
+            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+            CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
 
-			CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
-			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE EXTENSION pg_trgm;
-			
-			CREATE SCHEMA schema_2;
-			CREATE SCHEMA schema_3;
+            CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
+            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE EXTENSION pg_trgm;
+            
+            CREATE SCHEMA schema_2;
+            CREATE SCHEMA schema_3;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
+            CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
 
-			CREATE SEQUENCE schema_3.new_foobar_sequence
-			    AS SMALLINT
-				INCREMENT BY 4
-				MINVALUE 10 MAXVALUE 200
-				START WITH 20 CACHE 10 NO CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_3.new_foobar_sequence
+                AS SMALLINT
+                INCREMENT BY 4
+                MINVALUE 10 MAXVALUE 200
+                START WITH 20 CACHE 10 NO CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b + a;
+            CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b + a;
 
-			CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 2;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 2;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_3."new add"(a, b) + "new increment"(a);
+            CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_3."new add"(a, b) + "new increment"(a);
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = "new increment"(OLD.version);
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = "new increment"(OLD.version);
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TABLE "New_table"(
-			    new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT PRIMARY KEY,
-			    version INT NOT NULL DEFAULT 0,
-			    new_color new_color DEFAULT 'cyan',
-			    new_bar SMALLSERIAL NOT NULL,
-				new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
-				UNIQUE (new_foo, new_bar)
-			);
-			ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
-			CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
+            CREATE TABLE "New_table"(
+                new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                version INT NOT NULL DEFAULT 0,
+                new_color new_color DEFAULT 'cyan',
+                new_bar SMALLSERIAL NOT NULL,
+                new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
+                UNIQUE (new_foo, new_bar)
+            );
+            ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
+            CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
 
-			CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
+            CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "New_table"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "New_table"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TABLE schema_2.bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL,
-				quux TEXT,
-				FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
-			);
-			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
-			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-			CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
-			CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
+            CREATE TABLE schema_2.bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL,
+                quux TEXT,
+                FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
+            );
+            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
+            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+            CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
+            CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
 
-			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
+            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
 
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-				    IF LENGTH(NEW.id) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.id) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON schema_2.bar
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeAuthzUpdate,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeHasUntrackableDependencies,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Drop partitioned table, Add partitioned table with local keys",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE fizz();
-		
-			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON schema_2.bar
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeAuthzUpdate,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeHasUntrackableDependencies,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Drop partitioned table, Add partitioned table with local keys",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE fizz();
+        
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE fizz();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE fizz();
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				bar TIMESTAMPTZ NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                bar TIMESTAMPTZ NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-			
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestSchemaTestCases() {
-	suite.runTestCases(schemaAcceptanceTests)
+    suite.runTestCases(schemaAcceptanceTests)
 }

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -10,151 +10,151 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_1.foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_1.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + increment(a);
 
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                bar SERIAL NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
+            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-			`,
+            CREATE table bar(
+                id  INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            ALTER TABLE bar REPLICA IDENTITY FULL;
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_1.foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_1.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_1.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_1.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_1.add(a, b) + increment(a);
 
-			CREATE TABLE schema_1.foobar(
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
-			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                bar SERIAL NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
+            ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
-			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
-			CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo DESC, bar);
+            CREATE INDEX foobar_hash_idx ON schema_1.foobar USING hash (foo);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, fizz);
 
-			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			ALTER TABLE bar REPLICA IDENTITY FULL;
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
-			`,
+            CREATE table bar(
+                id  INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            ALTER TABLE bar REPLICA IDENTITY FULL;
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(foo, buzz);
+            `,
 		},
 		expectEmptyPlan: true,
 	},
@@ -163,178 +163,178 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		roles: []string{"role_1"},
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE EXTENSION amcheck WITH SCHEMA schema_1;
-			
-			CREATE SCHEMA schema_2;
+            CREATE SCHEMA schema_1;
+            CREATE EXTENSION amcheck WITH SCHEMA schema_1;
+            
+            CREATE SCHEMA schema_2;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
+            CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
-			CREATE SEQUENCE schema_2.foobar_sequence
-			    AS BIGINT
-				INCREMENT BY 2
-				MINVALUE 5 MAXVALUE 100
-				START WITH 10 CACHE 5 CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_2.foobar_sequence
+                AS BIGINT
+                INCREMENT BY 2
+                MINVALUE 5 MAXVALUE 100
+                START WITH 10 CACHE 5 CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b;
+            CREATE FUNCTION schema_2.add(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b;
 
-			CREATE FUNCTION increment(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 1;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION increment(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 1;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_2.add(a, b) + increment(a);
+            CREATE FUNCTION function_with_dependencies(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_2.add(a, b) + increment(a);
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = increment(OLD.version);
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = increment(OLD.version);
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-				color schema_1.color DEFAULT 'green',
-				UNIQUE (foo, bar)
-			);
-			CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                color schema_1.color DEFAULT 'green',
+                UNIQUE (foo, bar)
+            );
+            CREATE INDEX foobar_normal_idx ON foobar USING hash (fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz DESC);
 
-			CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
+            CREATE POLICY foobar_foo_policy ON foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON foobar
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON foobar
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE table schema_2.bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL,
-				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
-			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-			CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
+            CREATE table schema_2.bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL,
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
+            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+            CREATE UNIQUE INDEX bar_unique_idx on schema_2.bar(fizz, buzz);
 
-			CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
-			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
-			`,
+            CREATE POLICY bar_bar_policy ON schema_2.bar FOR INSERT TO role_1 WITH CHECK (bar > 5.1);
+            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO PUBLIC USING (foo = 'some_foo');
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE EXTENSION pg_trgm;
-			
-			CREATE SCHEMA schema_2;
-			CREATE SCHEMA schema_3;
+            CREATE EXTENSION pg_trgm;
+            
+            CREATE SCHEMA schema_2;
+            CREATE SCHEMA schema_3;
 
-			CREATE TABLE fizz(
-			);
+            CREATE TABLE fizz(
+            );
 
-			CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
+            CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
 
-			CREATE SEQUENCE schema_3.new_foobar_sequence
-			    AS SMALLINT
-				INCREMENT BY 4
-				MINVALUE 10 MAXVALUE 200
-				START WITH 20 CACHE 10 NO CYCLE
-				OWNED BY NONE;
+            CREATE SEQUENCE schema_3.new_foobar_sequence
+                AS SMALLINT
+                INCREMENT BY 4
+                MINVALUE 10 MAXVALUE 200
+                START WITH 20 CACHE 10 NO CYCLE
+                OWNED BY NONE;
 
-			CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN a + b + a;
+            CREATE FUNCTION schema_3."new add"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + b + a;
 
-			CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
-					BEGIN
-							RETURN i + 2;
-					END;
-			$$ LANGUAGE plpgsql;
+            CREATE FUNCTION "new increment"(i integer) RETURNS integer AS $$
+                    BEGIN
+                            RETURN i + 2;
+                    END;
+            $$ LANGUAGE plpgsql;
 
-			CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
-				LANGUAGE SQL
-				IMMUTABLE
-				RETURNS NULL ON NULL INPUT
-				RETURN schema_3."new add"(a, b) + "new increment"(a);
+            CREATE FUNCTION "new function with dependencies"(a integer, b integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN schema_3."new add"(a, b) + "new increment"(a);
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = "new increment"(OLD.version);
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = "new increment"(OLD.version);
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TABLE "New_table"(
-			    new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT PRIMARY KEY,
-			    version INT NOT NULL DEFAULT 0,
-			    new_color new_color DEFAULT 'cyan',
-			    new_bar SMALLSERIAL NOT NULL,
-				new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
-				UNIQUE (new_foo, new_bar)
-			);
-			ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
-			CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
+            CREATE TABLE "New_table"(
+                new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                version INT NOT NULL DEFAULT 0,
+                new_color new_color DEFAULT 'cyan',
+                new_bar SMALLSERIAL NOT NULL,
+                new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
+                UNIQUE (new_foo, new_bar)
+            );
+            ALTER TABLE "New_table" ADD CONSTRAINT "new_fzz_check" CHECK ( new_fizz < CURRENT_TIMESTAMP - interval '1 month' ) NO INHERIT NOT VALID;
+            CREATE UNIQUE INDEX foobar_unique_idx ON "New_table"(new_foo, new_fizz);
 
-			CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
+            CREATE POLICY "New_table_foo_policy" ON "New_table" FOR DELETE TO PUBLIC USING (version > 0);
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "New_table"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "New_table"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TABLE schema_2.bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL,
-				quux TEXT,
-				FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
-			);
-			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
-			CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
-			CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
-			CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
-			CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
+            CREATE TABLE schema_2.bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL,
+                quux TEXT,
+                FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
+            );
+            ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK ( LENGTH(foo) < bar );
+            CREATE INDEX bar_normal_idx ON schema_2.bar(bar);
+            CREATE INDEX bar_another_normal_id ON schema_2.bar(bar DESC, fizz DESC);
+            CREATE UNIQUE INDEX bar_unique_idx ON schema_2.bar(fizz, buzz);
+            CREATE INDEX gin_index ON schema_2.bar USING gin (quux gin_trgm_ops);
 
-			CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
+            CREATE POLICY bar_foo_policy ON schema_2.bar FOR SELECT TO role_1 USING (foo = 'some_foo' AND quux = 'some_quux');
 
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-				    IF LENGTH(NEW.id) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.id) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON schema_2.bar
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
-			`,
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON schema_2.bar
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
@@ -348,78 +348,78 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 		name: "Drop partitioned table, Add partitioned table with local keys",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
-		
-			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
-				UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE TABLE fizz();
+        
+            CREATE TABLE foobar(
+                id INT,
+                bar SERIAL NOT NULL,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (foo, id),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE foobar_1 PARTITION of foobar(
+                fizz NOT NULL
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
 
-			`,
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE fizz();
+            CREATE TABLE fizz();
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				bar TIMESTAMPTZ NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT,
-				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    UNIQUE (foo, bar)
-			) PARTITION BY LIST(foo);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                bar TIMESTAMPTZ NOT NULL,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                id INT,
+                foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
+                UNIQUE (foo, bar)
+            ) PARTITION BY LIST(foo);
 
-			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
-			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
+            CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
+                fizz NOT NULL,
+                PRIMARY KEY (foo, bar)
+            ) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
-			-- local indexes
-			CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
-			-- partitioned indexes
-			CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
-			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
+            -- local indexes
+            CREATE INDEX foobar_1_local_idx ON schema_1.foobar_1(foo, bar);
+            -- partitioned indexes
+            CREATE INDEX foobar_normal_idx ON schema_1.foobar(foo, bar);
+            CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
-			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
-			);
-			CREATE INDEX bar_normal_idx ON bar(bar);
-			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
-			CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
-			
-			`,
+            CREATE table bar(
+                id VARCHAR(255) PRIMARY KEY,
+                foo VARCHAR(255),
+                bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+                fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+                   FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
+            );
+            CREATE INDEX bar_normal_idx ON bar(bar);
+            CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
+            CREATE UNIQUE INDEX bar_unique_idx on bar(fizz, buzz);
+            
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -19,7 +19,7 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
 			CREATE SEQUENCE schema_1.foobar_sequence
-			    AS BIGINT
+				AS BIGINT
 				INCREMENT BY 2
 				MINVALUE 5 MAXVALUE 100
 				START WITH 10 CACHE 5 CYCLE
@@ -44,19 +44,19 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 				RETURN schema_1.add(a, b) + increment(a);
 
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				bar SERIAL NOT NULL,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
 				color schema_1.color DEFAULT 'green',
-			    PRIMARY KEY (foo, id),
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
 			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
 			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL
+				fizz NOT NULL
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- partitioned indexes
@@ -69,11 +69,11 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
 			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				id  INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
 				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
 			);
 			ALTER TABLE bar REPLICA IDENTITY FULL;
@@ -93,7 +93,7 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
 			CREATE SEQUENCE schema_1.foobar_sequence
-			    AS BIGINT
+				AS BIGINT
 				INCREMENT BY 2
 				MINVALUE 5 MAXVALUE 100
 				START WITH 10 CACHE 5 CYCLE
@@ -118,19 +118,19 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 				RETURN schema_1.add(a, b) + increment(a);
 
 			CREATE TABLE schema_1.foobar(
-			    id INT,
+				id INT,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    bar SERIAL NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				bar SERIAL NOT NULL,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
 				color schema_1.color DEFAULT 'green',
-			    PRIMARY KEY (foo, id),
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 			ALTER TABLE schema_1.foobar ENABLE ROW LEVEL SECURITY;
 			ALTER TABLE schema_1.foobar FORCE ROW LEVEL SECURITY;
 
 			CREATE TABLE foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL
+				fizz NOT NULL
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- partitioned indexes
@@ -143,11 +143,11 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE POLICY foobar_foo_policy ON schema_1.foobar FOR SELECT TO PUBLIC USING (foo = current_user);
 
 			CREATE table bar(
-			    id  INT PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				id  INT PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
 				FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
 			);
 			ALTER TABLE bar REPLICA IDENTITY FULL;
@@ -174,7 +174,7 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE TYPE schema_1.color AS ENUM ('red', 'green', 'blue');
 
 			CREATE SEQUENCE schema_2.foobar_sequence
-			    AS BIGINT
+				AS BIGINT
 				INCREMENT BY 2
 				MINVALUE 5 MAXVALUE 100
 				START WITH 10 CACHE 5 CYCLE
@@ -206,10 +206,10 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			$$ language 'plpgsql';
 
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    bar SERIAL NOT NULL,
+				id INT PRIMARY KEY,
+				bar SERIAL NOT NULL,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
 				color schema_1.color DEFAULT 'green',
 				UNIQUE (foo, bar)
 			);
@@ -225,11 +225,11 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 				EXECUTE PROCEDURE "increment version"();
 
 			CREATE table schema_2.bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL,
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL,
 				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
 			);
 			ALTER TABLE schema_2.bar ADD CONSTRAINT "FOO_CHECK" CHECK (LENGTH(foo) < bar) NOT VALID;
@@ -254,7 +254,7 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE TYPE new_color AS ENUM ('yellow', 'orange', 'cyan');
 
 			CREATE SEQUENCE schema_3.new_foobar_sequence
-			    AS SMALLINT
+				AS SMALLINT
 				INCREMENT BY 4
 				MINVALUE 10 MAXVALUE 200
 				START WITH 20 CACHE 10 NO CYCLE
@@ -286,11 +286,11 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			$$ language 'plpgsql';
 
 			CREATE TABLE "New_table"(
-			    new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT PRIMARY KEY,
-			    version INT NOT NULL DEFAULT 0,
-			    new_color new_color DEFAULT 'cyan',
-			    new_bar SMALLSERIAL NOT NULL,
+				new_fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				id INT PRIMARY KEY,
+				version INT NOT NULL DEFAULT 0,
+				new_color new_color DEFAULT 'cyan',
+				new_bar SMALLSERIAL NOT NULL,
 				new_foo VARCHAR(255) DEFAULT '' NOT NULL CHECK ( new_foo IS NOT NULL),
 				UNIQUE (new_foo, new_bar)
 			);
@@ -306,11 +306,11 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 				EXECUTE PROCEDURE "increment version"();
 
 			CREATE TABLE schema_2.bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL,
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL,
 				quux TEXT,
 				FOREIGN KEY (foo, fizz) REFERENCES "New_table" (new_foo, new_fizz)
 			);
@@ -324,9 +324,9 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 
 			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
 				BEGIN
-				    IF LENGTH(NEW.id) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
+					IF LENGTH(NEW.id) == 0 THEN
+						RAISE EXCEPTION 'content is empty';
+					END IF;
 				END;
 			$$ language 'plpgsql';
 
@@ -351,16 +351,16 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE TABLE fizz();
 		
 			CREATE TABLE foobar(
-			    id INT,
-			    bar SERIAL NOT NULL,
+				id INT,
+				bar SERIAL NOT NULL,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    PRIMARY KEY (foo, id),
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (foo, id),
 				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 
 			CREATE TABLE foobar_1 PARTITION of foobar(
-			    fizz NOT NULL
+				fizz NOT NULL
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- partitioned indexes
@@ -370,12 +370,12 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE INDEX foobar_1_local_idx ON foobar_1(foo, bar);
 
 			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
-			    FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				FOREIGN KEY (foo, fizz) REFERENCES foobar (foo, fizz)
 			);
 			CREATE INDEX bar_normal_idx ON bar(bar);
 			CREATE INDEX bar_another_normal_id ON bar(bar, fizz);
@@ -390,15 +390,15 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
 				bar TIMESTAMPTZ NOT NULL,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    id INT,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				id INT,
 				foo VARCHAR(255) DEFAULT 'some default' NOT NULL CHECK (LENGTH(foo) > 0),
-			    UNIQUE (foo, bar)
+				UNIQUE (foo, bar)
 			) PARTITION BY LIST(foo);
 
 			CREATE TABLE schema_1.foobar_1 PARTITION of schema_1.foobar(
-			    fizz NOT NULL,
-			    PRIMARY KEY (foo, bar)
+				fizz NOT NULL,
+				PRIMARY KEY (foo, bar)
 			) FOR VALUES IN ('foobar_1_val_1', 'foobar_1_val_2');
 
 			-- local indexes
@@ -408,11 +408,11 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_unique_idx ON schema_1.foobar(foo, fizz);
 
 			CREATE table bar(
-			    id VARCHAR(255) PRIMARY KEY,
-			    foo VARCHAR(255),
-			    bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
-			    fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			    buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
+				id VARCHAR(255) PRIMARY KEY,
+				foo VARCHAR(255),
+				bar DOUBLE PRECISION NOT NULL DEFAULT 8.8,
+				fizz TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+				buzz REAL NOT NULL CHECK (buzz IS NOT NULL),
 			   	FOREIGN KEY (foo, fizz) REFERENCES schema_1.foobar (foo, fizz)
 			);
 			CREATE INDEX bar_normal_idx ON bar(bar);

--- a/internal/migration_acceptance_tests/sequence_cases_test.go
+++ b/internal/migration_acceptance_tests/sequence_cases_test.go
@@ -3,763 +3,763 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var sequenceAcceptanceTests = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE foobar_sequence
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE foobar_sequence
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Add sequence",
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeHasUntrackableDependencies,
-        },
-    },
-    {
-        name: "Add sequence via serial",
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                "some id" SERIAL
-            )
-            `,
-        },
-    },
-    {
-        name: "Drop sequence",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeHasUntrackableDependencies,
-        },
-    },
-    {
-        name: "Drop sequence via deleting column",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "some id" SERIAL
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Drop sequence via deleting column (partitioned table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE foobar_sequence
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE foobar_sequence
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Add sequence",
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeHasUntrackableDependencies,
+		},
+	},
+	{
+		name: "Add sequence via serial",
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    "some id" SERIAL
+			)
+			`,
+		},
+	},
+	{
+		name: "Drop sequence",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeHasUntrackableDependencies,
+		},
+	},
+	{
+		name: "Drop sequence via deleting column",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "some id" SERIAL
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Drop sequence via deleting column (partitioned table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Drop sequence via changing column type",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "some id" SERIAL
-            )
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "some id" TEXT
-            )
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Drop sequence via changing column type (partitioned)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Drop sequence via changing column type",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "some id" SERIAL
+			)
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "some id" TEXT
+			)
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Drop sequence via changing column type (partitioned)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "some id" TEXT,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "some id" TEXT,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Drop sequence via table drop",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id SERIAL
-            )
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Drop sequence via table drop (partitioned)",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Drop sequence via table drop",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id SERIAL
+			)
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Drop sequence via table drop (partitioned)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "And and Drop sequences (conflicing schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_2;
-            CREATE SEQUENCE schema_2."foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeHasUntrackableDependencies,
-        },
-    },
-    {
-        name: "Alter data type",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter increment",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 3
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter min value",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 6 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter from no min value and change type",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        NO MINVALUE MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter to no min value and change type",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        NO MINVALUE MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter max value",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 101
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter from no max value and change type",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 NO MAXVALUE
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter to no max value and change type",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 NO MAXVALUE
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter start with",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 11 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter cache",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 6 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter cycle",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 NO CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-    },
-    {
-        name: "Alter ownership (from none to table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
-        },
-    },
-    {
-        name: "Alter ownership (from table to none)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Alter ownership (from table to table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
-        },
-    },
-    {
-        name: "Alter ownership (from table to table; original column dropped)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Alter ownership (from table to table; original table dropped)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Alter ownership (from table to table; original partitioned table dropped)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "And and Drop sequences (conflicing schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_2;
+			CREATE SEQUENCE schema_2."foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeHasUntrackableDependencies,
+		},
+	},
+	{
+		name: "Alter data type",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter increment",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 3
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter min value",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 6 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter from no min value and change type",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						NO MINVALUE MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter to no min value and change type",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						NO MINVALUE MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter max value",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 101
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter from no max value and change type",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 NO MAXVALUE
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter to no max value and change type",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 NO MAXVALUE
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter start with",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 11 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter cache",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 6 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter cycle",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 NO CYCLE
+						OWNED BY NONE;
+			`,
+		},
+	},
+	{
+		name: "Alter ownership (from none to table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
+		},
+	},
+	{
+		name: "Alter ownership (from table to none)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Alter ownership (from table to table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
+		},
+	},
+	{
+		name: "Alter ownership (from table to table; original column dropped)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Alter ownership (from table to table; original table dropped)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Alter ownership (from table to table; original partitioned table dropped)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
 
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 
-            ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
+			ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
 
-            CREATE TABLE some_other_foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE some_other_foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
-            CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
+			CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
+			CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
 
-            ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Alter ownership (from table to table) and sequence properties (new type is not compatible with old table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" INT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 3
-                        MINVALUE 6 MAXVALUE 101
-                        START WITH 11 CACHE 6 NO CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" INT
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
-        },
-    },
-    {
-        name: "Alter ownership (from table to table) and sequence properties (old type is not compatible with new table)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 3
-                        MINVALUE 6 MAXVALUE 101
-                        START WITH 11 CACHE 6 NO CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" INT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
-        },
-    },
+			ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Alter ownership (from table to table) and sequence properties (new type is not compatible with old table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" INT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 3
+						MINVALUE 6 MAXVALUE 101
+						START WITH 11 CACHE 6 NO CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" INT
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
+		},
+	},
+	{
+		name: "Alter ownership (from table to table) and sequence properties (old type is not compatible with new table)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 3
+						MINVALUE 6 MAXVALUE 101
+						START WITH 11 CACHE 6 NO CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" INT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestSequenceTestCases() {
-    suite.runTestCases(sequenceAcceptanceTests)
+	suite.runTestCases(sequenceAcceptanceTests)
 }

--- a/internal/migration_acceptance_tests/sequence_cases_test.go
+++ b/internal/migration_acceptance_tests/sequence_cases_test.go
@@ -48,7 +48,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar(
-			    "some id" SERIAL
+				"some id" SERIAL
 			)
 			`,
 		},
@@ -76,7 +76,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "some id" SERIAL
+				"some id" SERIAL
 			);
 			`,
 		},
@@ -95,7 +95,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "some id" SERIAL,
+				"some id" SERIAL,
 				type TEXT
 			) PARTITION BY LIST (type);
 
@@ -122,14 +122,14 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "some id" SERIAL
+				"some id" SERIAL
 			)
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "some id" TEXT
+				"some id" TEXT
 			)
 			`,
 		},
@@ -144,7 +144,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "some id" SERIAL,
+				"some id" SERIAL,
 				type TEXT
 			) PARTITION BY LIST (type);
 
@@ -155,7 +155,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "some id" TEXT,
+				"some id" TEXT,
 				type TEXT
 			) PARTITION BY LIST (type);
 
@@ -174,7 +174,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id SERIAL
+				id SERIAL
 			)
 			`,
 		},
@@ -187,7 +187,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    "some id" SERIAL,
+				"some id" SERIAL,
 				type TEXT
 			) PARTITION BY LIST (type);
 
@@ -656,7 +656,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 						OWNED BY NONE;
 
 			CREATE TABLE foobar(
-			    "some id" SERIAL,
+				"some id" SERIAL,
 				type TEXT
 			) PARTITION BY LIST (type);
 
@@ -676,7 +676,7 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 						OWNED BY NONE;
 
 			CREATE TABLE some_other_foobar(
-			    "some id" SERIAL,
+				"some id" SERIAL,
 				type TEXT
 			) PARTITION BY LIST (type);
 

--- a/internal/migration_acceptance_tests/sequence_cases_test.go
+++ b/internal/migration_acceptance_tests/sequence_cases_test.go
@@ -7,36 +7,36 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE foobar_sequence
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
+			CREATE SEQUENCE foobar_sequence
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE foobar_sequence
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
+			CREATE SEQUENCE foobar_sequence
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Add sequence",
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeHasUntrackableDependencies,
@@ -46,25 +46,25 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Add sequence via serial",
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar(
-                "some id" SERIAL
-            )
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar(
+			    "some id" SERIAL
+			)
+			`,
 		},
 	},
 	{
 		name: "Drop sequence",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -75,16 +75,16 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via deleting column",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "some id" SERIAL
-            );
-            `,
+			CREATE TABLE foobar(
+			    "some id" SERIAL
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-            );
-            `,
+			CREATE TABLE foobar(
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -94,24 +94,24 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via deleting column (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar(
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -121,17 +121,17 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via changing column type",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "some id" SERIAL
-            )
-            `,
+			CREATE TABLE foobar(
+			    "some id" SERIAL
+			)
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "some id" TEXT
-            )
-            `,
+			CREATE TABLE foobar(
+			    "some id" TEXT
+			)
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -143,25 +143,25 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via changing column type (partitioned)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "some id" TEXT,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar(
+			    "some id" TEXT,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -173,10 +173,10 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via table drop",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id SERIAL
-            )
-            `,
+			CREATE TABLE foobar(
+			    id SERIAL
+			)
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -186,14 +186,14 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via table drop (partitioned)",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-            `,
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -203,25 +203,25 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "And and Drop sequences (conflicing schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_2;
-            CREATE SEQUENCE schema_2."foobar sequence"
-                    AS BIGINT
-                    INCREMENT BY 2
-                    MINVALUE 5 MAXVALUE 100
-                    START WITH 10 CACHE 5 CYCLE
-                    OWNED BY NONE;
-            `,
+			CREATE SCHEMA schema_2;
+			CREATE SEQUENCE schema_2."foobar sequence"
+					AS BIGINT
+					INCREMENT BY 2
+					MINVALUE 5 MAXVALUE 100
+					START WITH 10 CACHE 5 CYCLE
+					OWNED BY NONE;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -232,309 +232,309 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter data type",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter increment",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 3
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 3
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter min value",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 6 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 6 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter from no min value and change type",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        NO MINVALUE MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						NO MINVALUE MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter to no min value and change type",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        NO MINVALUE MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						NO MINVALUE MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter max value",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 101
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 101
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter from no max value and change type",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 NO MAXVALUE
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 NO MAXVALUE
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter to no max value and change type",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 NO MAXVALUE
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 NO MAXVALUE
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter start with",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 11 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 11 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter cache",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 6 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 6 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter cycle",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE SEQUENCE schema_1."foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 NO CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE SEQUENCE schema_1."foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 NO CYCLE
+						OWNED BY NONE;
+			`,
 		},
 	},
 	{
 		name: "Alter ownership (from none to table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
 		},
 	},
 	{
 		name: "Alter ownership (from table to none)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -544,67 +544,67 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
 		},
 	},
 	{
 		name: "Alter ownership (from table to table; original column dropped)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -614,31 +614,31 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table; original table dropped)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -648,43 +648,43 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table; original partitioned table dropped)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
 
-            CREATE TABLE foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 
-            ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
-            `,
+			ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
 
-            CREATE TABLE some_other_foobar(
-                "some id" SERIAL,
-                type TEXT
-            ) PARTITION BY LIST (type);
+			CREATE TABLE some_other_foobar(
+			    "some id" SERIAL,
+				type TEXT
+			) PARTITION BY LIST (type);
 
-            CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
-            CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
+			CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
+			CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
 
-            ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
-            `,
+			ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -694,68 +694,68 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table) and sequence properties (new type is not compatible with old table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" INT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" INT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 3
-                        MINVALUE 6 MAXVALUE 101
-                        START WITH 11 CACHE 6 NO CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" INT
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 3
+						MINVALUE 6 MAXVALUE 101
+						START WITH 11 CACHE 6 NO CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" INT
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
 		},
 	},
 	{
 		name: "Alter ownership (from table to table) and sequence properties (old type is not compatible with new table)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS BIGINT
-                        INCREMENT BY 2
-                        MINVALUE 5 MAXVALUE 100
-                        START WITH 10 CACHE 5 CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS BIGINT
+						INCREMENT BY 2
+						MINVALUE 5 MAXVALUE 100
+						START WITH 10 CACHE 5 CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SEQUENCE "foobar sequence"
-                        AS INT
-                        INCREMENT BY 3
-                        MINVALUE 6 MAXVALUE 101
-                        START WITH 11 CACHE 6 NO CYCLE
-                        OWNED BY NONE;
-            CREATE TABLE "some foobar"(
-                "some id" BIGINT
-            );
-            CREATE TABLE "some other foobar"(
-                "some id" INT
-            );
-            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-            `,
+			CREATE SEQUENCE "foobar sequence"
+						AS INT
+						INCREMENT BY 3
+						MINVALUE 6 MAXVALUE 101
+						START WITH 11 CACHE 6 NO CYCLE
+						OWNED BY NONE;
+			CREATE TABLE "some foobar"(
+				"some id" BIGINT
+			);
+			CREATE TABLE "some other foobar"(
+				"some id" INT
+			);
+			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+			`,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/sequence_cases_test.go
+++ b/internal/migration_acceptance_tests/sequence_cases_test.go
@@ -7,36 +7,36 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE foobar_sequence
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
+            CREATE SEQUENCE foobar_sequence
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE foobar_sequence
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
+            CREATE SEQUENCE foobar_sequence
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Add sequence",
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeHasUntrackableDependencies,
@@ -46,25 +46,25 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Add sequence via serial",
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    "some id" SERIAL
-			)
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                "some id" SERIAL
+            )
+            `,
 		},
 	},
 	{
 		name: "Drop sequence",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -75,16 +75,16 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via deleting column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL
-			);
-			`,
+            CREATE TABLE foobar(
+                "some id" SERIAL
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			);
-			`,
+            CREATE TABLE foobar(
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -94,24 +94,24 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via deleting column (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -121,17 +121,17 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via changing column type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL
-			)
-			`,
+            CREATE TABLE foobar(
+                "some id" SERIAL
+            )
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "some id" TEXT
-			)
-			`,
+            CREATE TABLE foobar(
+                "some id" TEXT
+            )
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -143,25 +143,25 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via changing column type (partitioned)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "some id" TEXT,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" TEXT,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -173,10 +173,10 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via table drop",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id SERIAL
-			)
-			`,
+            CREATE TABLE foobar(
+                id SERIAL
+            )
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -186,14 +186,14 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via table drop (partitioned)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -203,25 +203,25 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "And and Drop sequences (conflicing schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_2;
-			CREATE SEQUENCE schema_2."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
+            CREATE SCHEMA schema_2;
+            CREATE SEQUENCE schema_2."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -232,309 +232,309 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter data type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter increment",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 3
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 3
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter min value",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 6 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 6 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter from no min value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						NO MINVALUE MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        NO MINVALUE MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter to no min value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						NO MINVALUE MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        NO MINVALUE MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter max value",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 101
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 101
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter from no max value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 NO MAXVALUE
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 NO MAXVALUE
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter to no max value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 NO MAXVALUE
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 NO MAXVALUE
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter start with",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 11 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 11 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter cache",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 6 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 6 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter cycle",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 NO CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 NO CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 	},
 	{
 		name: "Alter ownership (from none to table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
 		},
 	},
 	{
 		name: "Alter ownership (from table to none)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -544,67 +544,67 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
 		},
 	},
 	{
 		name: "Alter ownership (from table to table; original column dropped)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -614,31 +614,31 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table; original table dropped)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -648,43 +648,43 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table; original partitioned table dropped)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 
-			ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
-			`,
+            ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 
-			CREATE TABLE some_other_foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE some_other_foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
-			CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
+            CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
+            CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
 
-			ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
-			`,
+            ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -694,68 +694,68 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table) and sequence properties (new type is not compatible with old table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" INT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" INT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 3
-						MINVALUE 6 MAXVALUE 101
-						START WITH 11 CACHE 6 NO CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" INT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 3
+                        MINVALUE 6 MAXVALUE 101
+                        START WITH 11 CACHE 6 NO CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" INT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
 		},
 	},
 	{
 		name: "Alter ownership (from table to table) and sequence properties (old type is not compatible with new table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 3
-						MINVALUE 6 MAXVALUE 101
-						START WITH 11 CACHE 6 NO CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" INT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 3
+                        MINVALUE 6 MAXVALUE 101
+                        START WITH 11 CACHE 6 NO CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" INT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/sequence_cases_test.go
+++ b/internal/migration_acceptance_tests/sequence_cases_test.go
@@ -7,22 +7,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE foobar_sequence
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
+            CREATE SEQUENCE foobar_sequence
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE foobar_sequence
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
+            CREATE SEQUENCE foobar_sequence
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
 			`,
 		},
 	},
@@ -30,12 +30,12 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Add sequence",
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -46,10 +46,10 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Add sequence via serial",
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-				"some id" SERIAL
-			)
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                "some id" SERIAL
+            )
 			`,
 		},
 	},
@@ -57,13 +57,13 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -75,15 +75,15 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via deleting column",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"some id" SERIAL
-			);
+            CREATE TABLE foobar(
+                "some id" SERIAL
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			);
+            CREATE TABLE foobar(
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -94,23 +94,23 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via deleting column (partitioned table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -121,16 +121,16 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via changing column type",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"some id" SERIAL
-			)
+            CREATE TABLE foobar(
+                "some id" SERIAL
+            )
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"some id" TEXT
-			)
+            CREATE TABLE foobar(
+                "some id" TEXT
+            )
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -143,24 +143,24 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via changing column type (partitioned)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"some id" TEXT,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" TEXT,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -173,9 +173,9 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via table drop",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id SERIAL
-			)
+            CREATE TABLE foobar(
+                id SERIAL
+            )
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -186,13 +186,13 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Drop sequence via table drop (partitioned)",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				"some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -203,24 +203,24 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "And and Drop sequences (conflicing schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_2;
-			CREATE SEQUENCE schema_2."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
+            CREATE SCHEMA schema_2;
+            CREATE SEQUENCE schema_2."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -232,22 +232,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter data type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -255,22 +255,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter increment",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 3
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 3
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -278,22 +278,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter min value",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 6 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 6 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -301,22 +301,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter from no min value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						NO MINVALUE MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        NO MINVALUE MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -324,22 +324,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter to no min value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						NO MINVALUE MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        NO MINVALUE MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -347,22 +347,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter max value",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 101
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 101
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -370,22 +370,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter from no max value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 NO MAXVALUE
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 NO MAXVALUE
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -393,22 +393,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter to no max value and change type",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 NO MAXVALUE
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 NO MAXVALUE
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -416,22 +416,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter start with",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 11 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 11 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -439,22 +439,22 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter cache",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 6 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 6 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -462,24 +462,24 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter cycle",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 NO CYCLE
-						OWNED BY NONE;
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 NO CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 	},
@@ -487,26 +487,26 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from none to table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
 			`,
 		},
 	},
@@ -514,26 +514,26 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to none)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -544,33 +544,33 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
 			`,
 		},
 	},
@@ -578,32 +578,32 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table; original column dropped)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -614,30 +614,30 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table; original table dropped)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -648,42 +648,42 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table; original partitioned table dropped)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 
-			CREATE TABLE foobar(
-				"some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 
-			ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
+            ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 
-			CREATE TABLE some_other_foobar(
-				"some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE some_other_foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
-			CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
+            CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
+            CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
 
-			ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
+            ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -694,33 +694,33 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table) and sequence properties (new type is not compatible with old table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" INT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" INT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 3
-						MINVALUE 6 MAXVALUE 101
-						START WITH 11 CACHE 6 NO CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" INT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 3
+                        MINVALUE 6 MAXVALUE 101
+                        START WITH 11 CACHE 6 NO CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" INT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
 			`,
 		},
 	},
@@ -728,33 +728,33 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 		name: "Alter ownership (from table to table) and sequence properties (old type is not compatible with new table)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 3
-						MINVALUE 6 MAXVALUE 101
-						START WITH 11 CACHE 6 NO CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" INT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 3
+                        MINVALUE 6 MAXVALUE 101
+                        START WITH 11 CACHE 6 NO CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" INT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
 			`,
 		},
 	},

--- a/internal/migration_acceptance_tests/sequence_cases_test.go
+++ b/internal/migration_acceptance_tests/sequence_cases_test.go
@@ -3,763 +3,763 @@ package migration_acceptance_tests
 import "github.com/stripe/pg-schema-diff/pkg/diff"
 
 var sequenceAcceptanceTests = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE foobar_sequence
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE foobar_sequence
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Add sequence",
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeHasUntrackableDependencies,
-		},
-	},
-	{
-		name: "Add sequence via serial",
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar(
-			    "some id" SERIAL
-			)
-			`,
-		},
-	},
-	{
-		name: "Drop sequence",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeHasUntrackableDependencies,
-		},
-	},
-	{
-		name: "Drop sequence via deleting column",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Drop sequence via deleting column (partitioned table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE foobar_sequence
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE foobar_sequence
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Add sequence",
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeHasUntrackableDependencies,
+        },
+    },
+    {
+        name: "Add sequence via serial",
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                "some id" SERIAL
+            )
+            `,
+        },
+    },
+    {
+        name: "Drop sequence",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeHasUntrackableDependencies,
+        },
+    },
+    {
+        name: "Drop sequence via deleting column",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "some id" SERIAL
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Drop sequence via deleting column (partitioned table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Drop sequence via changing column type",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL
-			)
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "some id" TEXT
-			)
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Drop sequence via changing column type (partitioned)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Drop sequence via changing column type",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "some id" SERIAL
+            )
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "some id" TEXT
+            )
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Drop sequence via changing column type (partitioned)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "some id" TEXT,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "some id" TEXT,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Drop sequence via table drop",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id SERIAL
-			)
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Drop sequence via table drop (partitioned)",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Drop sequence via table drop",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id SERIAL
+            )
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Drop sequence via table drop (partitioned)",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "And and Drop sequences (conflicing schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_2;
-			CREATE SEQUENCE schema_2."foobar sequence"
-					AS BIGINT
-					INCREMENT BY 2
-					MINVALUE 5 MAXVALUE 100
-					START WITH 10 CACHE 5 CYCLE
-					OWNED BY NONE;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeHasUntrackableDependencies,
-		},
-	},
-	{
-		name: "Alter data type",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter increment",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 3
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter min value",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 6 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter from no min value and change type",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						NO MINVALUE MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter to no min value and change type",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						NO MINVALUE MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter max value",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 101
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter from no max value and change type",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 NO MAXVALUE
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter to no max value and change type",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 NO MAXVALUE
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter start with",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 11 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter cache",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 6 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter cycle",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE SEQUENCE schema_1."foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 NO CYCLE
-						OWNED BY NONE;
-			`,
-		},
-	},
-	{
-		name: "Alter ownership (from none to table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
-		},
-	},
-	{
-		name: "Alter ownership (from table to none)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Alter ownership (from table to table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
-		},
-	},
-	{
-		name: "Alter ownership (from table to table; original column dropped)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Alter ownership (from table to table; original table dropped)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Alter ownership (from table to table; original partitioned table dropped)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "And and Drop sequences (conflicing schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_2;
+            CREATE SEQUENCE schema_2."foobar sequence"
+                    AS BIGINT
+                    INCREMENT BY 2
+                    MINVALUE 5 MAXVALUE 100
+                    START WITH 10 CACHE 5 CYCLE
+                    OWNED BY NONE;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeHasUntrackableDependencies,
+        },
+    },
+    {
+        name: "Alter data type",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter increment",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 3
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter min value",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 6 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter from no min value and change type",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        NO MINVALUE MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter to no min value and change type",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        NO MINVALUE MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter max value",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 101
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter from no max value and change type",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 NO MAXVALUE
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter to no max value and change type",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 NO MAXVALUE
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter start with",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 11 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter cache",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 6 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter cycle",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE SEQUENCE schema_1."foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 NO CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+    },
+    {
+        name: "Alter ownership (from none to table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
+        },
+    },
+    {
+        name: "Alter ownership (from table to none)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Alter ownership (from table to table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
+        },
+    },
+    {
+        name: "Alter ownership (from table to table; original column dropped)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Alter ownership (from table to table; original table dropped)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Alter ownership (from table to table; original partitioned table dropped)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 
-			CREATE TABLE foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
-			CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
+            CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN (1);
+            CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN (2);
 
-			ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
+            ALTER SEQUENCE "foobar sequence" OWNED BY foobar."some id";
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
 
-			CREATE TABLE some_other_foobar(
-			    "some id" SERIAL,
-				type TEXT
-			) PARTITION BY LIST (type);
+            CREATE TABLE some_other_foobar(
+                "some id" SERIAL,
+                type TEXT
+            ) PARTITION BY LIST (type);
 
-			CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
-			CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
+            CREATE TABLE some_other_foobar_1 PARTITION OF some_other_foobar FOR VALUES IN (1);
+            CREATE TABLE some_other_foobar_2 PARTITION OF some_other_foobar FOR VALUES IN (2);
 
-			ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Alter ownership (from table to table) and sequence properties (new type is not compatible with old table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" INT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 3
-						MINVALUE 6 MAXVALUE 101
-						START WITH 11 CACHE 6 NO CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" INT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
-		},
-	},
-	{
-		name: "Alter ownership (from table to table) and sequence properties (old type is not compatible with new table)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS BIGINT
-						INCREMENT BY 2
-						MINVALUE 5 MAXVALUE 100
-						START WITH 10 CACHE 5 CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SEQUENCE "foobar sequence"
-						AS INT
-						INCREMENT BY 3
-						MINVALUE 6 MAXVALUE 101
-						START WITH 11 CACHE 6 NO CYCLE
-						OWNED BY NONE;
-			CREATE TABLE "some foobar"(
-				"some id" BIGINT
-			);
-			CREATE TABLE "some other foobar"(
-				"some id" INT
-			);
-			ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
-			`,
-		},
-	},
+            ALTER SEQUENCE "foobar sequence" OWNED BY some_other_foobar."some id";
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Alter ownership (from table to table) and sequence properties (new type is not compatible with old table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" INT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 3
+                        MINVALUE 6 MAXVALUE 101
+                        START WITH 11 CACHE 6 NO CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" INT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
+        },
+    },
+    {
+        name: "Alter ownership (from table to table) and sequence properties (old type is not compatible with new table)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS BIGINT
+                        INCREMENT BY 2
+                        MINVALUE 5 MAXVALUE 100
+                        START WITH 10 CACHE 5 CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some foobar"."some id";
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SEQUENCE "foobar sequence"
+                        AS INT
+                        INCREMENT BY 3
+                        MINVALUE 6 MAXVALUE 101
+                        START WITH 11 CACHE 6 NO CYCLE
+                        OWNED BY NONE;
+            CREATE TABLE "some foobar"(
+                "some id" BIGINT
+            );
+            CREATE TABLE "some other foobar"(
+                "some id" INT
+            );
+            ALTER SEQUENCE "foobar sequence" OWNED BY "some other foobar"."some id";
+            `,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestSequenceTestCases() {
-	suite.runTestCases(sequenceAcceptanceTests)
+    suite.runTestCases(sequenceAcceptanceTests)
 }

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -1,570 +1,570 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var tableAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE ,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE ,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
 
-		expectEmptyPlan: true,
-	},
-	{
-		name:         "Create table",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+        expectEmptyPlan: true,
+    },
+    {
+        name:         "Create table",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
-		},
-	},
-	{
-		name:         "Create table with RLS enabled",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY,
-				fizz SERIAL NOT NULL,
-				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-			);
-			ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-			`,
-		},
-	},
-	{
-		name:         "Create table with force RLS enabled",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY,
-				fizz SERIAL NOT NULL,
-				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-			);
-			ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-			`,
-		},
-	},
-	{
-		name:         "Create table with index replica identity",
-		oldSchemaDDL: nil,
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foobar TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-			`,
-		},
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
+        },
+    },
+    {
+        name:         "Create table with RLS enabled",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                fizz SERIAL NOT NULL,
+                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+            );
+            ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+            `,
+        },
+    },
+    {
+        name:         "Create table with force RLS enabled",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                fizz SERIAL NOT NULL,
+                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+            );
+            ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+            `,
+        },
+    },
+    {
+        name:         "Create table with index replica identity",
+        oldSchemaDDL: nil,
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+            `,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Drop table",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-		newSchemaDDL: nil,
-	},
-	{
-		name: "Drop a table with quoted names",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL
-			);
-			CREATE INDEX normal_idx ON "Foobar"(fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
-			`,
-		},
-		newSchemaDDL: nil,
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Add and drop a table (conflicting schemas)",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
-	{
-		name: "Alter replica identity",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeCorrectness,
-		},
-	},
-	{
-		name: "Alter replica identity to index replica identity",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeCorrectness,
-		},
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Drop table",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+        newSchemaDDL: nil,
+    },
+    {
+        name: "Drop a table with quoted names",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL
+            );
+            CREATE INDEX normal_idx ON "Foobar"(fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
+            `,
+        },
+        newSchemaDDL: nil,
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Add and drop a table (conflicting schemas)",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."Foobar"(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
+    {
+        name: "Alter replica identity",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeCorrectness,
+        },
+    },
+    {
+        name: "Alter replica identity to index replica identity",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeCorrectness,
+        },
 
-		expectedPlanErrorIs: diff.ErrNotImplemented,
-	},
-	{
-		name: "Enable RLS",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Disable RLS",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Force RLS",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Unforce RLS",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAuthzUpdate,
-		},
-	},
-	{
-		name: "Alter table: New primary key, drop unique constraint, new unique constraint, change column types, delete unique index, delete FK's, new index, validate check constraint",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL,
-				buzz REAL,
-				fizzbuzz TEXT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+        expectedPlanErrorIs: diff.ErrNotImplemented,
+    },
+    {
+        name: "Enable RLS",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Disable RLS",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Force RLS",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Unforce RLS",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAuthzUpdate,
+        },
+    },
+    {
+        name: "Alter table: New primary key, drop unique constraint, new unique constraint, change column types, delete unique index, delete FK's, new index, validate check constraint",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL,
+                buzz REAL,
+                fizzbuzz TEXT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT CHECK (id > 0) UNIQUE,
-				foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
-			    fizz BOOLEAN NOT NULL,
-			    buzz REAL,
-				fizzbuzz TEXT COLLATE "POSIX"
-			);
-			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE INDEX other_idx ON foobar(bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT CHECK (id > 0) UNIQUE,
+                foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+                fizz BOOLEAN NOT NULL,
+                buzz REAL,
+                fizzbuzz TEXT COLLATE "POSIX"
+            );
+            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE INDEX other_idx ON foobar(bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
-	{
-		name: "Alter table: New column, new primary key, new FK, drop FK, alter column to nullable, alter column types, drop column, drop index, drop check constraints, alter policies",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL,
-			   	buzz REAL CHECK (buzz IS NOT NULL)
-			);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
+    {
+        name: "Alter table: New column, new primary key, new FK, drop FK, alter column to nullable, alter column types, drop column, drop index, drop check constraints, alter policies",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL,
+                   buzz REAL CHECK (buzz IS NOT NULL)
+            );
 
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (fizz > 0);
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (fizz > 0);
 
-			CREATE POLICY some_policy_to_drop ON foobar
-				AS RESTRICTIVE
-				FOR SELECT
-				TO PUBLIC
-				USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);	
-
-
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id SMALLSERIAL,
-				foo CHAR DEFAULT '5',
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-			    new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
-			);
-
-			CREATE INDEX other_idx ON foobar(bar);
-
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (new_fizz = 5.25);
-
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo CHAR
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeAuthzUpdate,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Alter table: effectively drop by changing everything",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-			    buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			CREATE INDEX normal_idx ON foobar USING hash (fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (id > 1 AND foo = 'value');
-
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				new_buzz REAL CHECK (new_buzz IS NOT NULL),
-			    new_fizz SERIAL NOT NULL UNIQUE,
-				new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
-			);
-			CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
+            CREATE POLICY some_policy_to_drop ON foobar
+                AS RESTRICTIVE
+                FOR SELECT
+                TO PUBLIC
+                USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);    
 
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS RESTRICTIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id SMALLSERIAL,
+                foo CHAR DEFAULT '5',
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
+            );
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-			diff.MigrationHazardTypeAuthzUpdate,
-			diff.MigrationHazardTypeDeletesData,
-			diff.MigrationHazardTypeIndexDropped,
-			diff.MigrationHazardTypeIndexBuild,
-		},
-	},
-	{
-		name: "Alter table: translate BIGINT type to TIMESTAMP, set to not null, set default",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    obj_attr__c_time BIGINT,
-				obj_attr__m_time BIGINT
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				obj_attr__c_time TIMESTAMP NOT NULL,
-				obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-			diff.MigrationHazardTypeImpactsDatabasePerformance,
-		},
-	},
+            CREATE INDEX other_idx ON foobar(bar);
+
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (new_fizz = 5.25);
+
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo CHAR
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeAuthzUpdate,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Alter table: effectively drop by changing everything",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            CREATE INDEX normal_idx ON foobar USING hash (fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (id > 1 AND foo = 'value');
+
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                new_buzz REAL CHECK (new_buzz IS NOT NULL),
+                new_fizz SERIAL NOT NULL UNIQUE,
+                new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
+            );
+            CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
+
+
+            CREATE POLICY foobar_policy ON foobar 
+                AS RESTRICTIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
+
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+            diff.MigrationHazardTypeAuthzUpdate,
+            diff.MigrationHazardTypeDeletesData,
+            diff.MigrationHazardTypeIndexDropped,
+            diff.MigrationHazardTypeIndexBuild,
+        },
+    },
+    {
+        name: "Alter table: translate BIGINT type to TIMESTAMP, set to not null, set default",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                obj_attr__c_time BIGINT,
+                obj_attr__m_time BIGINT
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                obj_attr__c_time TIMESTAMP NOT NULL,
+                obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+            diff.MigrationHazardTypeImpactsDatabasePerformance,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestTableTestCases() {
-	suite.runTestCases(tableAcceptanceTestCases)
+    suite.runTestCases(tableAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -1,570 +1,570 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var tableAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE ,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE ,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
 
-        expectEmptyPlan: true,
-    },
-    {
-        name:         "Create table",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+		expectEmptyPlan: true,
+	},
+	{
+		name:         "Create table",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
-        },
-    },
-    {
-        name:         "Create table with RLS enabled",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY,
-                fizz SERIAL NOT NULL,
-                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-            );
-            ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-            `,
-        },
-    },
-    {
-        name:         "Create table with force RLS enabled",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY,
-                fizz SERIAL NOT NULL,
-                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-            );
-            ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-            `,
-        },
-    },
-    {
-        name:         "Create table with index replica identity",
-        oldSchemaDDL: nil,
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-            `,
-        },
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
+		},
+	},
+	{
+		name:         "Create table with RLS enabled",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				id INT PRIMARY KEY,
+				fizz SERIAL NOT NULL,
+				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+			);
+			ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+			`,
+		},
+	},
+	{
+		name:         "Create table with force RLS enabled",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				id INT PRIMARY KEY,
+				fizz SERIAL NOT NULL,
+				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+			);
+			ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+			`,
+		},
+	},
+	{
+		name:         "Create table with index replica identity",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foobar TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+			`,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Drop table",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-        newSchemaDDL: nil,
-    },
-    {
-        name: "Drop a table with quoted names",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL
-            );
-            CREATE INDEX normal_idx ON "Foobar"(fizz);
-            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
-            `,
-        },
-        newSchemaDDL: nil,
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Add and drop a table (conflicting schemas)",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."Foobar"(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
-    {
-        name: "Alter replica identity",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeCorrectness,
-        },
-    },
-    {
-        name: "Alter replica identity to index replica identity",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeCorrectness,
-        },
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Drop table",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+		newSchemaDDL: nil,
+	},
+	{
+		name: "Drop a table with quoted names",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL
+			);
+			CREATE INDEX normal_idx ON "Foobar"(fizz);
+			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
+			`,
+		},
+		newSchemaDDL: nil,
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Add and drop a table (conflicting schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Alter replica identity",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeCorrectness,
+		},
+	},
+	{
+		name: "Alter replica identity to index replica identity",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeCorrectness,
+		},
 
-        expectedPlanErrorIs: diff.ErrNotImplemented,
-    },
-    {
-        name: "Enable RLS",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Disable RLS",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Force RLS",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Unforce RLS",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAuthzUpdate,
-        },
-    },
-    {
-        name: "Alter table: New primary key, drop unique constraint, new unique constraint, change column types, delete unique index, delete FK's, new index, validate check constraint",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz BOOLEAN NOT NULL,
-                buzz REAL,
-                fizzbuzz TEXT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+		expectedPlanErrorIs: diff.ErrNotImplemented,
+	},
+	{
+		name: "Enable RLS",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Disable RLS",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Force RLS",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Unforce RLS",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter table: New primary key, drop unique constraint, new unique constraint, change column types, delete unique index, delete FK's, new index, validate check constraint",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz BOOLEAN NOT NULL,
+				buzz REAL,
+				fizzbuzz TEXT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT CHECK (id > 0) UNIQUE,
-                foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
-                fizz BOOLEAN NOT NULL,
-                buzz REAL,
-                fizzbuzz TEXT COLLATE "POSIX"
-            );
-            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE INDEX other_idx ON foobar(bar);
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT CHECK (id > 0) UNIQUE,
+				foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+			    fizz BOOLEAN NOT NULL,
+			    buzz REAL,
+				fizzbuzz TEXT COLLATE "POSIX"
+			);
+			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE INDEX other_idx ON foobar(bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
-    {
-        name: "Alter table: New column, new primary key, new FK, drop FK, alter column to nullable, alter column types, drop column, drop index, drop check constraints, alter policies",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL,
-                   buzz REAL CHECK (buzz IS NOT NULL)
-            );
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Alter table: New column, new primary key, new FK, drop FK, alter column to nullable, alter column types, drop column, drop index, drop check constraints, alter policies",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL,
+			   	buzz REAL CHECK (buzz IS NOT NULL)
+			);
 
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
 
-            CREATE POLICY foobar_policy ON foobar 
-                AS PERMISSIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (fizz > 0);
+			CREATE POLICY foobar_policy ON foobar 
+				AS PERMISSIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (fizz > 0);
 
-            CREATE POLICY some_policy_to_drop ON foobar
-                AS RESTRICTIVE
-                FOR SELECT
-                TO PUBLIC
-                USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);    
-
-
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id SMALLSERIAL,
-                foo CHAR DEFAULT '5',
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
-            );
-
-            CREATE INDEX other_idx ON foobar(bar);
-
-            CREATE POLICY foobar_policy ON foobar 
-                AS PERMISSIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (new_fizz = 5.25);
-
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo CHAR
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeAuthzUpdate,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Alter table: effectively drop by changing everything",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            CREATE INDEX normal_idx ON foobar USING hash (fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-
-            CREATE POLICY foobar_policy ON foobar 
-                AS PERMISSIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (id > 1 AND foo = 'value');
-
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                new_buzz REAL CHECK (new_buzz IS NOT NULL),
-                new_fizz SERIAL NOT NULL UNIQUE,
-                new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
-            );
-            CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
+			CREATE POLICY some_policy_to_drop ON foobar
+				AS RESTRICTIVE
+				FOR SELECT
+				TO PUBLIC
+				USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);	
 
 
-            CREATE POLICY foobar_policy ON foobar 
-                AS RESTRICTIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id SMALLSERIAL,
+				foo CHAR DEFAULT '5',
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+			    new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
+			);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
-            diff.MigrationHazardTypeAuthzUpdate,
-            diff.MigrationHazardTypeDeletesData,
-            diff.MigrationHazardTypeIndexDropped,
-            diff.MigrationHazardTypeIndexBuild,
-        },
-    },
-    {
-        name: "Alter table: translate BIGINT type to TIMESTAMP, set to not null, set default",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                obj_attr__c_time BIGINT,
-                obj_attr__m_time BIGINT
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                obj_attr__c_time TIMESTAMP NOT NULL,
-                obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
-            diff.MigrationHazardTypeImpactsDatabasePerformance,
-        },
-    },
+			CREATE INDEX other_idx ON foobar(bar);
+
+			CREATE POLICY foobar_policy ON foobar 
+				AS PERMISSIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (new_fizz = 5.25);
+
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo CHAR
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeAuthzUpdate,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Alter table: effectively drop by changing everything",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+			    buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			CREATE INDEX normal_idx ON foobar USING hash (fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+
+			CREATE POLICY foobar_policy ON foobar 
+				AS PERMISSIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (id > 1 AND foo = 'value');
+
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				new_buzz REAL CHECK (new_buzz IS NOT NULL),
+			    new_fizz SERIAL NOT NULL UNIQUE,
+				new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
+			);
+			CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
+
+
+			CREATE POLICY foobar_policy ON foobar 
+				AS RESTRICTIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
+
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeAcquiresShareRowExclusiveLock,
+			diff.MigrationHazardTypeAuthzUpdate,
+			diff.MigrationHazardTypeDeletesData,
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Alter table: translate BIGINT type to TIMESTAMP, set to not null, set default",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    obj_attr__c_time BIGINT,
+				obj_attr__m_time BIGINT
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				obj_attr__c_time TIMESTAMP NOT NULL,
+				obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestTableTestCases() {
-    suite.runTestCases(tableAcceptanceTestCases)
+	suite.runTestCases(tableAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -9,53 +9,53 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE ,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE ,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 
 		expectEmptyPlan: true,
@@ -65,29 +65,29 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
 		},
 	},
 	{
@@ -95,16 +95,16 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY,
-                fizz SERIAL NOT NULL,
-                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-            );
-            ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-            `,
+			CREATE TABLE "Foobar"(
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				id INT PRIMARY KEY,
+				fizz SERIAL NOT NULL,
+				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+			);
+			ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+			`,
 		},
 	},
 	{
@@ -112,16 +112,16 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                id INT PRIMARY KEY,
-                fizz SERIAL NOT NULL,
-                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-            );
-            ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
-            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-            `,
+			CREATE TABLE "Foobar"(
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				id INT PRIMARY KEY,
+				fizz SERIAL NOT NULL,
+				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+			);
+			ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
+			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+			`,
 		},
 	},
 	{
@@ -129,13 +129,13 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    foobar TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+			`,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -144,26 +144,26 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop table",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-            
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1.foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1.foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -174,15 +174,15 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop a table with quoted names",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "Foobar"(
-                id INT PRIMARY KEY,
-                "Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL
-            );
-            CREATE INDEX normal_idx ON "Foobar"(fizz);
-            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
-            `,
+			CREATE TABLE "Foobar"(
+			    id INT PRIMARY KEY,
+				"Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL
+			);
+			CREATE INDEX normal_idx ON "Foobar"(fizz);
+			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
+			`,
 		},
 		newSchemaDDL: nil,
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -193,19 +193,19 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop a table (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_2;
-            CREATE TABLE schema_2."Foobar"(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE SCHEMA schema_2;
+			CREATE TABLE schema_2."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -215,21 +215,21 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."Foobar"(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."Foobar"(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
@@ -239,21 +239,21 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity to index replica identity",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar REPLICA IDENTITY FULL;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar REPLICA IDENTITY FULL;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                foobar TEXT NOT NULL
-            );
-            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				foobar TEXT NOT NULL
+			);
+			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
@@ -265,18 +265,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Enable RLS",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -286,18 +286,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -307,18 +307,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Force RLS",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -328,18 +328,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unforce RLS",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -349,47 +349,47 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New primary key, drop unique constraint, new unique constraint, change column types, delete unique index, delete FK's, new index, validate check constraint",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz BOOLEAN NOT NULL,
-                buzz REAL,
-                fizzbuzz TEXT
-            );
-            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz BOOLEAN NOT NULL,
+				buzz REAL,
+				fizzbuzz TEXT
+			);
+			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT CHECK (id > 0) UNIQUE,
-                foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
-                fizz BOOLEAN NOT NULL,
-                buzz REAL,
-                fizzbuzz TEXT COLLATE "POSIX"
-            );
-            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE INDEX other_idx ON foobar(bar);
+			CREATE TABLE foobar(
+			    id INT CHECK (id > 0) UNIQUE,
+				foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+			    fizz BOOLEAN NOT NULL,
+			    buzz REAL,
+				fizzbuzz TEXT COLLATE "POSIX"
+			);
+			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE INDEX other_idx ON foobar(bar);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -402,63 +402,63 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New column, new primary key, new FK, drop FK, alter column to nullable, alter column types, drop column, drop index, drop check constraints, alter policies",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL,
-                   buzz REAL CHECK (buzz IS NOT NULL)
-            );
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL,
+			   	buzz REAL CHECK (buzz IS NOT NULL)
+			);
 
-            CREATE INDEX normal_idx ON foobar(fizz);
-            CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
+			CREATE INDEX normal_idx ON foobar(fizz);
+			CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
 
-            CREATE POLICY foobar_policy ON foobar 
-                AS PERMISSIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (fizz > 0);
+			CREATE POLICY foobar_policy ON foobar 
+				AS PERMISSIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (fizz > 0);
 
-            CREATE POLICY some_policy_to_drop ON foobar
-                AS RESTRICTIVE
-                FOR SELECT
-                TO PUBLIC
-                USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);    
+			CREATE POLICY some_policy_to_drop ON foobar
+				AS RESTRICTIVE
+				FOR SELECT
+				TO PUBLIC
+				USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);	
 
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id SMALLSERIAL,
-                foo CHAR DEFAULT '5',
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
-            );
+			CREATE TABLE foobar(
+			    id SMALLSERIAL,
+				foo CHAR DEFAULT '5',
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+			    new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
+			);
 
-            CREATE INDEX other_idx ON foobar(bar);
+			CREATE INDEX other_idx ON foobar(bar);
 
-            CREATE POLICY foobar_policy ON foobar 
-                AS PERMISSIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (new_fizz = 5.25);
+			CREATE POLICY foobar_policy ON foobar 
+				AS PERMISSIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (new_fizz = 5.25);
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo CHAR
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo CHAR
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -474,60 +474,60 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: effectively drop by changing everything",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                fizz SERIAL NOT NULL UNIQUE,
-                buzz REAL CHECK (buzz IS NOT NULL)
-            );
-            CREATE INDEX normal_idx ON foobar USING hash (fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			    fizz SERIAL NOT NULL UNIQUE,
+			    buzz REAL CHECK (buzz IS NOT NULL)
+			);
+			CREATE INDEX normal_idx ON foobar USING hash (fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-            CREATE POLICY foobar_policy ON foobar 
-                AS PERMISSIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (id > 1 AND foo = 'value');
+			CREATE POLICY foobar_policy ON foobar 
+				AS PERMISSIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (id > 1 AND foo = 'value');
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                new_buzz REAL CHECK (new_buzz IS NOT NULL),
-                new_fizz SERIAL NOT NULL UNIQUE,
-                new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-                new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
-            );
-            CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
-            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
+			CREATE TABLE foobar(
+			    new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				new_buzz REAL CHECK (new_buzz IS NOT NULL),
+			    new_fizz SERIAL NOT NULL UNIQUE,
+				new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+			    new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
+			);
+			CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
+			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
 
 
-            CREATE POLICY foobar_policy ON foobar 
-                AS RESTRICTIVE 
-                FOR INSERT 
-                TO PUBLIC
-                WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
+			CREATE POLICY foobar_policy ON foobar 
+				AS RESTRICTIVE 
+				FOR INSERT 
+				TO PUBLIC
+				WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
 
-            CREATE TABLE foobar_fk(
-                bar TIMESTAMP,
-                foo VARCHAR(255)
-            );
-            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-            -- create a circular dependency of foreign keys (this is allowed)
-            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
-            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
-            `,
+			CREATE TABLE foobar_fk(
+			    bar TIMESTAMP,
+			    foo VARCHAR(255)
+			);
+			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+			-- create a circular dependency of foreign keys (this is allowed)
+			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
+			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -542,21 +542,21 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: translate BIGINT type to TIMESTAMP, set to not null, set default",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                obj_attr__c_time BIGINT,
-                obj_attr__m_time BIGINT
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+			    obj_attr__c_time BIGINT,
+				obj_attr__m_time BIGINT
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foobar(
-                id INT PRIMARY KEY,
-                obj_attr__c_time TIMESTAMP NOT NULL,
-                obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
-            );
-            `,
+			CREATE TABLE foobar(
+			    id INT PRIMARY KEY,
+				obj_attr__c_time TIMESTAMP NOT NULL,
+				obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -9,52 +9,52 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL UNIQUE ,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE ,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 
@@ -65,28 +65,28 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
 			`,
 		},
 	},
@@ -95,15 +95,15 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY,
-				fizz SERIAL NOT NULL,
-				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-			);
-			ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+            CREATE TABLE "Foobar"(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                fizz SERIAL NOT NULL,
+                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+            );
+            ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
 			`,
 		},
 	},
@@ -112,15 +112,15 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY,
-				fizz SERIAL NOT NULL,
-				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-			);
-			ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+            CREATE TABLE "Foobar"(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                fizz SERIAL NOT NULL,
+                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+            );
+            ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
 			`,
 		},
 	},
@@ -129,12 +129,12 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
 			`,
 		},
 
@@ -144,25 +144,25 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop table",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -174,14 +174,14 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop a table with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				id INT PRIMARY KEY,
-				"Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL
-			);
-			CREATE INDEX normal_idx ON "Foobar"(fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL
+            );
+            CREATE INDEX normal_idx ON "Foobar"(fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
 			`,
 		},
 		newSchemaDDL: nil,
@@ -193,18 +193,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop a table (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT PRIMARY KEY
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."Foobar"(
-				id INT PRIMARY KEY
-			);
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."Foobar"(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -215,20 +215,20 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT PRIMARY KEY
-			);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-				id INT PRIMARY KEY
-			);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -239,20 +239,20 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity to index replica identity",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				foobar TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -265,17 +265,17 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Enable RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -286,17 +286,17 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -307,17 +307,17 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Force RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -328,17 +328,17 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unforce RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -349,46 +349,46 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New primary key, drop unique constraint, new unique constraint, change column types, delete unique index, delete FK's, new index, validate check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz BOOLEAN NOT NULL,
-				buzz REAL,
-				fizzbuzz TEXT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL,
+                buzz REAL,
+                fizzbuzz TEXT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT CHECK (id > 0) UNIQUE,
-				foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
-				fizz BOOLEAN NOT NULL,
-				buzz REAL,
-				fizzbuzz TEXT COLLATE "POSIX"
-			);
-			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE INDEX other_idx ON foobar(bar);
+            CREATE TABLE foobar(
+                id INT CHECK (id > 0) UNIQUE,
+                foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+                fizz BOOLEAN NOT NULL,
+                buzz REAL,
+                fizzbuzz TEXT COLLATE "POSIX"
+            );
+            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE INDEX other_idx ON foobar(bar);
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -402,62 +402,62 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New column, new primary key, new FK, drop FK, alter column to nullable, alter column types, drop column, drop index, drop check constraints, alter policies",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL,
-			   	buzz REAL CHECK (buzz IS NOT NULL)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL,
+                   buzz REAL CHECK (buzz IS NOT NULL)
+            );
 
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (fizz > 0);
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (fizz > 0);
 
-			CREATE POLICY some_policy_to_drop ON foobar
-				AS RESTRICTIVE
-				FOR SELECT
-				TO PUBLIC
-				USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);	
+            CREATE POLICY some_policy_to_drop ON foobar
+                AS RESTRICTIVE
+                FOR SELECT
+                TO PUBLIC
+                USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);    
 
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id SMALLSERIAL,
-				foo CHAR DEFAULT '5',
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-				new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
-			);
+            CREATE TABLE foobar(
+                id SMALLSERIAL,
+                foo CHAR DEFAULT '5',
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
+            );
 
-			CREATE INDEX other_idx ON foobar(bar);
+            CREATE INDEX other_idx ON foobar(bar);
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (new_fizz = 5.25);
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (new_fizz = 5.25);
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo CHAR
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo CHAR
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -474,59 +474,59 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: effectively drop by changing everything",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			CREATE INDEX normal_idx ON foobar USING hash (fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            CREATE INDEX normal_idx ON foobar USING hash (fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (id > 1 AND foo = 'value');
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (id > 1 AND foo = 'value');
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				new_buzz REAL CHECK (new_buzz IS NOT NULL),
-				new_fizz SERIAL NOT NULL UNIQUE,
-				new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-				new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
-			);
-			CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
+            CREATE TABLE foobar(
+                new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                new_buzz REAL CHECK (new_buzz IS NOT NULL),
+                new_fizz SERIAL NOT NULL UNIQUE,
+                new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
+            );
+            CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
 
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS RESTRICTIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
+            CREATE POLICY foobar_policy ON foobar 
+                AS RESTRICTIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
 
-			CREATE TABLE foobar_fk(
-				bar TIMESTAMP,
-				foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -542,20 +542,20 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: translate BIGINT type to TIMESTAMP, set to not null, set default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				obj_attr__c_time BIGINT,
-				obj_attr__m_time BIGINT
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                obj_attr__c_time BIGINT,
+                obj_attr__m_time BIGINT
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-				id INT PRIMARY KEY,
-				obj_attr__c_time TIMESTAMP NOT NULL,
-				obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                obj_attr__c_time TIMESTAMP NOT NULL,
+                obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -10,10 +10,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE ,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL UNIQUE ,
 				buzz REAL CHECK (buzz IS NOT NULL)
 			);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
@@ -23,8 +23,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -35,10 +35,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL UNIQUE,
 				buzz REAL CHECK (buzz IS NOT NULL)
 			);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
@@ -48,8 +48,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -66,10 +66,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL UNIQUE,
 				buzz REAL CHECK (buzz IS NOT NULL)
 			);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
@@ -80,8 +80,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -130,8 +130,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foobar TEXT NOT NULL
+				id INT PRIMARY KEY,
+				foobar TEXT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
 			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
@@ -145,10 +145,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL UNIQUE,
 				buzz REAL CHECK (buzz IS NOT NULL)
 			);
 			CREATE INDEX normal_idx ON foobar(fizz);
@@ -156,8 +156,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -175,10 +175,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				"Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL
 			);
 			CREATE INDEX normal_idx ON "Foobar"(fizz);
 			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
@@ -195,7 +195,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -203,7 +203,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_2;
 			CREATE TABLE schema_2."Foobar"(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -217,7 +217,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
 			`,
@@ -226,7 +226,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			`
 			CREATE SCHEMA schema_1;
 			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
 			`,
@@ -240,7 +240,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			ALTER TABLE foobar REPLICA IDENTITY FULL;
 			`,
@@ -248,7 +248,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				foobar TEXT NOT NULL
 			);
 			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
@@ -266,14 +266,14 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
 			`,
@@ -287,7 +287,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
 			`,
@@ -295,7 +295,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -308,14 +308,14 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
 			`,
@@ -329,7 +329,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
 			`,
@@ -337,7 +337,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
+				id INT PRIMARY KEY
 			);
 			`,
 		},
@@ -350,10 +350,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz BOOLEAN NOT NULL,
 				buzz REAL,
 				fizzbuzz TEXT
 			);
@@ -362,8 +362,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -374,11 +374,11 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT CHECK (id > 0) UNIQUE,
+				id INT CHECK (id > 0) UNIQUE,
 				foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
-			    fizz BOOLEAN NOT NULL,
-			    buzz REAL,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+				fizz BOOLEAN NOT NULL,
+				buzz REAL,
 				fizzbuzz TEXT COLLATE "POSIX"
 			);
 			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
@@ -386,8 +386,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 			CREATE INDEX other_idx ON foobar(bar);
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			`,
 		},
@@ -403,10 +403,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL,
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL,
 			   	buzz REAL CHECK (buzz IS NOT NULL)
 			);
 
@@ -427,8 +427,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			-- create a circular dependency of foreign keys (this is allowed)
 			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
@@ -437,10 +437,10 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id SMALLSERIAL,
+				id SMALLSERIAL,
 				foo CHAR DEFAULT '5',
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-			    new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+				new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
 			);
 
 			CREATE INDEX other_idx ON foobar(bar);
@@ -452,8 +452,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 				WITH CHECK (new_fizz = 5.25);
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo CHAR
+				bar TIMESTAMP,
+				foo CHAR
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -475,11 +475,11 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+				id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
 				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-			    buzz REAL CHECK (buzz IS NOT NULL)
+				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				fizz SERIAL NOT NULL UNIQUE,
+				buzz REAL CHECK (buzz IS NOT NULL)
 			);
 			CREATE INDEX normal_idx ON foobar USING hash (fizz);
 			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
@@ -491,8 +491,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 				WITH CHECK (id > 1 AND foo = 'value');
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -503,11 +503,11 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 				new_buzz REAL CHECK (new_buzz IS NOT NULL),
-			    new_fizz SERIAL NOT NULL UNIQUE,
+				new_fizz SERIAL NOT NULL UNIQUE,
 				new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
+				new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
 			);
 			CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
 			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
@@ -520,8 +520,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 				WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
 
 			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
+				bar TIMESTAMP,
+				foo VARCHAR(255)
 			);
 			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
 			-- create a circular dependency of foreign keys (this is allowed)
@@ -543,8 +543,8 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    obj_attr__c_time BIGINT,
+				id INT PRIMARY KEY,
+				obj_attr__c_time BIGINT,
 				obj_attr__m_time BIGINT
 			);
 			`,
@@ -552,7 +552,7 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		newSchemaDDL: []string{
 			`
 			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
+				id INT PRIMARY KEY,
 				obj_attr__c_time TIMESTAMP NOT NULL,
 				obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			);

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -9,53 +9,53 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE ,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE ,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 
 		expectEmptyPlan: true,
@@ -65,29 +65,29 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
 		},
 	},
 	{
@@ -95,16 +95,16 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY,
-				fizz SERIAL NOT NULL,
-				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-			);
-			ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-			`,
+            CREATE TABLE "Foobar"(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                fizz SERIAL NOT NULL,
+                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+            );
+            ALTER TABLE "Foobar" ENABLE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+            `,
 		},
 	},
 	{
@@ -112,16 +112,16 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-				bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				id INT PRIMARY KEY,
-				fizz SERIAL NOT NULL,
-				"Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
-			);
-			ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
-			CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
-			`,
+            CREATE TABLE "Foobar"(
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                id INT PRIMARY KEY,
+                fizz SERIAL NOT NULL,
+                "Foo" VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0)
+            );
+            ALTER TABLE "Foobar" FORCE ROW LEVEL SECURITY;
+            CREATE INDEX normal_idx ON "Foobar" USING hash (fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo" DESC, bar);
+            `,
 		},
 	},
 	{
@@ -129,13 +129,13 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    foobar TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+            `,
 		},
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
@@ -144,26 +144,26 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop table",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-				buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
-			
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1.foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON schema_1.foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE schema_1.foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES schema_1.foobar_fk(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -174,15 +174,15 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop a table with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "Foobar"(
-			    id INT PRIMARY KEY,
-				"Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL
-			);
-			CREATE INDEX normal_idx ON "Foobar"(fizz);
-			CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
-			`,
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                "Foo" VARCHAR(255) COLLATE "C" DEFAULT '' NOT NULL CHECK (LENGTH("Foo") > 0),
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL
+            );
+            CREATE INDEX normal_idx ON "Foobar"(fizz);
+            CREATE UNIQUE INDEX unique_idx ON "Foobar"("Foo", "bar");
+            `,
 		},
 		newSchemaDDL: nil,
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -193,19 +193,19 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop a table (conflicting schemas)",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_2;
-			CREATE TABLE schema_2."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE SCHEMA schema_2;
+            CREATE TABLE schema_2."Foobar"(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,
@@ -215,21 +215,21 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY FULL;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."Foobar"(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."Foobar"(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE schema_1."Foobar" REPLICA IDENTITY DEFAULT;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
@@ -239,21 +239,21 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter replica identity to index replica identity",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar REPLICA IDENTITY FULL;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar REPLICA IDENTITY FULL;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				foobar TEXT NOT NULL
-			);
-			CREATE UNIQUE INDEX some_idx ON foobar(foobar);
-			ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foobar TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX some_idx ON foobar(foobar);
+            ALTER TABLE foobar REPLICA IDENTITY USING INDEX some_idx;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeCorrectness,
@@ -265,18 +265,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Enable RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -286,18 +286,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Disable RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar ENABLE ROW LEVEL SECURITY;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -307,18 +307,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Force RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -328,18 +328,18 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Unforce RLS",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            ALTER TABLE foobar FORCE ROW LEVEL SECURITY;
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAuthzUpdate,
@@ -349,47 +349,47 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New primary key, drop unique constraint, new unique constraint, change column types, delete unique index, delete FK's, new index, validate check constraint",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz BOOLEAN NOT NULL,
-				buzz REAL,
-				fizzbuzz TEXT
-			);
-			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" UNIQUE DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz BOOLEAN NOT NULL,
+                buzz REAL,
+                fizzbuzz TEXT
+            );
+            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL) NOT VALID;
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT CHECK (id > 0) UNIQUE,
-				foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
-			    fizz BOOLEAN NOT NULL,
-			    buzz REAL,
-				fizzbuzz TEXT COLLATE "POSIX"
-			);
-			ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE INDEX other_idx ON foobar(bar);
+            CREATE TABLE foobar(
+                id INT CHECK (id > 0) UNIQUE,
+                foo CHAR COLLATE "C" DEFAULT '5' NOT NULL PRIMARY KEY,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+                fizz BOOLEAN NOT NULL,
+                buzz REAL,
+                fizzbuzz TEXT COLLATE "POSIX"
+            );
+            ALTER TABLE foobar ADD CONSTRAINT buzz_check CHECK (buzz IS NOT NULL);
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE INDEX other_idx ON foobar(bar);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -402,63 +402,63 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: New column, new primary key, new FK, drop FK, alter column to nullable, alter column types, drop column, drop index, drop check constraints, alter policies",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL,
-			   	buzz REAL CHECK (buzz IS NOT NULL)
-			);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL,
+                   buzz REAL CHECK (buzz IS NOT NULL)
+            );
 
-			CREATE INDEX normal_idx ON foobar(fizz);
-			CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
+            CREATE INDEX normal_idx ON foobar(fizz);
+            CREATE UNIQUE INDEX unique_idx ON foobar(foo DESC, bar);
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (fizz > 0);
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (fizz > 0);
 
-			CREATE POLICY some_policy_to_drop ON foobar
-				AS RESTRICTIVE
-				FOR SELECT
-				TO PUBLIC
-				USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);	
+            CREATE POLICY some_policy_to_drop ON foobar
+                AS RESTRICTIVE
+                FOR SELECT
+                TO PUBLIC
+                USING (bar = CURRENT_TIMESTAMP AND fizz * 2 > 0);    
 
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id SMALLSERIAL,
-				foo CHAR DEFAULT '5',
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-			    new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
-			);
+            CREATE TABLE foobar(
+                id SMALLSERIAL,
+                foo CHAR DEFAULT '5',
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                new_fizz DECIMAL(65, 10) DEFAULT 5.25 NOT NULL PRIMARY KEY UNIQUE
+            );
 
-			CREATE INDEX other_idx ON foobar(bar);
+            CREATE INDEX other_idx ON foobar(bar);
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (new_fizz = 5.25);
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (new_fizz = 5.25);
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo CHAR
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo CHAR
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -474,60 +474,60 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: effectively drop by changing everything",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
-				foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			    fizz SERIAL NOT NULL UNIQUE,
-			    buzz REAL CHECK (buzz IS NOT NULL)
-			);
-			CREATE INDEX normal_idx ON foobar USING hash (fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY CHECK (id > 0), CHECK (id < buzz),
+                foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                fizz SERIAL NOT NULL UNIQUE,
+                buzz REAL CHECK (buzz IS NOT NULL)
+            );
+            CREATE INDEX normal_idx ON foobar USING hash (fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(foo, bar);
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS PERMISSIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (id > 1 AND foo = 'value');
+            CREATE POLICY foobar_policy ON foobar 
+                AS PERMISSIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (id > 1 AND foo = 'value');
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(foo, bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (foo, bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				new_buzz REAL CHECK (new_buzz IS NOT NULL),
-			    new_fizz SERIAL NOT NULL UNIQUE,
-				new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
-			    new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
-			);
-			CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
-			CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
+            CREATE TABLE foobar(
+                new_bar TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                new_buzz REAL CHECK (new_buzz IS NOT NULL),
+                new_fizz SERIAL NOT NULL UNIQUE,
+                new_foo VARCHAR(255) COLLATE "POSIX" DEFAULT '' NOT NULL,
+                new_id INT PRIMARY KEY CHECK (new_id > 0), CHECK (new_id < new_buzz)
+            );
+            CREATE INDEX normal_idx ON foobar USING hash (new_fizz);
+            CREATE UNIQUE INDEX foobar_unique_idx ON foobar(new_foo, new_bar);
 
 
-			CREATE POLICY foobar_policy ON foobar 
-				AS RESTRICTIVE 
-				FOR INSERT 
-				TO PUBLIC
-				WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
+            CREATE POLICY foobar_policy ON foobar 
+                AS RESTRICTIVE 
+                FOR INSERT 
+                TO PUBLIC
+                WITH CHECK (new_id > 0 AND new_foo = 'some_new_value');
 
-			CREATE TABLE foobar_fk(
-			    bar TIMESTAMP,
-			    foo VARCHAR(255)
-			);
-			CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
-			-- create a circular dependency of foreign keys (this is allowed)
-			ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
-			ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
-			`,
+            CREATE TABLE foobar_fk(
+                bar TIMESTAMP,
+                foo VARCHAR(255)
+            );
+            CREATE UNIQUE INDEX foobar_fk_unique_idx ON foobar_fk(foo, bar);
+            -- create a circular dependency of foreign keys (this is allowed)
+            ALTER TABLE foobar_fk ADD CONSTRAINT foobar_fk_fk FOREIGN KEY (foo, bar) REFERENCES foobar(new_foo, new_bar);
+            ALTER TABLE foobar ADD CONSTRAINT foobar_fk FOREIGN KEY (new_foo, new_bar) REFERENCES foobar_fk(foo, bar);
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
@@ -542,21 +542,21 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter table: translate BIGINT type to TIMESTAMP, set to not null, set default",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-			    obj_attr__c_time BIGINT,
-				obj_attr__m_time BIGINT
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                obj_attr__c_time BIGINT,
+                obj_attr__m_time BIGINT
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foobar(
-			    id INT PRIMARY KEY,
-				obj_attr__c_time TIMESTAMP NOT NULL,
-				obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
-			);
-			`,
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                obj_attr__c_time TIMESTAMP NOT NULL,
+                obj_attr__m_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -31,9 +31,9 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
 				BEGIN
-				    IF LENGTH(NEW.content) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
+					IF LENGTH(NEW.content) == 0 THEN
+						RAISE EXCEPTION 'content is empty';
+					END IF;
 				END;
 			$$ language 'plpgsql';
 
@@ -67,9 +67,9 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 
 			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
 				BEGIN
-				    IF LENGTH(NEW.content) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
+					IF LENGTH(NEW.content) == 0 THEN
+						RAISE EXCEPTION 'content is empty';
+					END IF;
 				END;
 			$$ language 'plpgsql';
 

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -9,75 +9,75 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE foo (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE foo (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-                BEGIN
-                    IF LENGTH(NEW.content) == 0 THEN
-                        RAISE EXCEPTION 'content is empty';
-                    END IF;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+				BEGIN
+				    IF LENGTH(NEW.content) == 0 THEN
+				        RAISE EXCEPTION 'content is empty';
+				    END IF;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_check_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                EXECUTE FUNCTION check_content();
-            `,
+			CREATE TRIGGER some_check_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				EXECUTE FUNCTION check_content();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE foo (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE foo (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
 
-            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-                BEGIN
-                    IF LENGTH(NEW.content) == 0 THEN
-                        RAISE EXCEPTION 'content is empty';
-                    END IF;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+				BEGIN
+				    IF LENGTH(NEW.content) == 0 THEN
+				        RAISE EXCEPTION 'content is empty';
+				    END IF;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER some_check_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                EXECUTE FUNCTION check_content();
-            `,
+			CREATE TRIGGER some_check_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				EXECUTE FUNCTION check_content();
+			`,
 		},
 		expectEmptyPlan: true,
 	},
@@ -85,39 +85,39 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create trigger with quoted name",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_1."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_2."increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_1."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_2."increment version"();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -125,47 +125,47 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create triggers with quoted names on partitioned table and partition",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
 
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-            `,
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
 
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -173,42 +173,42 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create two triggers depending on the same function",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TRIGGER "some other trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some other trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -216,56 +216,56 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create two triggers with the same name",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -273,94 +273,94 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop trigger with quoted names",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_1."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_2."increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_1."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_2."increment version"();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-            `,
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+			`,
 		},
 	},
 	{
 		name: "Drop triggers with quoted names on partitioned table and partition",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
 
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
 
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-            `,
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -368,56 +368,56 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop two triggers with the same name",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -425,364 +425,364 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop trigger - conflicting schemas",
 		oldSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_1."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_2."increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_1."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_2."increment version"();
 
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE SCHEMA schema_4;
-            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-            `,
+			CREATE SCHEMA schema_4;
+			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE SCHEMA schema_4;
-            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE SCHEMA schema_4;
+			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_3."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_4."increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_3."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_4."increment version"();
+			`,
 		},
 	},
 	{
 		name: "Alter trigger when clause",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (NEW.author != 'fizz')
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (NEW.author != 'fizz')
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 	},
 	{
 		name: "Alter trigger table",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 	},
 	{
 		name: "Change trigger function and keep old function",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-        `},
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
 
-            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "decrement version"();
-        `},
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "decrement version"();
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Change trigger function and drop old function",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-        `},
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+		`},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
 
-            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "decrement version"();
-        `},
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "decrement version"();
+		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Trigger on re-created table is re-created",
 		oldSchemaDDL: []string{
 			`
-            CREATE TABLE "some foobar" (
-                id INTEGER,
-                version INT NOT NULL DEFAULT 0,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT ''
-            ) PARTITION BY LIST (content);
+			CREATE TABLE "some foobar" (
+				id INTEGER,
+				version INT NOT NULL DEFAULT 0,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT ''
+			) PARTITION BY LIST (content);
 
-            CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foobar"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foobar"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		newSchemaDDL: []string{
 			`
-            CREATE TABLE "some other foobar" (
-                id INTEGER,
-                version INT NOT NULL DEFAULT 0,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT ''
-            ) PARTITION BY LIST (content);
+			CREATE TABLE "some other foobar" (
+				id INTEGER,
+				version INT NOT NULL DEFAULT 0,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT ''
+			) PARTITION BY LIST (content);
 
-            CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
+			CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
 
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
 
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foobar"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foobar"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
 
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -1,795 +1,795 @@
 package migration_acceptance_tests
 
 import (
-    "github.com/stripe/pg-schema-diff/pkg/diff"
+	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var triggerAcceptanceTestCases = []acceptanceTestCase{
-    {
-        name: "No-op",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE foo (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-                BEGIN
-                    IF LENGTH(NEW.content) == 0 THEN
-                        RAISE EXCEPTION 'content is empty';
-                    END IF;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_check_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                EXECUTE FUNCTION check_content();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE foo (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_update_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE increment_version();
-
-            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-                BEGIN
-                    IF LENGTH(NEW.content) == 0 THEN
-                        RAISE EXCEPTION 'content is empty';
-                    END IF;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER some_check_trigger
-                BEFORE UPDATE ON foo
-                FOR EACH ROW
-                EXECUTE FUNCTION check_content();
-            `,
-        },
-        expectEmptyPlan: true,
-    },
-    {
-        name: "Create trigger with quoted name",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_1."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_2."increment version"();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Create triggers with quoted names on partitioned table and partition",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
-
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
-
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Create two triggers depending on the same function",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-
-            CREATE TRIGGER "some other trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Create two triggers with the same name",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Drop trigger with quoted names",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_1."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_2."increment version"();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-            `,
-        },
-    },
-    {
-        name: "Drop triggers with quoted names on partitioned table and partition",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
-
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            ) PARTITION BY LIST (content);
-
-            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Drop two triggers with the same name",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Add and drop trigger - conflicting schemas",
-        oldSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_1."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_2."increment version"();
-
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE SCHEMA schema_4;
-            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE SCHEMA schema_1;
-            CREATE TABLE schema_1."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE SCHEMA schema_2;
-            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE SCHEMA schema_3;
-            CREATE TABLE schema_3."some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE SCHEMA schema_4;
-            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON schema_3."some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE schema_4."increment version"();
-            `,
-        },
-    },
-    {
-        name: "Alter trigger when clause",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (NEW.author != 'fizz')
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-    },
-    {
-        name: "Alter trigger table",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-            CREATE TABLE "some other foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-    },
-    {
-        name: "Change trigger function and keep old function",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-
-            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "decrement version"();
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Change trigger function and drop old function",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-        `},
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some foo" (
-                id INTEGER PRIMARY KEY,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT '',
-                version INT NOT NULL DEFAULT 0
-            );
-
-            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foo"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "decrement version"();
-        `},
-        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-    },
-    {
-        name: "Trigger on re-created table is re-created",
-        oldSchemaDDL: []string{
-            `
-            CREATE TABLE "some foobar" (
-                id INTEGER,
-                version INT NOT NULL DEFAULT 0,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT ''
-            ) PARTITION BY LIST (content);
-
-            CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some foobar"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        newSchemaDDL: []string{
-            `
-            CREATE TABLE "some other foobar" (
-                id INTEGER,
-                version INT NOT NULL DEFAULT 0,
-                author TEXT,
-                content TEXT NOT NULL DEFAULT ''
-            ) PARTITION BY LIST (content);
-
-            CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
-
-            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-                BEGIN
-                    NEW.version = OLD.version + 1;
-                    RETURN NEW;
-                END;
-            $$ language 'plpgsql';
-
-            CREATE TRIGGER "some trigger"
-                BEFORE UPDATE ON "some other foobar"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-
-            CREATE TRIGGER "some partition trigger"
-                BEFORE UPDATE ON "foobar 1"
-                FOR EACH ROW
-                WHEN (OLD.* IS DISTINCT FROM NEW.*)
-                EXECUTE PROCEDURE "increment version"();
-            `,
-        },
-        expectedHazardTypes: []diff.MigrationHazardType{
-            diff.MigrationHazardTypeDeletesData,
-        },
-    },
+	{
+		name: "No-op",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE foo (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+				BEGIN
+				    IF LENGTH(NEW.content) == 0 THEN
+				        RAISE EXCEPTION 'content is empty';
+				    END IF;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_check_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				EXECUTE FUNCTION check_content();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE foo (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_update_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE increment_version();
+
+			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+				BEGIN
+				    IF LENGTH(NEW.content) == 0 THEN
+				        RAISE EXCEPTION 'content is empty';
+				    END IF;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER some_check_trigger
+				BEFORE UPDATE ON foo
+				FOR EACH ROW
+				EXECUTE FUNCTION check_content();
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Create trigger with quoted name",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_1."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_2."increment version"();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Create triggers with quoted names on partitioned table and partition",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
+
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
+
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Create two triggers depending on the same function",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+
+			CREATE TRIGGER "some other trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Create two triggers with the same name",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Drop trigger with quoted names",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_1."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_2."increment version"();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+			`,
+		},
+	},
+	{
+		name: "Drop triggers with quoted names on partitioned table and partition",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
+
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			) PARTITION BY LIST (content);
+
+			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Drop two triggers with the same name",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Add and drop trigger - conflicting schemas",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_1."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_2."increment version"();
+
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE SCHEMA schema_4;
+			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_1;
+			CREATE TABLE schema_1."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE SCHEMA schema_2;
+			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE SCHEMA schema_3;
+			CREATE TABLE schema_3."some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE SCHEMA schema_4;
+			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON schema_3."some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE schema_4."increment version"();
+			`,
+		},
+	},
+	{
+		name: "Alter trigger when clause",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (NEW.author != 'fizz')
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+	},
+	{
+		name: "Alter trigger table",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+			CREATE TABLE "some other foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+	},
+	{
+		name: "Change trigger function and keep old function",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+
+			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "decrement version"();
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Change trigger function and drop old function",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+		`},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some foo" (
+				id INTEGER PRIMARY KEY,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT '',
+				version INT NOT NULL DEFAULT 0
+			);
+
+			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foo"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "decrement version"();
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "Trigger on re-created table is re-created",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE "some foobar" (
+				id INTEGER,
+				version INT NOT NULL DEFAULT 0,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT ''
+			) PARTITION BY LIST (content);
+
+			CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some foobar"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE "some other foobar" (
+				id INTEGER,
+				version INT NOT NULL DEFAULT 0,
+				author TEXT,
+				content TEXT NOT NULL DEFAULT ''
+			) PARTITION BY LIST (content);
+
+			CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
+
+			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.version = OLD.version + 1;
+					RETURN NEW;
+				END;
+			$$ language 'plpgsql';
+
+			CREATE TRIGGER "some trigger"
+				BEFORE UPDATE ON "some other foobar"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+
+			CREATE TRIGGER "some partition trigger"
+				BEFORE UPDATE ON "foobar 1"
+				FOR EACH ROW
+				WHEN (OLD.* IS DISTINCT FROM NEW.*)
+				EXECUTE PROCEDURE "increment version"();
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
 }
 
 func (suite *acceptanceTestSuite) TestTriggerTestCases() {
-    suite.runTestCases(triggerAcceptanceTestCases)
+	suite.runTestCases(triggerAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -1,795 +1,795 @@
 package migration_acceptance_tests
 
 import (
-	"github.com/stripe/pg-schema-diff/pkg/diff"
+    "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
 var triggerAcceptanceTestCases = []acceptanceTestCase{
-	{
-		name: "No-op",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE foo (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-				    IF LENGTH(NEW.content) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE foo (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
-
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-				    IF LENGTH(NEW.content) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
-			`,
-		},
-		expectEmptyPlan: true,
-	},
-	{
-		name: "Create trigger with quoted name",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Create triggers with quoted names on partitioned table and partition",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
-
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
-
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Create two triggers depending on the same function",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-
-			CREATE TRIGGER "some other trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Create two triggers with the same name",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Drop trigger with quoted names",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-			`,
-		},
-	},
-	{
-		name: "Drop triggers with quoted names on partitioned table and partition",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
-
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
-
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
-
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Drop two triggers with the same name",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Add and drop trigger - conflicting schemas",
-		oldSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
-
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE SCHEMA schema_4;
-			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE SCHEMA schema_4;
-			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_3."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_4."increment version"();
-			`,
-		},
-	},
-	{
-		name: "Alter trigger when clause",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (NEW.author != 'fizz')
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-	},
-	{
-		name: "Alter trigger table",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-	},
-	{
-		name: "Change trigger function and keep old function",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-
-			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "decrement version"();
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Change trigger function and drop old function",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-		`},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-
-			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "decrement version"();
-		`},
-		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
-	},
-	{
-		name: "Trigger on re-created table is re-created",
-		oldSchemaDDL: []string{
-			`
-			CREATE TABLE "some foobar" (
-				id INTEGER,
-				version INT NOT NULL DEFAULT 0,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT ''
-			) PARTITION BY LIST (content);
-
-			CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foobar"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		newSchemaDDL: []string{
-			`
-			CREATE TABLE "some other foobar" (
-				id INTEGER,
-				version INT NOT NULL DEFAULT 0,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT ''
-			) PARTITION BY LIST (content);
-
-			CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
-
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foobar"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
-		},
-		expectedHazardTypes: []diff.MigrationHazardType{
-			diff.MigrationHazardTypeDeletesData,
-		},
-	},
+    {
+        name: "No-op",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE foo (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.content) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE foo (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
+
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.content) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
+            `,
+        },
+        expectEmptyPlan: true,
+    },
+    {
+        name: "Create trigger with quoted name",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Create triggers with quoted names on partitioned table and partition",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
+
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
+
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Create two triggers depending on the same function",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+
+            CREATE TRIGGER "some other trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Create two triggers with the same name",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Drop trigger with quoted names",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+            `,
+        },
+    },
+    {
+        name: "Drop triggers with quoted names on partitioned table and partition",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
+
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
+
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Drop two triggers with the same name",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Add and drop trigger - conflicting schemas",
+        oldSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
+
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE SCHEMA schema_4;
+            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE SCHEMA schema_4;
+            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_3."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_4."increment version"();
+            `,
+        },
+    },
+    {
+        name: "Alter trigger when clause",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (NEW.author != 'fizz')
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+    },
+    {
+        name: "Alter trigger table",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+    },
+    {
+        name: "Change trigger function and keep old function",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+
+            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "decrement version"();
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Change trigger function and drop old function",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+        `},
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+
+            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "decrement version"();
+        `},
+        expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+    },
+    {
+        name: "Trigger on re-created table is re-created",
+        oldSchemaDDL: []string{
+            `
+            CREATE TABLE "some foobar" (
+                id INTEGER,
+                version INT NOT NULL DEFAULT 0,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT ''
+            ) PARTITION BY LIST (content);
+
+            CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foobar"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        newSchemaDDL: []string{
+            `
+            CREATE TABLE "some other foobar" (
+                id INTEGER,
+                version INT NOT NULL DEFAULT 0,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT ''
+            ) PARTITION BY LIST (content);
+
+            CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
+
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foobar"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
+        },
+        expectedHazardTypes: []diff.MigrationHazardType{
+            diff.MigrationHazardTypeDeletesData,
+        },
+    },
 }
 
 func (suite *acceptanceTestSuite) TestTriggerTestCases() {
-	suite.runTestCases(triggerAcceptanceTestCases)
+    suite.runTestCases(triggerAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -9,74 +9,74 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foo (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE foo (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-					IF LENGTH(NEW.content) == 0 THEN
-						RAISE EXCEPTION 'content is empty';
-					END IF;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.content) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foo (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE foo (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-					IF LENGTH(NEW.content) == 0 THEN
-						RAISE EXCEPTION 'content is empty';
-					END IF;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.content) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
 			`,
 		},
 		expectEmptyPlan: true,
@@ -85,38 +85,38 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create trigger with quoted name",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -125,46 +125,46 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create triggers with quoted names on partitioned table and partition",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -173,41 +173,41 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create two triggers depending on the same function",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some other trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some other trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -216,55 +216,55 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create two triggers with the same name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -273,46 +273,46 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop trigger with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 			`,
 		},
 	},
@@ -320,45 +320,45 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop triggers with quoted names on partitioned table and partition",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
 			`,
 		},
@@ -368,55 +368,55 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop two triggers with the same name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
@@ -425,84 +425,84 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop trigger - conflicting schemas",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_4;
-			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_4;
+            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_4;
-			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_4;
+            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_3."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_4."increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_3."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_4."increment version"();
 			`,
 		},
 	},
@@ -510,48 +510,48 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter trigger when clause",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (NEW.author != 'fizz')
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (NEW.author != 'fizz')
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 	},
@@ -559,60 +559,60 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Alter trigger table",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 	},
@@ -620,55 +620,55 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change trigger function and keep old function",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
 
-			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "decrement version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "decrement version"();
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -676,47 +676,47 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Change trigger function and drop old function",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 		`},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "decrement version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "decrement version"();
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -724,64 +724,64 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Trigger on re-created table is re-created",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foobar" (
-				id INTEGER,
-				version INT NOT NULL DEFAULT 0,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT ''
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foobar" (
+                id INTEGER,
+                version INT NOT NULL DEFAULT 0,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT ''
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foobar"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foobar"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some other foobar" (
-				id INTEGER,
-				version INT NOT NULL DEFAULT 0,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT ''
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some other foobar" (
+                id INTEGER,
+                version INT NOT NULL DEFAULT 0,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT ''
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foobar"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foobar"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -9,75 +9,75 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "No-op",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE foo (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE foo (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-				    IF LENGTH(NEW.content) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.content) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
-			`,
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE foo (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE foo (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION increment_version() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_update_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE increment_version();
+            CREATE TRIGGER some_update_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE increment_version();
 
-			CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
-				BEGIN
-				    IF LENGTH(NEW.content) == 0 THEN
-				        RAISE EXCEPTION 'content is empty';
-				    END IF;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION check_content() RETURNS TRIGGER AS $$
+                BEGIN
+                    IF LENGTH(NEW.content) == 0 THEN
+                        RAISE EXCEPTION 'content is empty';
+                    END IF;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER some_check_trigger
-				BEFORE UPDATE ON foo
-				FOR EACH ROW
-				EXECUTE FUNCTION check_content();
-			`,
+            CREATE TRIGGER some_check_trigger
+                BEFORE UPDATE ON foo
+                FOR EACH ROW
+                EXECUTE FUNCTION check_content();
+            `,
 		},
 		expectEmptyPlan: true,
 	},
@@ -85,39 +85,39 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create trigger with quoted name",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -125,47 +125,47 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create triggers with quoted names on partitioned table and partition",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-			`,
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -173,42 +173,42 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create two triggers depending on the same function",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some other trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some other trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -216,56 +216,56 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Create two triggers with the same name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -273,94 +273,94 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop trigger with quoted names",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-			`,
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+            `,
 		},
 	},
 	{
 		name: "Drop triggers with quoted names on partitioned table and partition",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foo" (
+                id INTEGER,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foo" FOR VALUES IN ('foo_2');
 
-			`,
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -368,56 +368,56 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Drop two triggers with the same name",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			`,
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
@@ -425,364 +425,364 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 		name: "Add and drop trigger - conflicting schemas",
 		oldSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_1."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_2."increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_1."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_2."increment version"();
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_4;
-			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
-			`,
+            CREATE SCHEMA schema_4;
+            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE SCHEMA schema_1;
-			CREATE TABLE schema_1."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_2;
-			CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_2;
+            CREATE FUNCTION schema_2."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE SCHEMA schema_3;
-			CREATE TABLE schema_3."some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE SCHEMA schema_3;
+            CREATE TABLE schema_3."some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE SCHEMA schema_4;
-			CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE SCHEMA schema_4;
+            CREATE FUNCTION schema_4."increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON schema_3."some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE schema_4."increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON schema_3."some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE schema_4."increment version"();
+            `,
 		},
 	},
 	{
 		name: "Alter trigger when clause",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (NEW.author != 'fizz')
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (NEW.author != 'fizz')
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 	},
 	{
 		name: "Alter trigger table",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
-			CREATE TABLE "some other foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
+            CREATE TABLE "some other foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 	},
 	{
 		name: "Change trigger function and keep old function",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-		`},
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
 
-			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "decrement version"();
-		`},
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "decrement version"();
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Change trigger function and drop old function",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-		`},
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+        `},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some foo" (
-				id INTEGER PRIMARY KEY,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT '',
-				version INT NOT NULL DEFAULT 0
-			);
+            CREATE TABLE "some foo" (
+                id INTEGER PRIMARY KEY,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT '',
+                version INT NOT NULL DEFAULT 0
+            );
 
-			CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "decrement version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foo"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "decrement version"();
-		`},
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foo"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "decrement version"();
+        `},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
 	{
 		name: "Trigger on re-created table is re-created",
 		oldSchemaDDL: []string{
 			`
-			CREATE TABLE "some foobar" (
-				id INTEGER,
-				version INT NOT NULL DEFAULT 0,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT ''
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some foobar" (
+                id INTEGER,
+                version INT NOT NULL DEFAULT 0,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT ''
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some foobar" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some foobar"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some foobar"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		newSchemaDDL: []string{
 			`
-			CREATE TABLE "some other foobar" (
-				id INTEGER,
-				version INT NOT NULL DEFAULT 0,
-				author TEXT,
-				content TEXT NOT NULL DEFAULT ''
-			) PARTITION BY LIST (content);
+            CREATE TABLE "some other foobar" (
+                id INTEGER,
+                version INT NOT NULL DEFAULT 0,
+                author TEXT,
+                content TEXT NOT NULL DEFAULT ''
+            ) PARTITION BY LIST (content);
 
-			CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
+            CREATE TABLE "foobar 1" PARTITION OF "some other foobar" FOR VALUES IN ('foo_2');
 
-			CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
-				BEGIN
-					NEW.version = OLD.version + 1;
-					RETURN NEW;
-				END;
-			$$ language 'plpgsql';
+            CREATE FUNCTION "increment version"() RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.version = OLD.version + 1;
+                    RETURN NEW;
+                END;
+            $$ language 'plpgsql';
 
-			CREATE TRIGGER "some trigger"
-				BEFORE UPDATE ON "some other foobar"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
+            CREATE TRIGGER "some trigger"
+                BEFORE UPDATE ON "some other foobar"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
 
-			CREATE TRIGGER "some partition trigger"
-				BEFORE UPDATE ON "foobar 1"
-				FOR EACH ROW
-				WHEN (OLD.* IS DISTINCT FROM NEW.*)
-				EXECUTE PROCEDURE "increment version"();
-			`,
+            CREATE TRIGGER "some partition trigger"
+                BEFORE UPDATE ON "foobar 1"
+                FOR EACH ROW
+                WHEN (OLD.* IS DISTINCT FROM NEW.*)
+                EXECUTE PROCEDURE "increment version"();
+            `,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeDeletesData,


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description

Standardizing the whitespace in the migration_acceptance_tests to be spaces so viewing isn't uneven.

### Motivation

Resolves #67 

### Testing

I ran the test docker image built on my local machine and observed no test failures which is expected given the only changes are whitespace. The one caveat is it was only run against `postgres` 14 given that was the specified arg in the test dockerfile.
