### PR TITLE
Add test cases for functional indexes

### DIFF
--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -106,6 +106,31 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		},
 	},
 	{
+		name: "Add a functional index",
+		oldSchemaDDL: []string{
+			`
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255)
+            );
+            CREATE INDEX some_idx ON schema_1.foobar(lower(foo));
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
 		name: "Add a unique index",
 		oldSchemaDDL: []string{
 			`
@@ -478,7 +503,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
                 foo VARCHAR(255) NOT NULL
             );
             CREATE INDEX some_idx ON schema_1.foobar(id, foo);
-            
+
             CREATE SCHEMA schema_2;
             CREATE TABLE schema_2.foobar(
                 id INT PRIMARY KEY,
@@ -493,7 +518,7 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
                 id INT PRIMARY KEY,
                 foo VARCHAR(255) NOT NULL
             );
-            
+
             CREATE SCHEMA schema_2;
             CREATE TABLE schema_2.foobar(
                 id INT PRIMARY KEY,

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -167,6 +167,40 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 		},
 	},
 	{
+		name: "Add a functional partitioned index",
+		oldSchemaDDL: []string{
+			`
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE SCHEMA schema_1;
+            CREATE TABLE schema_1.foobar(
+                id INT,
+                foo VARCHAR(255)
+            ) PARTITION BY LIST (foo);
+            CREATE schema schema_2;
+            CREATE TABLE schema_2.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_1');
+            CREATE TABLE schema_2.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_2');
+            CREATE TABLE schema_2.foobar_3 PARTITION OF schema_1.foobar FOR VALUES IN ('foo_3');
+
+            CREATE INDEX some_idx ON schema_1.foobar(lower(foo));
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
 		name: "Add a primary key",
 		oldSchemaDDL: []string{
 			`
@@ -330,11 +364,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
             CREATE TABLE schema_2.foobar(
                 id INT,
                 foo VARCHAR(255)
-            ); 
+            );
             CREATE TABLE schema_2.foobar_1(
                 id INT,
                 foo VARCHAR(255)
-            ); 
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -376,11 +410,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
             CREATE TABLE schema_2.foobar(
                 id INT,
                 foo VARCHAR(255)
-            ); 
+            );
             CREATE TABLE schema_2.foobar_1(
                 id INT,
                 foo VARCHAR(255)
-            ); 
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -423,11 +457,11 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
             CREATE TABLE schema_2.foobar(
                 id INT,
                 foo VARCHAR(255)
-            ); 
+            );
             CREATE TABLE schema_2.foobar_1(
                 id INT,
                 foo VARCHAR(255)
-            ); 
+            );
 			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -570,12 +604,12 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar INT,
                 foo VARCHAR(255)
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 
             CREATE INDEX some_idx ON foobar(foo, id);
             CREATE INDEX foobar_1_some_local_idx ON foobar_1(foo, bar, id);
-            
+
             -- Create a table in a different schema to ensure that dependencies are correctly set
             CREATE schema schema_1;
             CREATE TABLE schema_1.foobar(
@@ -590,7 +624,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar INT,
                 foo VARCHAR(255)
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
 		`},
 		expectedHazardTypes: []diff.MigrationHazardType{
@@ -614,7 +648,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar INT,
                 foo VARCHAR(255)
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
             CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
@@ -629,7 +663,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar INT,
                 foo VARCHAR(255)
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
             CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
@@ -675,7 +709,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar INT,
                 foo VARCHAR(255)
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
             CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
@@ -691,7 +725,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar VARCHAR(255),
                 foo INT
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
             CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 
@@ -706,7 +740,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar INT,
                 foo VARCHAR(255)
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE foobar_1 PARTITION OF foobar FOR VALUES IN ('foo_1');
             CREATE TABLE foobar_2 PARTITION OF foobar FOR VALUES IN ('foo_2');
 
@@ -721,7 +755,7 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
                 bar VARCHAR(255),
                 foo INT
             ) PARTITION BY LIST (foo);
-            
+
             CREATE TABLE schema_1.foobar_1 PARTITION OF schema_1.foobar FOR VALUES IN (1);
             CREATE TABLE schema_1.foobar_2 PARTITION OF schema_1.foobar FOR VALUES IN (2);
 


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Adds test cases to cover [functional indexes](https://www.postgresql.org/docs/7.3/indexes-functional.html) to ensure that we test them in perpetuity.

A callout: under the hood the apply generates with a type cast for the input to the lower function (which only accepts text not varchar) which is different from the user provided definition without the cast. I think this doesn't trip up the tests and is desirable behavior because in reality pg-schema-diff is diffing schema that's been applied and read from a test database, not the user provided schema, so that type cast is always present.

Let me know if those empty line cleanup diffs should be removed. That's something my editor did.

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
We want to use functional indexes. pg-schema-diff already does, but it's preferable to ensure it's covered by tests.

### Testing
[//]: # (Describe how you tested these changes)
CI
