### PR TITLE
Create simple version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ $ pg-schema-diff plan --dsn "postgres://postgres:postgres@localhost:5432/postgre
 # Install
 ## CLI
 ```bash
-go install github.com/stripe/pg-schema-diff/cmd/pg-schema-diff
+go install github.com/stripe/pg-schema-diff/cmd/pg-schema-diff@latest
 ```
 
 ## Library
 ```bash
-go get -u github.com/stripe/pg-schema-diff
+go get -u github.com/stripe/pg-schema-diff@latest
 ```
 # Using CLI
 ## 1. Apply schema to fresh database

--- a/cmd/pg-schema-diff/main.go
+++ b/cmd/pg-schema-diff/main.go
@@ -15,6 +15,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(buildPlanCmd())
 	rootCmd.AddCommand(buildApplyCmd())
+	rootCmd.AddCommand(buildVersionCmd())
 }
 
 func main() {

--- a/cmd/pg-schema-diff/version_cmd.go
+++ b/cmd/pg-schema-diff/version_cmd.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+func buildVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Get the version of pg-schema-diff",
+	}
+	cmd.RunE = func(_ *cobra.Command, _ []string) error {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if !ok {
+			return fmt.Errorf("build information not available")
+		}
+		fmt.Printf("version=%s\n", buildInfo.Main.Version)
+
+		return nil
+	}
+	return cmd
+}


### PR DESCRIPTION
[//]: # (README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed)

### Description
[//]: # (A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change.)
Create simple version command to help with debugging
### Motivation
[//]: # (Why you made these changes. Link to any relevant issues.)
None
### Testing
[//]: # (Describe how you tested these changes)

It says "(devel)" beecause it is the version of the locally build command (which has no version). This code should print out the same info as `go version -m (binary path)`

New command:
```
 go run ./cmd/pg-schema-diff version                                                                                                   INT х │ 01:01:02
version=(devel)
```

Example of go version of latest commit sha (it's what's next to the mod). This uses the same go debug info under the hood, so I expect the `version` command on the installed binary to mirror its output
```
go version -m $(where pg-schema-diff)                                                                                                ✔ │ 4s │ 01:01:55
/Users/bplunkett/go/bin/pg-schema-diff: go1.22.0
        path    github.com/stripe/pg-schema-diff/cmd/pg-schema-diff
        mod     github.com/stripe/pg-schema-diff        v0.7.1-0.20240909221644-5fe8259b82bd    h1:jF5uaAlsiU0Txzf+7kviuIyqdLcwuAWAJALDH92kXkU=
```
