### PR TITLE
Fix: recreate dependent views when altering column type           

### DIFF
--- a/internal/migration_acceptance_tests/view_cases_test.go
+++ b/internal/migration_acceptance_tests/view_cases_test.go
@@ -573,6 +573,73 @@ var viewAcceptanceTestCases = []acceptanceTestCase{
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Recreate view due to multiple dependent column type changes",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE plans(
+                id INT PRIMARY KEY,
+                annual_fee NUMERIC(10,2),
+                monthly_fee NUMERIC(10,2)
+            );
+
+            CREATE VIEW plans_view AS
+                SELECT id, annual_fee, monthly_fee
+                FROM plans;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE plans(
+                id INT PRIMARY KEY,
+                annual_fee INTEGER,
+                monthly_fee INTEGER
+            );
+
+            CREATE VIEW plans_view AS
+                SELECT id, annual_fee, monthly_fee
+                FROM plans;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "No view recreate when non-dependent column type changes",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar NUMERIC(10,2)
+            );
+
+            CREATE VIEW foobar_view AS
+                SELECT id, foo
+                FROM foobar;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                bar INTEGER
+            );
+
+            CREATE VIEW foobar_view AS
+                SELECT id, foo
+                FROM foobar;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
 		},
 	},
 }

--- a/internal/migration_acceptance_tests/view_cases_test.go
+++ b/internal/migration_acceptance_tests/view_cases_test.go
@@ -543,6 +543,38 @@ var viewAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 	},
+	{
+		name: "Recreate view due to dependent column type change",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                price NUMERIC(10,2)
+            );
+
+            CREATE VIEW foobar_view AS
+                SELECT id, foo, price
+                FROM foobar;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY,
+                foo VARCHAR(255),
+                price INTEGER
+            );
+
+            CREATE VIEW foobar_view AS
+                SELECT id, foo, price
+                FROM foobar;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
 }
 
 func TestViewTestCases(t *testing.T) {

--- a/pkg/diff/view_sql_generator.go
+++ b/pkg/diff/view_sql_generator.go
@@ -54,6 +54,17 @@ func buildViewDiff(
 				return viewDiff{}, true, nil
 			}
 		}
+		// Also recreate if a dependent column's type is being changed.
+		// ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE fails when a view depends
+		// on that column; the view must be dropped first and recreated after.
+		alteredColumnDiffsByName := buildDiffByNameMap[schema.Column, columnDiff](td.columnsDiff.alters)
+		for _, c := range t.Columns {
+			if colDiff, ok := alteredColumnDiffsByName[c]; ok {
+				if !strings.EqualFold(colDiff.old.Type, colDiff.new.Type) {
+					return viewDiff{}, true, nil
+				}
+			}
+		}
 	}
 
 	// Recreate if the view SQL generator cannot alter the view.


### PR DESCRIPTION
<!-- README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed -->

### Description
<!-- A clear and concise description of the purpose of this Pull Request. What is being changed? Include any relevant background for this change. -->

In `buildViewDiff`, after checking for deleted columns, also check if any dependent column's type is being altered. If so, mark the view for recreation (drop before, recreate after).

### Motivation
<!-- Why you made these changes. Link to any relevant issues. -->

When a table column's type is changed,  views that depend on it are not dropped first and recreated later, causing ALTER TABLE...ALTER COLUMN...SET DATA TYPE to fail:

`Error: 0A000: cannot alter type of a column used by a view or rule`

### Testing
<!-- Describe how you tested these changes -->
Added three acceptance test cases in `view_cases_test.go`:
  - Single column type change with dependent view
  - Multiple column type changes with dependent view
  - Non-dependent column type change (view should NOT be recreated)

  Without the fix, the first two tests fail with the Postgres error above.