### PR TITLE
Accelerate tests

### DIFF
--- a/build/Dockerfile.test
+++ b/build/Dockerfile.test
@@ -24,5 +24,5 @@ RUN adduser --disabled-password --gecos '' testrunner
 USER testrunner
 
 # Run tests serially so logs can be streamed. Set overall timeout to 30m (the default is 10m, which is not enough)
-CMD ["-v", "-race", "-p", "1", "./...", "-timeout", "30m"]
+CMD ["-v", "-race", "./...", "-timeout", "30m"]
 ENTRYPOINT ["go", "test"]

--- a/internal/migration_acceptance_tests/backwards_compat_cases_test.go
+++ b/internal/migration_acceptance_tests/backwards_compat_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var backCompatAcceptanceTestCases = []acceptanceTestCase{
 	{
@@ -132,6 +136,6 @@ var backCompatAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestBackCompatTestCases() {
-	suite.runTestCases(backCompatAcceptanceTestCases)
+func TestBackCompatTestCases(t *testing.T) {
+	runTestCases(t, backCompatAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/check_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/check_constraint_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -551,6 +553,6 @@ var checkConstraintCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestCheckConstraintTestCases() {
-	suite.runTestCases(checkConstraintCases)
+func TestCheckConstraintTestCases(t *testing.T) {
+	runTestCases(t, checkConstraintCases)
 }

--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -1184,6 +1186,6 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestColumnTestCases() {
-	suite.runTestCases(columnAcceptanceTestCases)
+func TestColumnTestCases(t *testing.T) {
+	runTestCases(t, columnAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/data_packing_cases_test.go
+++ b/internal/migration_acceptance_tests/data_packing_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var dataPackingCases = []acceptanceTestCase{
 	{
@@ -133,11 +137,11 @@ var dataPackingCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestDataPackingTestCases() {
+func TestDataPackingTestCases(t *testing.T) {
 	var tcs []acceptanceTestCase
 	for _, tc := range dataPackingCases {
 		tc.planOpts = append(tc.planOpts, diff.WithDataPackNewTables())
 		tcs = append(tcs, tc)
 	}
-	suite.runTestCases(tcs)
+	runTestCases(t, tcs)
 }

--- a/internal/migration_acceptance_tests/database_schema_source_cases_test.go
+++ b/internal/migration_acceptance_tests/database_schema_source_cases_test.go
@@ -3,6 +3,7 @@ package migration_acceptance_tests
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 	"github.com/stripe/pg-schema-diff/pkg/sqldb"
@@ -187,6 +188,6 @@ var databaseSchemaSourceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestDatabaseSchemaSourceTestCases() {
-	suite.runTestCases(databaseSchemaSourceTestCases)
+func TestDatabaseSchemaSourceTestCases(t *testing.T) {
+	runTestCases(t, databaseSchemaSourceTestCases)
 }

--- a/internal/migration_acceptance_tests/enum_cases_test.go
+++ b/internal/migration_acceptance_tests/enum_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var enumAcceptanceTestCases = []acceptanceTestCase{
 	{
@@ -116,6 +120,6 @@ var enumAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestEnumTestCases() {
-	suite.runTestCases(enumAcceptanceTestCases)
+func TestEnumTestCases(t *testing.T) {
+	runTestCases(t, enumAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/extensions_cases_test.go
+++ b/internal/migration_acceptance_tests/extensions_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var extensionAcceptanceTestCases = []acceptanceTestCase{
 	{
@@ -67,6 +71,6 @@ var extensionAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestExtensionTestCases() {
-	suite.runTestCases(extensionAcceptanceTestCases)
+func TestExtensionTestCases(t *testing.T) {
+	runTestCases(t, extensionAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
+++ b/internal/migration_acceptance_tests/foreign_key_constraint_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var foreignKeyConstraintCases = []acceptanceTestCase{
 	{
@@ -923,6 +927,6 @@ var foreignKeyConstraintCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestForeignKeyConstraintTestCases() {
-	suite.runTestCases(foreignKeyConstraintCases)
+func TestForeignKeyConstraintTestCases(t *testing.T) {
+	runTestCases(t, foreignKeyConstraintCases)
 }

--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -573,6 +575,6 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestFunctionTestCases() {
-	suite.runTestCases(functionAcceptanceTestCases)
+func TestFunctionTestCases(t *testing.T) {
+	runTestCases(t, functionAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -824,6 +826,6 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestIndexTestCases() {
-	suite.runTestCases(indexAcceptanceTestCases)
+func TestIndexTestCases(t *testing.T) {
+	runTestCases(t, indexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/local_partition_index_cases_test.go
+++ b/internal/migration_acceptance_tests/local_partition_index_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -601,6 +603,6 @@ var localPartitionIndexAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestLocalPartitionIndexTestCases() {
-	suite.runTestCases(localPartitionIndexAcceptanceTestCases)
+func TestLocalPartitionIndexTestCases(t *testing.T) {
+	runTestCases(t, localPartitionIndexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/named_schema_cases_test.go
+++ b/internal/migration_acceptance_tests/named_schema_cases_test.go
@@ -1,5 +1,7 @@
 package migration_acceptance_tests
 
+import "testing"
+
 var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
 	{
 		name: "no op",
@@ -35,6 +37,6 @@ var namedSchemaAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestNamedSchemaTestCases() {
-	suite.runTestCases(namedSchemaAcceptanceTestCases)
+func TestNamedSchemaTestCases(t *testing.T) {
+	runTestCases(t, namedSchemaAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/partitioned_index_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_index_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -1262,6 +1264,6 @@ var partitionedIndexAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestPartitionedIndexTestCases() {
-	suite.runTestCases(partitionedIndexAcceptanceTestCases)
+func TestPartitionedIndexTestCases(t *testing.T) {
+	runTestCases(t, partitionedIndexAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/partitioned_table_cases_test.go
+++ b/internal/migration_acceptance_tests/partitioned_table_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -1292,6 +1294,6 @@ var partitionedTableAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestPartitionedTableTestCases() {
-	suite.runTestCases(partitionedTableAcceptanceTestCases)
+func TestPartitionedTableTestCases(t *testing.T) {
+	runTestCases(t, partitionedTableAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var policyAcceptanceTestCases = []acceptanceTestCase{
 	{
@@ -656,6 +660,6 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestPolicyCases() {
-	suite.runTestCases(policyAcceptanceTestCases)
+func TestPolicyCases(t *testing.T) {
+	runTestCases(t, policyAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/procedure_cases_test.go
+++ b/internal/migration_acceptance_tests/procedure_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var procedureAcceptanceTestCases = []acceptanceTestCase{
 	{
@@ -159,6 +163,6 @@ var procedureAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestProcedureTestCases() {
-	suite.runTestCases(procedureAcceptanceTestCases)
+func TestProcedureTestCases(t *testing.T) {
+	runTestCases(t, procedureAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/schema_cases_test.go
+++ b/internal/migration_acceptance_tests/schema_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -450,6 +452,6 @@ var schemaAcceptanceTests = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestSchemaTestCases() {
-	suite.runTestCases(schemaAcceptanceTests)
+func TestSchemaTestCases(t *testing.T) {
+	runTestCases(t, schemaAcceptanceTests)
 }

--- a/internal/migration_acceptance_tests/sequence_cases_test.go
+++ b/internal/migration_acceptance_tests/sequence_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var sequenceAcceptanceTests = []acceptanceTestCase{
 	{
@@ -760,6 +764,6 @@ var sequenceAcceptanceTests = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestSequenceTestCases() {
-	suite.runTestCases(sequenceAcceptanceTests)
+func TestSequenceTestCases(t *testing.T) {
+	runTestCases(t, sequenceAcceptanceTests)
 }

--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -1,6 +1,8 @@
 package migration_acceptance_tests
 
 import (
+	"testing"
+
 	"github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
@@ -569,6 +571,6 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestTableTestCases() {
-	suite.runTestCases(tableAcceptanceTestCases)
+func TestTableTestCases(t *testing.T) {
+	runTestCases(t, tableAcceptanceTestCases)
 }

--- a/internal/migration_acceptance_tests/trigger_cases_test.go
+++ b/internal/migration_acceptance_tests/trigger_cases_test.go
@@ -1,6 +1,10 @@
 package migration_acceptance_tests
 
-import "github.com/stripe/pg-schema-diff/pkg/diff"
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
 
 var triggerAcceptanceTestCases = []acceptanceTestCase{
 	{
@@ -939,6 +943,6 @@ var triggerAcceptanceTestCases = []acceptanceTestCase{
 	},
 }
 
-func (suite *acceptanceTestSuite) TestTriggerTestCases() {
-	suite.runTestCases(triggerAcceptanceTestCases)
+func TestTriggerTestCases(t *testing.T) {
+	runTestCases(t, triggerAcceptanceTestCases)
 }

--- a/internal/pgidentifier/identifier.go
+++ b/internal/pgidentifier/identifier.go
@@ -3,6 +3,7 @@ package pgidentifier
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 
@@ -24,8 +25,8 @@ var postgresIdentifierEncoding = base64.NewEncoding(encodePostgresIdentifier).Wi
 
 // RandomUUID builds a RandomUUID to be used in Postgres identifiers. This RandomUUID cannot be used directly as an identifier
 // and must be prefixed with a letter
-func RandomUUID() (string, error) {
-	uuid, err := uuid.NewRandom()
+func RandomUUID(randReader io.Reader) (string, error) {
+	uuid, err := uuid.NewRandomFromReader(randReader)
 	if err != nil {
 		return "", fmt.Errorf("generating RandomUUID: %w", err)
 	}

--- a/pkg/diff/schema_migration_plan_test.go
+++ b/pkg/diff/schema_migration_plan_test.go
@@ -3,7 +3,6 @@ package diff
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -360,8 +359,7 @@ func (r *deterministicRandReader) Read(p []byte) (int, error) {
 }
 
 func TestSchemaMigrationPlanTest(t *testing.T) {
-	uuid.SetRand(&deterministicRandReader{})
-
+	randReader := &deterministicRandReader{}
 	for _, testCase := range schemaMigrationPlanTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			schemaDiff, _, err := buildSchemaDiff(testCase.oldSchema, testCase.newSchema)
@@ -372,7 +370,7 @@ func TestSchemaMigrationPlanTest(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			stmts, err := schemaSQLGenerator{}.Alter(schemaDiff)
+			stmts, err := newSchemaSQLGenerator(randReader).Alter(schemaDiff)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.expectedStatements, stmts, "actual:\n %# v", pretty.Formatter(stmts))
 		})

--- a/pkg/tempdb/factory.go
+++ b/pkg/tempdb/factory.go
@@ -2,6 +2,7 @@ package tempdb
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
 	"fmt"
 	"io"
@@ -63,6 +64,7 @@ type (
 		logger         log.Logger
 		rootDatabase   string
 		dropTimeout    time.Duration
+		randReader     io.Reader
 	}
 
 	OnInstanceFactoryOpt func(*onInstanceFactoryOptions)
@@ -110,6 +112,13 @@ func WithDropTimeout(d time.Duration) OnInstanceFactoryOpt {
 	}
 }
 
+// WithRandReader seeds the random used to generate random SQL identifiers.
+func WithRandReader(randReader io.Reader) OnInstanceFactoryOpt {
+	return func(options *onInstanceFactoryOptions) {
+		options.randReader = randReader
+	}
+}
+
 type (
 	CreateConnPoolForDbFn func(ctx context.Context, dbName string) (*sql.DB, error)
 
@@ -140,6 +149,7 @@ func NewOnInstanceFactory(ctx context.Context, createConnPoolForDb CreateConnPoo
 		dropTimeout:    DefaultStatementTimeout,
 		rootDatabase:   "postgres",
 		logger:         log.SimpleLogger(),
+		randReader:     rand.Reader,
 	}
 	for _, opt := range opts {
 		opt(&options)


### PR DESCRIPTION
### Description
Stop using a test suite in the acceptance tests. This enables us to leverage `t.Parallel`. Because tests ran in parallel, to maintain the same "randomly" generated outputs, I wired through a rand reader rather than relying on a global singleton. This makes tests about 50% faster

Before:
<img width="620" height="449" alt="image" src="https://github.com/user-attachments/assets/1cce4a75-3271-4611-a962-e6edf8e7f106" />

After:
<img width="841" height="368" alt="image" src="https://github.com/user-attachments/assets/3b263a8e-53cb-49e1-9113-964a8d53303c" />


### Motivation
Speed up acceptance tests.
### Testing
[//]: # Describe how you tested these changes
Ran locally