### PR TITLE
Support nested directories

### DIFF
--- a/cmd/pg-schema-diff/flags.go
+++ b/cmd/pg-schema-diff/flags.go
@@ -32,11 +32,11 @@ func parseConnConfig(c connFlags, logger log.Logger) (*pgx.ConnConfig, error) {
 	return pgx.ParseConfig(c.dsn)
 }
 
-// LogFmtToMap parses all LogFmt key/value pairs from the provided string into a
+// logFmtToMap parses all LogFmt key/value pairs from the provided string into a
 // map.
 //
 // All records are scanned. If a duplicate key is found, an error is returned.
-func LogFmtToMap(logFmt string) (map[string]string, error) {
+func logFmtToMap(logFmt string) (map[string]string, error) {
 	logMap := make(map[string]string)
 	decoder := logfmt.NewDecoder(strings.NewReader(logFmt))
 	for decoder.ScanRecord() {

--- a/cmd/pg-schema-diff/flags_test.go
+++ b/cmd/pg-schema-diff/flags_test.go
@@ -60,7 +60,7 @@ func TestLogFmtToMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LogFmtToMap(tt.args.logFmt)
+			got, err := logFmtToMap(tt.args.logFmt)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Support nested directories, i.e., walk nested directories

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Fixes #155 
Relates to #162 
### Testing
[//]: # (Describe how you tested these changes)

Validated on schema dir with nested folders:
```
  |-foobar.sql
  |-last
  |  |-nested
  |  |  |-fk.sql
  |-earlier_schema
  |  |-enum.sql
```

Execution order should be lexical order of file paths.

```
 go run ./cmd/pg-schema-diff plan --schema-dir ~/stripe/tempschema --dsn 'host=localhost user=bplunkett dbname=postgres'           INT х │ 00:37:34

################################ Generated plan ################################
1. CREATE TYPE "public"."mood" AS ENUM ('sad', 'ok', 'happy');
        -- Statement Timeout: 3s

2. CREATE TABLE "public"."fk" (
        "id" text COLLATE "pg_catalog"."default"
);
        -- Statement Timeout: 3s

3. ALTER TABLE "public"."foobar" ADD COLUMN "id" character varying(255) COLLATE "pg_catalog"."default";
        -- Statement Timeout: 3s

4. ALTER TABLE "public"."foobar" ADD COLUMN "mood" mood;
        -- Statement Timeout: 3s

5. CREATE UNIQUE INDEX CONCURRENTLY foobar_id_key ON public.foobar USING btree (id);
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s
        -- Hazard INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.

6. ALTER TABLE "public"."foobar" ADD CONSTRAINT "foobar_id_key" UNIQUE USING INDEX "foobar_id_key";
        -- Statement Timeout: 3s

7. ALTER TABLE "public"."fk" ADD CONSTRAINT "fk_id_fkey" FOREIGN KEY (id) REFERENCES foobar(id) NOT VALID;
        -- Statement Timeout: 3s

8. ALTER TABLE "public"."fk" VALIDATE CONSTRAINT "fk_id_fkey";
        -- Statement Timeout: 3s

```
