### PR TITLE
Improve dir schema source errors

### DIFF
--- a/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_0/0/0.sql
+++ b/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_0/0/0.sql
@@ -1,0 +1,1 @@
+CREATE TYPE color AS ENUM ('red', 'green', 'blue');

--- a/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_0/1.sql
+++ b/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_0/1.sql
@@ -1,0 +1,4 @@
+CREATE TABLE foobar (
+    id varchar(255) PRIMARY KEY,
+    color color
+);

--- a/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_0/2/0/0.sql
+++ b/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_0/2/0/0.sql
@@ -1,0 +1,3 @@
+CREATE TABLE foobar_fk (
+    id TEXT REFERENCES foobar (id)
+);

--- a/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_1/0.sql
+++ b/internal/migration_acceptance_tests/testdata/dirsrc_happy_path/schema_1/0.sql
@@ -1,0 +1,5 @@
+CREATE TABLE fizzbuzz (
+    id TEXT,
+    primary_color COLOR,
+    other_color COLOR
+);

--- a/internal/migration_acceptance_tests/testdata/dirsrc_invalid_sql/schema_0/0.sql
+++ b/internal/migration_acceptance_tests/testdata/dirsrc_invalid_sql/schema_0/0.sql
@@ -1,0 +1,3 @@
+CREATE TABLE foobar (
+    id SERIAL PRIMARY KEY
+);

--- a/internal/migration_acceptance_tests/testdata/dirsrc_invalid_sql/schema_0/1.sql
+++ b/internal/migration_acceptance_tests/testdata/dirsrc_invalid_sql/schema_0/1.sql
@@ -1,0 +1,3 @@
+CREATE TABLE fizzbuzz (
+    id TEXT REFERENCES non_existent_table (id)
+);


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Improve schema source errors to include file path that errored. Including line number is not really viable right now because it would require splitting a string blob into individual SQL statements. Parsing SQL is pretty fragile, and it's something pg-schema-diff tries to avoid. We can revisit adding that functionality later.

cc @aleclarson

### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
Partially fixes #167 

### Testing
[//]: # (Describe how you tested these changes)


Error with file name:
```
go run ./cmd/pg-schema-diff plan --schema-dir ./internal/migration_acceptance_tests/testdata/dirsrc_invalid_sql --dsn 'host=localhost user=bplunkett dbname=postgres'
Error: generating plan: getting new schema: running DDL (from internal/migration_acceptance_tests/testdata/dirsrc_invalid_sql/schema_0/1.sql): ERROR: relation "non_existent_table" does not exist (SQLSTATE 42P01)
exit status 1
```

Happy path:
```
 go run ./cmd/pg-schema-diff plan --schema-dir ./internal/migration_acceptance_tests/testdata/dirsrc_happy_path --dsn 'host=localhost user=bplunkett dbname=postgres'

################################ Generated plan ################################
1. CREATE TYPE "public"."color" AS ENUM ('red', 'green', 'blue');
        -- Statement Timeout: 3s

2. CREATE TABLE "public"."fizzbuzz" (
        "primary_color" color,
        "other_color" color,
        "id" text COLLATE "pg_catalog"."default"
);
        -- Statement Timeout: 3s

3. ALTER TABLE "public"."foobar" ADD COLUMN "color" color;
        -- Statement Timeout: 3s

4. ALTER TABLE "public"."foobar" ADD COLUMN "id" character varying(255) COLLATE "pg_catalog"."default" NOT NULL;
        -- Statement Timeout: 3s

5. CREATE UNIQUE INDEX CONCURRENTLY foobar_pkey ON public.foobar USING btree (id);
        -- Statement Timeout: 20m0s
        -- Lock Timeout: 3s
        -- Hazard INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.

6. ALTER TABLE "public"."foobar" ADD CONSTRAINT "foobar_pkey" PRIMARY KEY USING INDEX "foobar_pkey";
        -- Statement Timeout: 3s

7. CREATE TABLE "public"."foobar_fk" (
        "id" text COLLATE "pg_catalog"."default"
);
        -- Statement Timeout: 3s

8. ALTER TABLE "public"."foobar_fk" ADD CONSTRAINT "foobar_fk_id_fkey" FOREIGN KEY (id) REFERENCES foobar(id) NOT VALID;
        -- Statement Timeout: 3s

9. ALTER TABLE "public"."foobar_fk" VALIDATE CONSTRAINT "foobar_fk_id_fkey";
        -- Statement Timeout: 3s
```

