### PR TITLE
Account relation dependencies used by routines as composite types

### DIFF
--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -266,7 +266,33 @@ SELECT
     pg_catalog.pg_get_function_identity_arguments(
         pg_proc.oid
     ) AS func_identity_arguments,
-    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def
+    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def,
+    (
+        -- Find composite types of a table or a view used by this function
+        SELECT
+            ARRAY_AGG(DISTINCT JSONB_BUILD_OBJECT(
+                'schema', depend_namespace.nspname::TEXT,
+                'name', depend_class.relname::TEXT,
+                'columns', ARRAY[]::TEXT[]
+            ))
+        FROM pg_catalog.pg_depend AS depend
+        INNER JOIN
+            pg_catalog.pg_type AS depend_type
+            ON depend.refobjid = depend_type.oid
+        INNER JOIN
+            pg_catalog.pg_class AS depend_class
+            ON depend_type.typrelid = depend_class.oid
+        INNER JOIN
+            pg_catalog.pg_namespace AS depend_namespace
+            ON depend_class.relnamespace = depend_namespace.oid
+            AND depend_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+            AND depend_namespace.nspname !~ '^pg_toast'
+            AND depend_namespace.nspname !~ '^pg_temp'
+        WHERE
+            depend.classid = 'pg_proc'::REGCLASS
+            AND depend.objid = pg_proc.oid
+            AND depend.deptype = 'n'
+    )::TEXT [] AS table_dependencies
 FROM pg_catalog.pg_proc
 INNER JOIN
     pg_catalog.pg_namespace AS proc_namespace

--- a/internal/queries/queries.sql.go
+++ b/internal/queries/queries.sql.go
@@ -800,7 +800,33 @@ SELECT
     pg_catalog.pg_get_function_identity_arguments(
         pg_proc.oid
     ) AS func_identity_arguments,
-    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def
+    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def,
+    (
+        -- Find composite types of a table or a view used by this function
+        SELECT
+            ARRAY_AGG(DISTINCT JSONB_BUILD_OBJECT(
+                'schema', depend_namespace.nspname::TEXT,
+                'name', depend_class.relname::TEXT,
+                'columns', ARRAY[]::TEXT[]
+            ))
+        FROM pg_catalog.pg_depend AS depend
+        INNER JOIN
+            pg_catalog.pg_type AS depend_type
+            ON depend.refobjid = depend_type.oid
+        INNER JOIN
+            pg_catalog.pg_class AS depend_class
+            ON depend_type.typrelid = depend_class.oid
+        INNER JOIN
+            pg_catalog.pg_namespace AS depend_namespace
+            ON depend_class.relnamespace = depend_namespace.oid
+            AND depend_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+            AND depend_namespace.nspname !~ '^pg_toast'
+            AND depend_namespace.nspname !~ '^pg_temp'
+        WHERE
+            depend.classid = 'pg_proc'::REGCLASS
+            AND depend.objid = pg_proc.oid
+            AND depend.deptype = 'n'
+    )::TEXT [] AS table_dependencies
 FROM pg_catalog.pg_proc
 INNER JOIN
     pg_catalog.pg_namespace AS proc_namespace
@@ -831,6 +857,7 @@ type GetProcsRow struct {
 	FuncLang              string
 	FuncIdentityArguments string
 	FuncDef               string
+	TableDependencies     []string
 }
 
 func (q *Queries) GetProcs(ctx context.Context, prokind interface{}) ([]GetProcsRow, error) {
@@ -849,6 +876,7 @@ func (q *Queries) GetProcs(ctx context.Context, prokind interface{}) ([]GetProcs
 			&i.FuncLang,
 			&i.FuncIdentityArguments,
 			&i.FuncDef,
+			pq.Array(&i.TableDependencies),
 		); err != nil {
 			return nil, err
 		}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -449,6 +449,9 @@ type Function struct {
 	// can track the dependencies of the function (or not)
 	Language           string
 	DependsOnFunctions []SchemaQualifiedName
+
+	// TableDependencies is a list of tables the function depends on.
+	TableDependencies []TableDependency
 }
 
 type Procedure struct {
@@ -1320,11 +1323,17 @@ func (s *schemaFetcher) buildFunction(ctx context.Context, rawFunction queries.G
 		return Function{}, fmt.Errorf("fetchDependsOnFunctions(%s): %w", rawFunction.Oid, err)
 	}
 
+	tableDependencies, err := parseJSONTableDependencies(rawFunction.TableDependencies)
+	if err != nil {
+		return Function{}, fmt.Errorf("parsing table dependencies JSON: %w", err)
+	}
+
 	return Function{
 		SchemaQualifiedName: buildProcName(rawFunction.FuncName, rawFunction.FuncIdentityArguments, rawFunction.FuncSchemaName),
 		FunctionDef:         rawFunction.FuncDef,
 		Language:            rawFunction.FuncLang,
 		DependsOnFunctions:  dependsOnFunctions,
+		TableDependencies:   tableDependencies,
 	}, nil
 }
 

--- a/pkg/diff/function_sql_vertex_generator.go
+++ b/pkg/diff/function_sql_vertex_generator.go
@@ -87,12 +87,23 @@ func (f *functionSQLVertexGenerator) GetAddAlterDependencies(newFunction, oldFun
 		deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).after(buildFunctionVertexId(depFunction, diffTypeAddAlter)))
 	}
 
+	// Add/alter the function after the table it depends on has been added/altered.
+	for _, t := range newFunction.TableDependencies {
+		deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).after(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+	}
+
 	if !cmp.Equal(oldFunction, schema.Function{}) {
 		// If the function is being altered:
 		// If the old version of the function calls other functions that are being deleted come, those deletions
 		// must come after the function is altered, so it is no longer dependent on those dropped functions
 		for _, depFunction := range oldFunction.DependsOnFunctions {
 			deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).before(buildFunctionVertexId(depFunction, diffTypeDelete)))
+		}
+
+		// Alter the function before the table it used to depend on has been altered or deleted.
+		for _, t := range oldFunction.TableDependencies {
+			deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+			deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeDelete)))
 		}
 	}
 
@@ -103,6 +114,10 @@ func (f *functionSQLVertexGenerator) GetDeleteDependencies(function schema.Funct
 	var deps []dependency
 	for _, depFunction := range function.DependsOnFunctions {
 		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeDelete)).before(buildFunctionVertexId(depFunction, diffTypeDelete)))
+	}
+	for _, t := range function.TableDependencies {
+		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeDelete)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeDelete)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeDelete)))
 	}
 	return deps, nil
 }


### PR DESCRIPTION
### Description

Functions and procedures can use tables and views as composite types for parameter and return types. Those dependencies must be accounted for to avoid out of order errors in diffs.

Resolves #248

### Motivation

I'm building a project which uses table as function parameter type and couldn't get it working without these changes.

### Testing

Test cases are still missing which is why this PR is marked as draft. I'll add tests soon. I'd be happy to take feedback even before writing tests.