### PR TITLE
fix: order SQL functions after relation creation

### DIFF
--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -73,6 +73,20 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		},
 	},
 	{
+		name:         "Create sql function after table referenced by body",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA app;
+			CREATE TABLE app.dead_letter(id int);
+			CREATE FUNCTION app.record_dead_letter()
+			RETURNS void
+			LANGUAGE sql
+			AS $$ INSERT INTO app.dead_letter(id) VALUES (1) $$;
+			`,
+		},
+	},
+	{
 		name:         "Create functions with quoted names (with conflicting names)",
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{

--- a/pkg/diff/function_sql_vertex_generator.go
+++ b/pkg/diff/function_sql_vertex_generator.go
@@ -11,11 +11,13 @@ type functionSQLVertexGenerator struct {
 	// functionsInNewSchemaByName is a map of function name to functions in the new schema.
 	// These functions are not necessarily new
 	functionsInNewSchemaByName map[string]schema.Function
+	newSchema                  schema.Schema
 }
 
-func newFunctionSqlVertexGenerator(functionsInNewSchemaByName map[string]schema.Function) sqlVertexGenerator[schema.Function, functionDiff] {
+func newFunctionSqlVertexGenerator(functionsInNewSchemaByName map[string]schema.Function, newSchema schema.Schema) sqlVertexGenerator[schema.Function, functionDiff] {
 	return legacyToNewSqlVertexGenerator[schema.Function, functionDiff](&functionSQLVertexGenerator{
 		functionsInNewSchemaByName: functionsInNewSchemaByName,
+		newSchema:                  newSchema,
 	})
 }
 
@@ -86,6 +88,9 @@ func (f *functionSQLVertexGenerator) GetAddAlterDependencies(newFunction, oldFun
 	for _, depFunction := range newFunction.DependsOnFunctions {
 		deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).after(buildFunctionVertexId(depFunction, diffTypeAddAlter)))
 	}
+	if canFunctionDependenciesBeTracked(newFunction) {
+		deps = append(deps, f.getRelationAddAlterDependencies(newFunction)...)
+	}
 
 	if !cmp.Equal(oldFunction, schema.Function{}) {
 		// If the function is being altered:
@@ -105,4 +110,21 @@ func (f *functionSQLVertexGenerator) GetDeleteDependencies(function schema.Funct
 		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeDelete)).before(buildFunctionVertexId(depFunction, diffTypeDelete)))
 	}
 	return deps, nil
+}
+
+func (f *functionSQLVertexGenerator) getRelationAddAlterDependencies(function schema.Function) []dependency {
+	var deps []dependency
+
+	// SQL functions validate table and sequence references in their body at
+	// CREATE time, but PostgreSQL does not expose those body relation references
+	// as pg_proc -> pg_class dependencies in pg_depend. Keep this deliberately
+	// broad, mirroring the procedure generator's best-effort relation ordering.
+	for _, table := range f.newSchema.Tables {
+		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeAddAlter)).after(buildTableVertexId(table.SchemaQualifiedName, diffTypeAddAlter)))
+	}
+	for _, seq := range f.newSchema.Sequences {
+		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeAddAlter)).after(buildSequenceVertexId(seq.SchemaQualifiedName, diffTypeAddAlter)))
+	}
+
+	return deps
 }

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -653,7 +653,7 @@ func (s schemaSQLGenerator) Alter(diff schemaDiff) ([]Statement, error) {
 	}
 	partialGraph = concatPartialGraphs(partialGraph, sequenceOwnershipsPartialGraph)
 
-	functionGenerator := newFunctionSqlVertexGenerator(functionsInNewSchemaByName)
+	functionGenerator := newFunctionSqlVertexGenerator(functionsInNewSchemaByName, diff.new)
 	functionsPartialGraph, err := generatePartialGraph(functionGenerator, diff.functionDiffs)
 	if err != nil {
 		return nil, fmt.Errorf("resolving function diff: %w", err)


### PR DESCRIPTION
## Summary

- order SQL-language function create/replace vertices after target-schema tables and sequences
- add an acceptance regression for a SQL function whose body inserts into a table created in the same migration

## Why

PostgreSQL validates SQL function bodies at CREATE FUNCTION time and errors if referenced relations do not exist, but it does not persist those body relation references as pg_proc to pg_class rows in pg_depend. This makes exact relation dependencies unavailable to the planner; the fix mirrors the existing broad procedure relation ordering, scoped only to SQL functions to avoid PL/pgSQL trigger cycles.

## Test

PATH="/Applications/Postgres.app/Contents/Versions/17/bin:$PATH" go test ./pkg/diff -count=1
PATH="/Applications/Postgres.app/Contents/Versions/17/bin:$PATH" go test ./internal/migration_acceptance_tests -count=1
