### PR TITLE
Fix column renames for indexes

### DIFF
--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -893,6 +893,38 @@ var (
 			},
 		},
 		{
+			name: "Column rename",
+			ddl: []string{`
+			CREATE TABLE foo (
+				value TEXT
+			);
+			CREATE INDEX foo_value_idx ON foo (value);
+			ALTER TABLE foo RENAME COLUMN value TO renamed_value;
+		`},
+			expectedSchema: Schema{
+				NamedSchemas: []NamedSchema{
+					{Name: "public"},
+				},
+				Tables: []Table{
+					{
+						SchemaQualifiedName: SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foo\""},
+						Columns: []Column{
+							{Name: "renamed_value", Type: "text", IsNullable: true, Size: -1, Collation: defaultCollation},
+						},
+						CheckConstraints: nil,
+						ReplicaIdentity:  ReplicaIdentityDefault,
+					},
+				},
+				Indexes: []Index{
+					{
+						OwningTable: SchemaQualifiedName{SchemaName: "public", EscapedName: "\"foo\""},
+						Name:        "foo_value_idx", Columns: []string{"renamed_value"},
+						GetIndexDefStmt: "CREATE INDEX foo_value_idx ON public.foo USING btree (renamed_value)",
+					},
+				},
+			},
+		},
+		{
 			name: "Filtering - filtering out the base table",
 			opts: []GetSchemaOpt{WithIncludeSchemas("public")},
 			ddl: []string{`

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -1718,6 +1718,7 @@ func (isg *indexSQLVertexGenerator) addDepsOnTableAddAlterIfNecessary(index sche
 		}
 	}
 
+	// Otherwise, we can drop the index whenever we want.
 	return nil
 }
 


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Index columns effectively have two occurrences in pg_attribute, one is a "virtual column" created for the index and the other is the actual referenced column. For our purposes, we care about the latter, i.e., ensuring an index is deleted before its owning column is dropped, otherwise the index will be implicitly deleted (and not concurrently).

When a column is renamed, the virtual column name stays the same, but the underlying column name obviously changes. pg-schema-diff contained a bug where it referenced the _virtual_ column name. Effectively, a column would be renamed but the column names in the fetched index would not change, leading to incorrectly generated dependencies.

[I found this thread in the Postgres maling list to be very useful.
](https://www.postgresql.org/message-id/20210224.165511.465857914180630454.horikyota.ntt%40gmail.com)

What I did:
- Updated pg-schema-diff to reference the actual column name
- (added benefit) Index columns are now fetched in the same query as the indexes, reducing round trips to the database

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Bug fix

### Testing
[//]: # (Describe how you tested these changes)
See added test case