### PR TITLE
feat: add --disable-concurrent-index-ops command-line flag

### DIFF
--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -112,8 +112,9 @@ type (
 		includeSchemas []string
 		excludeSchemas []string
 
-		dataPackNewTables     bool
-		disablePlanValidation bool
+		dataPackNewTables         bool
+		disablePlanValidation     bool
+		disableConcurrentIndexOps bool
 
 		statementTimeoutModifiers []string
 		lockTimeoutModifiers      []string
@@ -216,6 +217,8 @@ func createPlanOptionsFlags(cmd *cobra.Command) *planOptionsFlags {
 	cmd.Flags().BoolVar(&flags.dataPackNewTables, "data-pack-new-tables", true, "If set, will data pack new tables in the plan to minimize table size (re-arranges columns).")
 	cmd.Flags().BoolVar(&flags.disablePlanValidation, "disable-plan-validation", false, "If set, will disable plan validation. Plan validation runs the migration against a temporary"+
 		"database with an identical schema to the original, asserting that the generated plan actually migrates the schema to the desired target.")
+	cmd.Flags().BoolVar(&flags.disableConcurrentIndexOps, "disable-concurrent-index-ops", false, "If set, will disable the use of CONCURRENTLY in CREATE INDEX and DROP INDEX statements. "+
+		"This may result in longer lock times and potential downtime during migrations.")
 
 	timeoutModifierFlagVar(cmd, &flags.statementTimeoutModifiers, "statement", "t")
 	timeoutModifierFlagVar(cmd, &flags.lockTimeoutModifiers, "lock", "l")
@@ -314,6 +317,9 @@ func parsePlanOptions(p planOptionsFlags) (planOptions, error) {
 	}
 	if p.disablePlanValidation {
 		opts = append(opts, diff.WithDoNotValidatePlan())
+	}
+	if p.disableConcurrentIndexOps {
+		opts = append(opts, diff.WithDisableConcurrentIndexOps())
 	}
 
 	var statementTimeoutModifiers []timeoutModifier

--- a/pkg/diff/schema_migration_plan_test.go
+++ b/pkg/diff/schema_migration_plan_test.go
@@ -370,7 +370,7 @@ func TestSchemaMigrationPlanTest(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			stmts, err := newSchemaSQLGenerator(randReader).Alter(schemaDiff)
+			stmts, err := newSchemaSQLGenerator(randReader, &planOptions{}).Alter(schemaDiff)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.expectedStatements, stmts, "actual:\n %# v", pretty.Formatter(stmts))
 		})


### PR DESCRIPTION
Description

This PR introduces a new flag, --disable-concurrent-index-ops, allowing users to disable the use of CONCURRENTLY in CREATE INDEX and DROP INDEX
statements. Previously, concurrent index operations were always used for non-partitioned tables, which may not be suitable for all environments or use
cases.

Motivation

Some environments or scenarios require simpler DDL statements without the CONCURRENTLY keyword:
- Testing environments where downtime is acceptable and simpler SQL is preferred
- Development workflows that need predictable, synchronous index operations
- Integration with systems that don't support or have limitations with concurrent index operations
- Debugging scenarios where non-concurrent operations provide clearer behavior

By making concurrent operations configurable while keeping them as the safe default, we can accommodate more diverse deployment scenarios while
maintaining the tool's focus on minimal-downtime migrations.

Changes Made

- Core Implementation: Added disableConcurrentIndexOps field to planOptions in pkg/diff/plan_generator.go
- API: Created WithDisableConcurrentIndexOps() PlanOpt function for programmatic use
- CLI: Added --disable-concurrent-index-ops command-line flag in cmd/pg-schema-diff/plan_cmd.go
- Index Creation: Modified index creation logic in pkg/diff/sql_generator.go to conditionally use CONCURRENTLY
- Index Deletion: Updated index deletion logic to conditionally use CONCURRENTLY
- Safety: Added appropriate hazard warnings (ACQUIRES_ACCESS_EXCLUSIVE_LOCK) when concurrent operations are disabled
- Timeouts: Adjusted statement timeouts (3s vs 20m) based on operation type
- Documentation: Updated CLAUDE.md with usage examples and implementation details

Testing

- ✅ All existing unit tests pass without regressions
- ✅ Verified default behavior remains unchanged (still uses CONCURRENTLY)
- ✅ Confirmed new flag correctly removes CONCURRENTLY from both CREATE and DROP INDEX statements
- ✅ Validated proper hazard warnings are displayed when concurrent operations are disabled
- ✅ Tested with both pretty and JSON output formats
- ✅ Verified help documentation displays the new flag correctly

Example Usage

Default behavior (unchanged):
pg-schema-diff plan --from-dsn "..." --to-dir ./schema
> Generates: CREATE INDEX CONCURRENTLY idx_name ON table(column);

With new flag:
pg-schema-diff plan --from-dsn "..." --to-dir ./schema --disable-concurrent-index-ops
> Generates: CREATE INDEX idx_name ON table(column);

Backward Compatibility

This change is fully backward compatible. The default behavior remains unchanged, and the new flag is opt-in only. Existing scripts and workflows will
continue to work exactly as before.