### PR TITLE
Fix unit test, by adding a fixed restrict key for pgdump output comparison

### DIFF
--- a/cmd/pg-schema-diff/apply_cmd_test.go
+++ b/cmd/pg-schema-diff/apply_cmd_test.go
@@ -78,9 +78,9 @@ func (suite *cmdTestSuite) TestApplyCmd() {
 			})
 			// The migration should have been successful. Assert it was.
 			expectedDb := tempDbWithSchema(suite.T(), suite.pgEngine, tc.expectedSchemaDDL)
-			expectedDbDump, err := pgdump.GetDump(expectedDb, pgdump.WithSchemaOnly())
+			expectedDbDump, err := pgdump.GetDump(expectedDb, pgdump.WithSchemaOnly(), pgdump.WithRestrictKey("test"))
 			suite.Require().NoError(err)
-			fromDbDump, err := pgdump.GetDump(fromDb, pgdump.WithSchemaOnly())
+			fromDbDump, err := pgdump.GetDump(fromDb, pgdump.WithSchemaOnly(), pgdump.WithRestrictKey("test"))
 			suite.Require().NoError(err)
 
 			suite.Equal(expectedDbDump, fromDbDump)

--- a/internal/pgdump/dump.go
+++ b/internal/pgdump/dump.go
@@ -26,6 +26,12 @@ func WithSchemaOnly() Parameter {
 	}
 }
 
+func WithRestrictKey(restrict_key string) Parameter {
+	return Parameter{
+		values: []string{"--restrict-key", restrict_key},
+	}
+}
+
 // GetDump gets the pg_dump of the inputted database.
 // It is only intended to be used for testing. You cannot securely pass passwords with this implementation, so it will
 // only accept databases created for unit tests (spun up with the pgengine package)


### PR DESCRIPTION
### Description
Fix unit test, by adding a fixed restrict key for pgdump output comparison

### Motivation
To get unit tests to pass 
Without this fix, cmd/pg-schema-diff/apply_cmd_test.go fails because the restrict key defaults to a random guid, and won't match when comparing two different pgdump outputs

### Testing
go test