### PR TITLE
fix: support DEFERRABLE attribute on unique constraints

### DIFF
--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -824,6 +824,144 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 			diff.MigrationHazardTypeIndexDropped,
 		},
 	},
+	{
+		name: "Add a deferrable unique constraint",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Add a deferrable initially deferred unique constraint",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE INITIALLY DEFERRED;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "No-op with deferrable unique constraint",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE;
+			`,
+		},
+	},
+	{
+		name: "No-op with deferrable initially deferred unique constraint",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE INITIALLY DEFERRED;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE INITIALLY DEFERRED;
+			`,
+		},
+	},
+	{
+		name: "Change unique constraint from not deferrable to deferrable",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE;
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
+		name: "Change unique constraint from deferrable to not deferrable",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank) DEFERRABLE;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT,
+                rank INT NOT NULL
+            );
+            ALTER TABLE foobar ADD CONSTRAINT foobar_id_rank_key UNIQUE (id, rank);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexDropped,
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
 }
 
 func TestIndexTestCases(t *testing.T) {

--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -164,7 +164,9 @@ SELECT
             pg_catalog.pg_attribute AS att
             ON att.attrelid = table_c.oid AND indkey_ord.attnum = att.attnum
     )::TEXT [] AS column_names,
-    COALESCE(con.conislocal, false) AS constraint_is_local
+    COALESCE(con.conislocal, false) AS constraint_is_local,
+    COALESCE(con.condeferrable, false) AS constraint_is_deferrable,
+    COALESCE(con.condeferred, false) AS constraint_is_initially_deferred
 FROM pg_catalog.pg_class AS c
 INNER JOIN pg_catalog.pg_index AS i ON (c.oid = i.indexrelid)
 INNER JOIN pg_catalog.pg_class AS table_c ON (i.indrelid = table_c.oid)

--- a/internal/queries/queries.sql.go
+++ b/internal/queries/queries.sql.go
@@ -488,7 +488,9 @@ SELECT
             pg_catalog.pg_attribute AS att
             ON att.attrelid = table_c.oid AND indkey_ord.attnum = att.attnum
     )::TEXT [] AS column_names,
-    COALESCE(con.conislocal, false) AS constraint_is_local
+    COALESCE(con.conislocal, false) AS constraint_is_local,
+    COALESCE(con.condeferrable, false) AS constraint_is_deferrable,
+    COALESCE(con.condeferred, false) AS constraint_is_initially_deferred
 FROM pg_catalog.pg_class AS c
 INNER JOIN pg_catalog.pg_index AS i ON (c.oid = i.indexrelid)
 INNER JOIN pg_catalog.pg_class AS table_c ON (i.indrelid = table_c.oid)
@@ -538,7 +540,9 @@ type GetIndexesRow struct {
 	ParentIndexName       string
 	ParentIndexSchemaName string
 	ColumnNames           []string
-	ConstraintIsLocal     bool
+	ConstraintIsLocal              bool
+	ConstraintIsDeferrable         bool
+	ConstraintIsInitiallyDeferred  bool
 }
 
 func (q *Queries) GetIndexes(ctx context.Context) ([]GetIndexesRow, error) {
@@ -567,6 +571,8 @@ func (q *Queries) GetIndexes(ctx context.Context) ([]GetIndexesRow, error) {
 			&i.ParentIndexSchemaName,
 			pq.Array(&i.ColumnNames),
 			&i.ConstraintIsLocal,
+			&i.ConstraintIsDeferrable,
+			&i.ConstraintIsInitiallyDeferred,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -347,6 +347,8 @@ type (
 		EscapedConstraintName string
 		ConstraintDef         string
 		IsLocal               bool
+		IsDeferrable          bool
+		IsInitiallyDeferred   bool
 	}
 
 	Index struct {
@@ -1165,6 +1167,8 @@ func (s *schemaFetcher) buildIndex(rawIndex queries.GetIndexesRow) Index {
 			EscapedConstraintName: EscapeIdentifier(rawIndex.ConstraintName),
 			ConstraintDef:         rawIndex.ConstraintDef,
 			IsLocal:               rawIndex.ConstraintIsLocal,
+			IsDeferrable:          rawIndex.ConstraintIsDeferrable,
+			IsInitiallyDeferred:   rawIndex.ConstraintIsInitiallyDeferred,
 		}
 	}
 

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -1927,11 +1927,19 @@ func (isg *indexSQLVertexGenerator) addIndexConstraint(index schema.Index) (Stat
 	if err != nil {
 		return Statement{}, fmt.Errorf("getting constraint type as SQL: %w", err)
 	}
+	ddl := fmt.Sprintf("%s %s USING INDEX %s",
+		addConstraintPrefix(index.OwningRelName, index.Constraint.EscapedConstraintName),
+		sqlConstraintType,
+		index.GetSchemaQualifiedName().EscapedName)
+	if index.Constraint.IsDeferrable {
+		if index.Constraint.IsInitiallyDeferred {
+			ddl += " DEFERRABLE INITIALLY DEFERRED"
+		} else {
+			ddl += " DEFERRABLE INITIALLY IMMEDIATE"
+		}
+	}
 	return Statement{
-		DDL: fmt.Sprintf("%s %s USING INDEX %s",
-			addConstraintPrefix(index.OwningRelName, index.Constraint.EscapedConstraintName),
-			sqlConstraintType,
-			index.GetSchemaQualifiedName().EscapedName),
+		DDL:         ddl,
 		Timeout:     statementTimeoutDefault,
 		LockTimeout: lockTimeoutDefault,
 	}, nil


### PR DESCRIPTION
Read `condeferrable` and `condeferred` from `pg_constraint` during schema introspection. Include deferrable state in constraint comparison and DDL generation.

Previously, deferrable unique constraints always produced a spurious diff because the tool didn't track the deferrable attribute. When recreating the constraint via `ADD CONSTRAINT ... UNIQUE USING INDEX`, the `DEFERRABLE` / `INITIALLY DEFERRED` clause was omitted, so the regenerated schema never matched the original.

**Changes:**
- `queries.sql` / `queries.sql.go`: fetch `condeferrable` and `condeferred` from `pg_constraint` in the GetIndexes query
- `schema.go`: add `IsDeferrable` and `IsInitiallyDeferred` fields to `IndexConstraint`
- `sql_generator.go`: append `DEFERRABLE INITIALLY DEFERRED` or `DEFERRABLE INITIALLY IMMEDIATE` to the `ADD CONSTRAINT ... USING INDEX` DDL when applicable
- `index_cases_test.go`: acceptance tests for adding, no-op, and changing deferrable unique constraints

Closes #273