### PR TITLE
Add --skip-privileges flag to skip table privilege diffing

### DIFF
--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -117,6 +117,7 @@ type (
 		dataPackNewTables     bool
 		disablePlanValidation bool
 		noConcurrentIndexOps  bool
+		skipPrivileges        bool
 
 		statementTimeoutModifiers []string
 		lockTimeoutModifiers      []string
@@ -227,6 +228,8 @@ func createPlanOptionsFlags(cmd *cobra.Command) *planOptionsFlags {
 		"database with an identical schema to the original, asserting that the generated plan actually migrates the schema to the desired target.")
 	cmd.Flags().BoolVar(&flags.noConcurrentIndexOps, "no-concurrent-index-ops", false, "If set, will disable the use of CONCURRENTLY in CREATE INDEX and DROP INDEX statements. "+
 		"This may result in longer lock times and potential downtime during migrations.")
+	cmd.Flags().BoolVar(&flags.skipPrivileges, "skip-privileges", false, "If set, will skip diffing of table privileges (GRANT/REVOKE). "+
+		"This is useful when privileges on partitioned tables cause plan generation to fail.")
 
 	timeoutModifierFlagVar(cmd, &flags.statementTimeoutModifiers, "statement", "t")
 	timeoutModifierFlagVar(cmd, &flags.lockTimeoutModifiers, "lock", "l")
@@ -328,6 +331,9 @@ func parsePlanOptions(p planOptionsFlags) (planOptions, error) {
 	}
 	if p.noConcurrentIndexOps {
 		opts = append(opts, diff.WithNoConcurrentIndexOps())
+	}
+	if p.skipPrivileges {
+		opts = append(opts, diff.WithSkipTablePrivileges())
 	}
 
 	var statementTimeoutModifiers []timeoutModifier

--- a/pkg/diff/plan_generator.go
+++ b/pkg/diff/plan_generator.go
@@ -36,6 +36,7 @@ type (
 		getSchemaOpts           []schema.GetSchemaOpt
 		randReader              io.Reader
 		noConcurrentIndexOps    bool
+		skipTablePrivileges     bool
 	}
 
 	PlanOpt func(opts *planOptions)
@@ -113,6 +114,16 @@ func WithNoConcurrentIndexOps() PlanOpt {
 	}
 }
 
+// WithSkipTablePrivileges configures plan generation to ignore table privilege differences.
+// This is useful when privileges on partitioned tables cause plan generation to fail with
+// "privileges on partitions: not implemented", or when privilege changes should not be
+// included in the migration plan.
+func WithSkipTablePrivileges() PlanOpt {
+	return func(opts *planOptions) {
+		opts.skipTablePrivileges = true
+	}
+}
+
 // Generate generates a migration plan to migrate the database to the target schema
 //
 // Parameters:
@@ -151,6 +162,11 @@ func Generate(
 	})
 	if err != nil {
 		return Plan{}, fmt.Errorf("getting new schema: %w", err)
+	}
+
+	if planOptions.skipTablePrivileges {
+		currentSchema = clearTablePrivileges(currentSchema)
+		newSchema = clearTablePrivileges(newSchema)
 	}
 
 	statements, err := generateMigrationStatements(currentSchema, newSchema, planOptions)


### PR DESCRIPTION
## Summary

Adds a `WithSkipTablePrivileges()` plan option and corresponding `--skip-privileges` CLI flag that strips table privileges from both the source and target schemas before diffing. This allows plan generation to succeed when partitioned tables have privileges, which otherwise fails with:

```
privileges on partitions: not implemented
```

## Motivation

After #264 introduced table privilege support, databases with partitioned tables that have privileges assigned (e.g., via `GRANT`) cannot generate migration plans. The privilege diff logic does not yet support partitions, so any privilege present on a partition causes plan generation to fail.

This flag provides a workaround: users who don't need privilege diffing can skip it entirely, unblocking plan generation for schemas with partitioned tables.

Fixes #269

## Changes

- **`pkg/diff/plan_generator.go`**: Added `skipTablePrivileges` field to `planOptions` and `WithSkipTablePrivileges()` exported option function. When enabled, calls the existing `clearTablePrivileges()` helper on both schemas before generating migration statements.
- **`cmd/pg-schema-diff/plan_cmd.go`**: Added `--skip-privileges` boolean CLI flag wired to the new plan option.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `--help` output shows the new flag with description
- The implementation reuses the existing `clearTablePrivileges()` function (already used in plan validation) so the privilege-stripping behavior is well-established