### PR TITLE
Add JSON output support to pg-schema-diff plan.

### DIFF
--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -489,14 +489,6 @@ func planToPrettyS(plan diff.Plan) string {
 	return sb.String()
 }
 
-func planToJsonS(plan diff.Plan) string {
-	jsonData, err := json.MarshalIndent(plan, "", "  ")
-	if err != nil {
-		panic(err)
-	}
-	return string(jsonData)
-}
-
 func statementToPrettyS(stmt diff.Statement) string {
 	sb := strings.Builder{}
 	sb.WriteString(fmt.Sprintf("%s;", stmt.DDL))
@@ -519,4 +511,12 @@ func hazardToPrettyS(hazard diff.MigrationHazard) string {
 	} else {
 		return hazard.Type
 	}
+}
+
+func planToJsonS(plan diff.Plan) string {
+	jsonData, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(jsonData)
 }


### PR DESCRIPTION
### Description

This adds support for different output formats when running the `plan` subcommand. Currently it only supports pretty printing (which is what already exists today) or JSON.

I rarely/never write golang so this PR was more or less a first attempt to get a discussion going, happy to refactor as needed.

### Motivation

I'm working on a tool written in Python that is using the pg-schema-diff to generate schema plans. It would be great to have a structured output option so I can just parse the output in Python.

Alternatively I can build some kind of bindings for this library, that would require waaay more overhead than just being able to parse the JSON output.

I think this would make the tool much more versatile.

### Testing
Just manual testing. I'm happy to add test coverage, but I didn't see any other CLI tests (besides some options parsing tests) so I wasn't really sure where to start.
