### PR TITLE
Use the test environment that is intended to be used

### DIFF
--- a/build/Dockerfile.test
+++ b/build/Dockerfile.test
@@ -7,8 +7,8 @@ RUN apk update && \
       build-base \
       make \
       $POSTGRES_PACKAGE \
-      postgresql-contrib \
-      postgresql-client
+      $POSTGRES_PACKAGE-contrib \
+      $POSTGRES_PACKAGE-client
 
 WORKDIR /pg-schema-diff
 


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
It seems postgresql-contrib installs postgresql16, which then had precedence in the $PATH. This resulted in the tests running postgresql16 for the non-16 tests. Obviously, this is not the behavior we want. I validated this because in the [postgresql 14 logs](https://productionresultssa8.blob.core.windows.net/actions-results/6fad0e39-9e29-4eb3-bc5f-7ff4eb01baa2/workflow-job-run-d0ba29aa-214f-539c-d02c-c4463caefb4e/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-07-03T22%3A42%3A42Z&sig=%2F1Y7gF6Vuoiye1B9PV5qGOni4oK2qQorCfxkc5KdFSc%3D&ske=2024-07-04T06%3A41%3A52Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-07-03T18%3A41%3A52Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2023-11-03&sp=r&spr=https&sr=b&st=2024-07-03T22%3A32%3A37Z&sv=2023-11-03)  you can see: `starting PostgreSQL 16.3`

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Fix our test environment
### Testing
[//]: # (Describe how you tested these changes)
Validating it works as expected:
Checked the postgresql14 and postgresql15 to ensure the versions were what we expect 
- `starting PostgreSQL 14.12`
- `starting PostgreSQL 15.7`

