### PR TITLE
Add function, view, and materialized view dependency ordering

### DIFF
--- a/cmd/pg-schema-diff/plan_cmd.go
+++ b/cmd/pg-schema-diff/plan_cmd.go
@@ -117,6 +117,7 @@ type (
 		dataPackNewTables     bool
 		disablePlanValidation bool
 		noConcurrentIndexOps  bool
+		skipPrivileges        bool
 
 		statementTimeoutModifiers []string
 		lockTimeoutModifiers      []string
@@ -227,6 +228,8 @@ func createPlanOptionsFlags(cmd *cobra.Command) *planOptionsFlags {
 		"database with an identical schema to the original, asserting that the generated plan actually migrates the schema to the desired target.")
 	cmd.Flags().BoolVar(&flags.noConcurrentIndexOps, "no-concurrent-index-ops", false, "If set, will disable the use of CONCURRENTLY in CREATE INDEX and DROP INDEX statements. "+
 		"This may result in longer lock times and potential downtime during migrations.")
+	cmd.Flags().BoolVar(&flags.skipPrivileges, "skip-privileges", false, "If set, will skip diffing of table privileges (GRANT/REVOKE). "+
+		"This is useful when privileges on partitioned tables cause plan generation to fail.")
 
 	timeoutModifierFlagVar(cmd, &flags.statementTimeoutModifiers, "statement", "t")
 	timeoutModifierFlagVar(cmd, &flags.lockTimeoutModifiers, "lock", "l")
@@ -328,6 +331,9 @@ func parsePlanOptions(p planOptionsFlags) (planOptions, error) {
 	}
 	if p.noConcurrentIndexOps {
 		opts = append(opts, diff.WithNoConcurrentIndexOps())
+	}
+	if p.skipPrivileges {
+		opts = append(opts, diff.WithSkipTablePrivileges())
 	}
 
 	var statementTimeoutModifiers []timeoutModifier

--- a/internal/migration_acceptance_tests/function_body_dep_cases_test.go
+++ b/internal/migration_acceptance_tests/function_body_dep_cases_test.go
@@ -1,0 +1,191 @@
+package migration_acceptance_tests
+
+import (
+	"testing"
+
+	"github.com/stripe/pg-schema-diff/pkg/diff"
+)
+
+// Tests for body-text dependency detection (patch 02).
+// These verify that pg-schema-diff correctly orders functions after the
+// tables/views they reference in their bodies via FROM, JOIN, %ROWTYPE, [].
+var functionBodyDepTestCases = []acceptanceTestCase{
+	{
+		name: "qualified FROM",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.orders(id INT PRIMARY KEY, total NUMERIC);
+			CREATE FUNCTION public.sum_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT SUM(total) FROM public.orders; $$;
+		`},
+	},
+	{
+		name: "unqualified FROM",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, total NUMERIC);
+			CREATE FUNCTION sum_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT SUM(total) FROM orders; $$;
+		`},
+	},
+	{
+		name: "qualified JOIN",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.customers(id INT PRIMARY KEY, name TEXT);
+			CREATE TABLE public.orders(id INT PRIMARY KEY, customer_id INT, total NUMERIC);
+			CREATE FUNCTION public.customer_totals() RETURNS TABLE(name TEXT, total NUMERIC) LANGUAGE sql AS
+			$$ SELECT c.name, SUM(o.total) FROM public.orders o JOIN public.customers c ON c.id = o.customer_id GROUP BY c.name; $$;
+		`},
+	},
+	{
+		name: "unqualified JOIN",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE customers(id INT PRIMARY KEY, name TEXT);
+			CREATE TABLE orders(id INT PRIMARY KEY, customer_id INT, total NUMERIC);
+			CREATE FUNCTION customer_totals() RETURNS TABLE(name TEXT, total NUMERIC) LANGUAGE sql AS
+			$$ SELECT c.name, SUM(o.total) FROM orders o JOIN customers c ON c.id = o.customer_id GROUP BY c.name; $$;
+		`},
+	},
+	{
+		name: "qualified %ROWTYPE",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.events(id INT PRIMARY KEY, event_type TEXT);
+			CREATE FUNCTION public.process_events() RETURNS void LANGUAGE plpgsql AS $$
+			DECLARE r public.events%ROWTYPE;
+			BEGIN
+				FOR r IN SELECT * FROM public.events LOOP
+					RAISE NOTICE '%', r.event_type;
+				END LOOP;
+			END; $$;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "unqualified %ROWTYPE",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE events(id INT PRIMARY KEY, event_type TEXT);
+			CREATE FUNCTION process_events() RETURNS void LANGUAGE plpgsql AS $$
+			DECLARE r events%ROWTYPE;
+			BEGIN
+				FOR r IN SELECT * FROM events LOOP
+					RAISE NOTICE '%', r.event_type;
+				END LOOP;
+			END; $$;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "qualified array of composite",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.items(id INT PRIMARY KEY, name TEXT, price NUMERIC);
+			CREATE FUNCTION public.batch_items() RETURNS void LANGUAGE plpgsql AS $$
+			DECLARE batch public.items[];
+			BEGIN
+				SELECT array_agg(i) INTO batch FROM public.items i;
+			END; $$;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "unqualified array of composite",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, name TEXT, price NUMERIC);
+			CREATE FUNCTION batch_items() RETURNS void LANGUAGE plpgsql AS $$
+			DECLARE batch items[];
+			BEGIN
+				SELECT array_agg(i) INTO batch FROM items i;
+			END; $$;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
+	},
+	{
+		name: "FROM in subquery",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.products(id INT PRIMARY KEY, category TEXT, price NUMERIC);
+			CREATE FUNCTION public.expensive_categories() RETURNS SETOF TEXT LANGUAGE sql AS
+			$$ SELECT DISTINCT category FROM public.products WHERE price > (SELECT AVG(price) FROM public.products); $$;
+		`},
+	},
+	{
+		name: "CTE referencing table",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.sales(id INT PRIMARY KEY, region TEXT, amount NUMERIC);
+			CREATE FUNCTION public.top_regions() RETURNS TABLE(region TEXT, total NUMERIC) LANGUAGE sql AS
+			$$ WITH regional AS (SELECT region, SUM(amount) as total FROM public.sales GROUP BY region)
+			   SELECT region, total FROM regional ORDER BY total DESC LIMIT 5; $$;
+		`},
+	},
+	{
+		name: "function referencing view (qualified FROM)",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.logs(id INT PRIMARY KEY, level TEXT, msg TEXT, created_at TIMESTAMPTZ DEFAULT now());
+			CREATE VIEW public.error_logs AS SELECT id, msg, created_at FROM public.logs WHERE level = 'ERROR';
+			CREATE FUNCTION public.recent_errors() RETURNS BIGINT LANGUAGE sql AS
+			$$ SELECT COUNT(*) FROM public.error_logs WHERE created_at > now() - interval '1 hour'; $$;
+		`},
+	},
+	{
+		name: "function referencing view (unqualified FROM)",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE logs(id INT PRIMARY KEY, level TEXT, msg TEXT, created_at TIMESTAMPTZ DEFAULT now());
+			CREATE VIEW error_logs AS SELECT id, msg, created_at FROM logs WHERE level = 'ERROR';
+			CREATE FUNCTION recent_errors() RETURNS BIGINT LANGUAGE sql AS
+			$$ SELECT COUNT(*) FROM error_logs WHERE created_at > now() - interval '1 hour'; $$;
+		`},
+	},
+}
+
+func TestFunctionBodyDepTestCases(t *testing.T) {
+	runTestCases(t, functionBodyDepTestCases)
+}
+
+var functionBodyDepGapTestCases = []acceptanceTestCase{
+	{
+		name: "Function with LEFT JOIN reference",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.a(id INT PRIMARY KEY, val TEXT);
+			CREATE TABLE public.b(id INT PRIMARY KEY, a_id INT, extra TEXT);
+			CREATE FUNCTION public.joined() RETURNS TABLE(val TEXT, extra TEXT) LANGUAGE sql AS
+			$$ SELECT a.val, b.extra FROM public.a LEFT JOIN public.b ON b.a_id = a.id; $$;
+		`},
+	},
+	{
+		name: "Function with multiple FROM tables",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE public.t1(id INT PRIMARY KEY);
+			CREATE TABLE public.t2(id INT PRIMARY KEY);
+			CREATE TABLE public.t3(id INT PRIMARY KEY);
+			CREATE FUNCTION public.multi() RETURNS BIGINT LANGUAGE sql AS
+			$$ SELECT COUNT(*) FROM public.t1, public.t2, public.t3; $$;
+		`},
+		// Gap: comma-separated FROM list only detects first table.
+		// t2 and t3 after commas are not matched by the regex.
+		expectedPlanErrorContains: "does not exist",
+	},
+	{
+		name: "Function with unqualified LEFT JOIN",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE a(id INT PRIMARY KEY, val TEXT);
+			CREATE TABLE b(id INT PRIMARY KEY, a_id INT, extra TEXT);
+			CREATE FUNCTION joined() RETURNS TABLE(val TEXT, extra TEXT) LANGUAGE sql AS
+			$$ SELECT a.val, b.extra FROM a LEFT JOIN b ON b.a_id = a.id; $$;
+		`},
+	},
+}
+
+func TestFunctionBodyDepGapTestCases(t *testing.T) {
+	runTestCases(t, functionBodyDepGapTestCases)
+}

--- a/internal/migration_acceptance_tests/materialized_view_cases_test.go
+++ b/internal/migration_acceptance_tests/materialized_view_cases_test.go
@@ -614,3 +614,162 @@ var materializedViewAcceptanceTestCases = []acceptanceTestCase{
 func TestMaterializedViewTestCases(t *testing.T) {
 	runTestCases(t, materializedViewAcceptanceTestCases)
 }
+
+var materializedViewDepTestCases = []acceptanceTestCase{
+	{
+		name: "No-op: materialized view depends on a view (identical schemas)",
+		oldSchemaDDL: []string{`
+			CREATE TABLE events(id INT PRIMARY KEY, event_type TEXT, created_at TIMESTAMPTZ DEFAULT now());
+			CREATE VIEW recent_events AS SELECT id, event_type FROM events WHERE created_at > now() - interval '7 days';
+			CREATE MATERIALIZED VIEW event_stats AS SELECT event_type, COUNT(*) as cnt FROM recent_events GROUP BY event_type;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE events(id INT PRIMARY KEY, event_type TEXT, created_at TIMESTAMPTZ DEFAULT now());
+			CREATE VIEW recent_events AS SELECT id, event_type FROM events WHERE created_at > now() - interval '7 days';
+			CREATE MATERIALIZED VIEW event_stats AS SELECT event_type, COUNT(*) as cnt FROM recent_events GROUP BY event_type;
+		`},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Recreate matview when dependent view is recreated due to table change",
+		oldSchemaDDL: []string{`
+			CREATE TABLE table_c(c1 INT PRIMARY KEY, c2_old TEXT);
+			CREATE VIEW view_b AS SELECT c1, c2_old FROM table_c;
+			CREATE MATERIALIZED VIEW matview_a AS SELECT c1 FROM view_b;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE table_c(c1 INT PRIMARY KEY, c2_new TEXT);
+			CREATE VIEW view_b AS SELECT c1, c2_new FROM table_c;
+			CREATE MATERIALIZED VIEW matview_a AS SELECT c1 FROM view_b;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Add matview that depends on existing view",
+		oldSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+			CREATE MATERIALIZED VIEW active_count AS SELECT COUNT(*) as total FROM active_items;
+		`},
+	},
+	{
+		name: "Drop matview that depends on view",
+		oldSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+			CREATE MATERIALIZED VIEW active_count AS SELECT COUNT(*) as total FROM active_items;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+		`},
+	},
+	{
+		name: "Matview depends on function - no-op identical schemas",
+		oldSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION double_val(val NUMERIC) RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT val * 2; $$;
+			CREATE MATERIALIZED VIEW order_doubles AS SELECT id, double_val(amount) as doubled FROM orders;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION double_val(val NUMERIC) RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT val * 2; $$;
+			CREATE MATERIALIZED VIEW order_doubles AS SELECT id, double_val(amount) as doubled FROM orders;
+		`},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "Recreate matview when dependent function signature changes",
+		oldSchemaDDL: []string{
+			`CREATE TABLE transactions(id INT PRIMARY KEY, amount NUMERIC);`,
+			`CREATE FUNCTION calc_fee(val NUMERIC) RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT val * 0.1; $$;
+			CREATE MATERIALIZED VIEW transaction_fees AS SELECT id, calc_fee(amount) as fee FROM transactions;`,
+		},
+		newSchemaDDL: []string{
+			`CREATE TABLE transactions(id INT PRIMARY KEY, amount NUMERIC);`,
+			`CREATE FUNCTION calc_fee(val NUMERIC) RETURNS TEXT LANGUAGE sql AS
+			$$ SELECT (val * 0.1)::TEXT; $$;
+			CREATE MATERIALIZED VIEW transaction_fees AS SELECT id, calc_fee(amount) as fee FROM transactions;`,
+		},
+		// Upstream limitation: pg-schema-diff doesn't handle function return type
+		// changes as drop+create.
+		expectedPlanErrorContains: "cannot change return type of existing function",
+	},
+}
+
+func TestMaterializedViewDepTestCases(t *testing.T) {
+	runTestCases(t, materializedViewDepTestCases)
+}
+
+// Matview function dependency ordering tests — from-scratch creation.
+var materializedViewFuncDepTestCases = []acceptanceTestCase{
+	{
+		name: "From scratch: matview calls a function",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION total_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT COALESCE(SUM(amount), 0) FROM public.orders; $$;
+			CREATE MATERIALIZED VIEW order_summary AS SELECT total_orders() as total;
+		`},
+	},
+}
+
+func TestMaterializedViewFuncDepTestCases(t *testing.T) {
+	runTestCases(t, materializedViewFuncDepTestCases)
+}
+
+var materializedViewGapTestCases = []acceptanceTestCase{
+	{
+		name: "From scratch: matview depends on view that calls a function",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, val NUMERIC);
+			CREATE FUNCTION double_val(v NUMERIC) RETURNS NUMERIC LANGUAGE sql AS $$ SELECT v * 2; $$;
+			CREATE VIEW v AS SELECT id, double_val(val) as doubled FROM t;
+			CREATE MATERIALIZED VIEW mv AS SELECT * FROM v;
+		`},
+	},
+	{
+		name: "From scratch: matview depends on another matview",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, category TEXT, amount NUMERIC);
+			CREATE MATERIALIZED VIEW mv_base AS SELECT category, SUM(amount) as total FROM t GROUP BY category;
+			CREATE MATERIALIZED VIEW mv_top AS SELECT category FROM mv_base WHERE total > 1000;
+		`},
+		// vertex ID namespace, not table vertex IDs).
+	},
+	{
+		name: "Recreate matview when dependent matview is recreated",
+		oldSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, old_col TEXT, amount NUMERIC);
+			CREATE MATERIALIZED VIEW mv_base AS SELECT old_col, SUM(amount) as total FROM t GROUP BY old_col;
+			CREATE MATERIALIZED VIEW mv_top AS SELECT old_col FROM mv_base WHERE total > 0;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, new_col TEXT, amount NUMERIC);
+			CREATE MATERIALIZED VIEW mv_base AS SELECT new_col, SUM(amount) as total FROM t GROUP BY new_col;
+			CREATE MATERIALIZED VIEW mv_top AS SELECT new_col FROM mv_base WHERE total > 0;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
+		expectedDBSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, amount NUMERIC, new_col TEXT);
+			CREATE MATERIALIZED VIEW mv_base AS SELECT new_col, SUM(amount) as total FROM t GROUP BY new_col WITH NO DATA;
+			CREATE MATERIALIZED VIEW mv_top AS SELECT new_col FROM mv_base WHERE total > 0 WITH NO DATA;
+		`},
+	},
+}
+
+func TestMaterializedViewGapTestCases(t *testing.T) {
+	runTestCases(t, materializedViewGapTestCases)
+}

--- a/internal/migration_acceptance_tests/view_cases_test.go
+++ b/internal/migration_acceptance_tests/view_cases_test.go
@@ -548,3 +548,363 @@ var viewAcceptanceTestCases = []acceptanceTestCase{
 func TestViewTestCases(t *testing.T) {
 	runTestCases(t, viewAcceptanceTestCases)
 }
+
+// Test cases for view-depends-on-view and view-depends-on-function scenarios.
+// These reproduce the failures described in darryls-ai-dev-setup issue #5.
+var viewDependencyTestCases = []acceptanceTestCase{
+	{
+		name: "No-op: view depends on another view (identical schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE base_table(
+				id INT PRIMARY KEY,
+				name TEXT NOT NULL,
+				active BOOLEAN DEFAULT true
+			);
+
+			CREATE VIEW active_items AS
+				SELECT id, name FROM base_table WHERE active = true;
+
+			CREATE VIEW active_item_count AS
+				SELECT COUNT(*) as total FROM active_items;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE base_table(
+				id INT PRIMARY KEY,
+				name TEXT NOT NULL,
+				active BOOLEAN DEFAULT true
+			);
+
+			CREATE VIEW active_items AS
+				SELECT id, name FROM base_table WHERE active = true;
+
+			CREATE VIEW active_item_count AS
+				SELECT COUNT(*) as total FROM active_items;
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "No-op: view calls a function (identical schemas)",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE orders(
+				id INT PRIMARY KEY,
+				amount NUMERIC NOT NULL
+			);
+
+			CREATE FUNCTION double_amount(val NUMERIC) RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT val * 2; $$;
+
+			CREATE VIEW doubled_orders AS
+				SELECT id, double_amount(amount) as doubled FROM orders;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE orders(
+				id INT PRIMARY KEY,
+				amount NUMERIC NOT NULL
+			);
+
+			CREATE FUNCTION double_amount(val NUMERIC) RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT val * 2; $$;
+
+			CREATE VIEW doubled_orders AS
+				SELECT id, double_amount(amount) as doubled FROM orders;
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+	{
+		name: "No-op: cross-schema view depends on view",
+		oldSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_a;
+			CREATE SCHEMA schema_b;
+
+			CREATE TABLE schema_a.items(
+				id INT PRIMARY KEY,
+				status TEXT NOT NULL
+			);
+
+			CREATE VIEW schema_a.pending_items AS
+				SELECT id, status FROM schema_a.items WHERE status = 'pending';
+
+			CREATE VIEW schema_b.pending_count AS
+				SELECT COUNT(*) as total FROM schema_a.pending_items;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE SCHEMA schema_a;
+			CREATE SCHEMA schema_b;
+
+			CREATE TABLE schema_a.items(
+				id INT PRIMARY KEY,
+				status TEXT NOT NULL
+			);
+
+			CREATE VIEW schema_a.pending_items AS
+				SELECT id, status FROM schema_a.items WHERE status = 'pending';
+
+			CREATE VIEW schema_b.pending_count AS
+				SELECT COUNT(*) as total FROM schema_a.pending_items;
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+}
+
+func TestViewDependencyTestCases(t *testing.T) {
+	runTestCases(t, viewDependencyTestCases)
+}
+
+// Known issue: function→view ordering in from-scratch apply (issue #1).
+// The function body references a view via FROM, but the apply path orders
+// the function before the view. This is a plan validation failure, not a
+// diff failure. Tracked separately from the view-depends-on-view fix.
+var viewFunctionOrderingTestCases = []acceptanceTestCase{
+	{
+		name: "No-op: function references view via FROM (identical schemas) [KNOWN ISSUE #1]",
+		oldSchemaDDL: []string{
+			`
+			CREATE TABLE events(
+				id INT PRIMARY KEY,
+				event_type TEXT NOT NULL,
+				created_at TIMESTAMPTZ DEFAULT now()
+			);
+
+			CREATE VIEW recent_events AS
+				SELECT id, event_type FROM events WHERE created_at > now() - interval '1 day';
+
+			CREATE FUNCTION count_recent() RETURNS BIGINT LANGUAGE sql AS
+			$$ SELECT COUNT(*) FROM recent_events; $$;
+
+			CREATE VIEW event_summary AS
+				SELECT count_recent() as recent_count;
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+			CREATE TABLE events(
+				id INT PRIMARY KEY,
+				event_type TEXT NOT NULL,
+				created_at TIMESTAMPTZ DEFAULT now()
+			);
+
+			CREATE VIEW recent_events AS
+				SELECT id, event_type FROM events WHERE created_at > now() - interval '1 day';
+
+			CREATE FUNCTION count_recent() RETURNS BIGINT LANGUAGE sql AS
+			$$ SELECT COUNT(*) FROM recent_events; $$;
+
+			CREATE VIEW event_summary AS
+				SELECT count_recent() as recent_count;
+			`,
+		},
+		expectEmptyPlan: true,
+	},
+}
+
+func TestViewFunctionOrderingTestCases(t *testing.T) {
+	runTestCases(t, viewFunctionOrderingTestCases)
+}
+
+// Additional view dependency scenarios: adds, drops, and cross-object interactions.
+var viewDepAdditionalTestCases = []acceptanceTestCase{
+	{
+		name: "Add view that depends on existing view",
+		oldSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+			CREATE VIEW active_count AS SELECT COUNT(*) as total FROM active_items;
+		`},
+	},
+	{
+		name: "Add view that calls existing function",
+		oldSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION total_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT SUM(amount) FROM orders; $$;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION total_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT SUM(amount) FROM orders; $$;
+			CREATE VIEW order_summary AS SELECT total_orders() as total;
+		`},
+	},
+	{
+		name: "Drop view that depends on another view",
+		oldSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+			CREATE VIEW active_count AS SELECT COUNT(*) as total FROM active_items;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE items(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM items WHERE active = true;
+		`},
+	},
+	{
+		name: "Drop view that calls a function",
+		oldSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION total_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT SUM(amount) FROM orders; $$;
+			CREATE VIEW order_summary AS SELECT total_orders() as total;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION total_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT SUM(amount) FROM orders; $$;
+		`},
+	},
+	{
+		name: "Drop function while table dep persists",
+		oldSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION sum_orders() RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT SUM(amount) FROM public.orders; $$;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE orders(id INT PRIMARY KEY, amount NUMERIC);
+		`},
+	},
+	{
+		name: "Function dep changes (old table removed, new table added)",
+		oldSchemaDDL: []string{`
+			CREATE TABLE old_data(id INT PRIMARY KEY, val TEXT);
+			CREATE TABLE new_data(id INT PRIMARY KEY, val TEXT);
+			CREATE FUNCTION get_val() RETURNS TEXT LANGUAGE sql AS
+			$$ SELECT val FROM public.old_data LIMIT 1; $$;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE old_data(id INT PRIMARY KEY, val TEXT);
+			CREATE TABLE new_data(id INT PRIMARY KEY, val TEXT);
+			CREATE FUNCTION get_val() RETURNS TEXT LANGUAGE sql AS
+			$$ SELECT val FROM public.new_data LIMIT 1; $$;
+		`},
+	},
+	{
+		name: "Recreate view_a when view_b is recreated due to table column type change",
+		oldSchemaDDL: []string{`
+			CREATE TABLE table_c(c1 INT PRIMARY KEY, c2_old TEXT);
+			CREATE VIEW view_b AS SELECT c1, c2_old FROM table_c;
+			CREATE VIEW view_a AS SELECT c1 FROM view_b;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE table_c(c1 INT PRIMARY KEY, c2_new TEXT);
+			CREATE VIEW view_b AS SELECT c1, c2_new FROM table_c;
+			CREATE VIEW view_a AS SELECT c1 FROM view_b;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeDeletesData,
+		},
+	},
+	{
+		name: "Recreate view when dependent function signature changes",
+		oldSchemaDDL: []string{
+			`CREATE TABLE transactions(id INT PRIMARY KEY, amount NUMERIC);`,
+			`CREATE FUNCTION calc_fee(val NUMERIC) RETURNS NUMERIC LANGUAGE sql AS
+			$$ SELECT val * 0.1; $$;
+			CREATE VIEW transaction_fees AS SELECT id, calc_fee(amount) as fee FROM transactions;`,
+		},
+		newSchemaDDL: []string{
+			`CREATE TABLE transactions(id INT PRIMARY KEY, amount NUMERIC);`,
+			`CREATE FUNCTION calc_fee(val NUMERIC) RETURNS TEXT LANGUAGE sql AS
+			$$ SELECT (val * 0.1)::TEXT; $$;
+			CREATE VIEW transaction_fees AS SELECT id, calc_fee(amount) as fee FROM transactions;`,
+		},
+		// Upstream limitation: pg-schema-diff doesn't handle function return type
+		// changes as drop+create. It emits CREATE OR REPLACE which PG rejects.
+		expectedPlanErrorContains: "cannot change return type of existing function",
+	},
+}
+
+func TestViewDepAdditionalTestCases(t *testing.T) {
+	runTestCases(t, viewDepAdditionalTestCases)
+}
+
+var viewGapTestCases = []acceptanceTestCase{
+	{
+		name: "From scratch: chain of 3 views (a -> b -> c -> table)",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, val TEXT);
+			CREATE VIEW vc AS SELECT id, val FROM t;
+			CREATE VIEW vb AS SELECT id, val FROM vc;
+			CREATE VIEW va AS SELECT id FROM vb;
+		`},
+	},
+	{
+		name: "Recreate cascades through 3-level view chain",
+		oldSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, old_val TEXT);
+			CREATE VIEW vc AS SELECT id, old_val FROM t;
+			CREATE VIEW vb AS SELECT id, old_val FROM vc;
+			CREATE VIEW va AS SELECT id FROM vb;
+		`},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, new_val TEXT);
+			CREATE VIEW vc AS SELECT id, new_val FROM t;
+			CREATE VIEW vb AS SELECT id, new_val FROM vc;
+			CREATE VIEW va AS SELECT id FROM vb;
+		`},
+		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeDeletesData},
+	},
+	{
+		name: "From scratch: view depends on function that depends on another function",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION helper(v NUMERIC) RETURNS NUMERIC LANGUAGE sql AS $$ SELECT v * 2; $$;
+			CREATE FUNCTION calc(v NUMERIC) RETURNS NUMERIC LANGUAGE sql AS $$ SELECT public.helper(v) + 1; $$;
+			CREATE VIEW v AS SELECT id, calc(amount) as result FROM t;
+		`},
+		// Gap: pg_depend doesn't track function→function deps for SQL functions.
+		// Body-text regex only detects table/view refs, not function calls.
+		expectedPlanErrorContains: "function public.helper(numeric) does not exist",
+	},
+	{
+		name: "From scratch: two views depend on same function",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, amount NUMERIC);
+			CREATE FUNCTION fmt(v NUMERIC) RETURNS TEXT LANGUAGE sql AS $$ SELECT v::TEXT; $$;
+			CREATE VIEW v1 AS SELECT id, fmt(amount) as formatted FROM t;
+			CREATE VIEW v2 AS SELECT id, fmt(amount) as formatted FROM t WHERE amount > 0;
+		`},
+	},
+	{
+		name: "From scratch: view with cross-schema function dependency",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE SCHEMA lib;
+			CREATE TABLE public.t(id INT PRIMARY KEY, val NUMERIC);
+			CREATE FUNCTION lib.transform(v NUMERIC) RETURNS NUMERIC LANGUAGE sql AS $$ SELECT v * 100; $$;
+			CREATE VIEW public.v AS SELECT id, lib.transform(val) as transformed FROM public.t;
+		`},
+	},
+	{
+		name: "From scratch: view depends on function with unqualified FROM referencing view",
+		oldSchemaDDL: []string{``},
+		newSchemaDDL: []string{`
+			CREATE TABLE t(id INT PRIMARY KEY, active BOOLEAN DEFAULT true);
+			CREATE VIEW active_items AS SELECT id FROM t WHERE active;
+			CREATE FUNCTION count_active() RETURNS BIGINT LANGUAGE sql AS $$ SELECT COUNT(*) FROM active_items; $$;
+			CREATE VIEW summary AS SELECT count_active() as total;
+		`},
+	},
+}
+
+func TestViewGapTestCases(t *testing.T) {
+	runTestCases(t, viewGapTestCases)
+}

--- a/internal/pgengine/engine.go
+++ b/internal/pgengine/engine.go
@@ -51,6 +51,10 @@ type Engine struct {
 	process  *os.Process
 	dbPath   string
 	sockPath string
+
+	// external mode: connect to existing PG instance
+	connOpts ConnectionOptions
+	external bool
 }
 
 const (
@@ -68,14 +72,44 @@ var (
 	}
 )
 
-// StartEngine starts a postgres instance. This is useful for testing, where Postgres databases need to be spun up.
-// "postgres" must be on the system's PATH, and the binary must be located in a directory containing "initdb"
+// StartEngine starts a postgres instance or connects to an existing one.
+// If PGSD_ENGINE_DSN is set (e.g. "host=localhost port=5488 user=postgres password=odie dbname=postgres sslmode=disable"),
+// it connects to that instance instead of running initdb/pg_ctl.
+// Otherwise, "postgres" must be on the system's PATH, and the binary must be located in a directory containing "initdb".
 func StartEngine() (*Engine, error) {
+	if dsn := os.Getenv("PGSD_ENGINE_DSN"); dsn != "" {
+		return startExternalEngine(dsn)
+	}
 	postgresPath, err := exec.LookPath("postgres")
 	if err != nil {
 		return nil, errors.New("postgres executable not found in path")
 	}
 	return StartEngineUsingPgDir(path.Dir(postgresPath))
+}
+
+// startExternalEngine connects to an existing PG instance via DSN (key=value pairs).
+func startExternalEngine(dsn string) (*Engine, error) {
+	connOpts := parseConnOptsDSN(dsn)
+	e := &Engine{
+		superuser: connOpts[ConnectionOptionUser],
+		connOpts:  connOpts,
+		external:  true,
+	}
+	if err := e.waitTillServingTraffic(defaultMaxConnAttemptsAtStartup, defaultWaitBetweenStartupConnAttempt); err != nil {
+		return nil, fmt.Errorf("connecting to external PG: %w", err)
+	}
+	return e, nil
+}
+
+func parseConnOptsDSN(dsn string) ConnectionOptions {
+	opts := make(ConnectionOptions)
+	for _, pair := range strings.Fields(dsn) {
+		k, v, ok := strings.Cut(pair, "=")
+		if ok {
+			opts[ConnectionOption(k)] = v
+		}
+	}
+	return opts
 }
 
 func StartEngineUsingPgDir(pgDir string) (_ *Engine, retErr error) {
@@ -192,6 +226,9 @@ func (e *Engine) testIfInstanceServingTraffic() error {
 }
 
 func (e *Engine) GetPostgresDatabaseConnOpts() ConnectionOptions {
+	if e.external {
+		return e.connOpts
+	}
 	result := make(map[ConnectionOption]string)
 	result[ConnectionOptionDatabase] = "postgres"
 	result[ConnectionOptionHost] = e.sockPath
@@ -207,6 +244,9 @@ func (e *Engine) GetPostgresDatabaseDSN() string {
 }
 
 func (e *Engine) Close() error {
+	if e.external {
+		return nil
+	}
 	// Make best effort attempt to clean up everything
 	e.process.Signal(os.Interrupt)
 	e.process.Wait()

--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -266,7 +266,33 @@ SELECT
     pg_catalog.pg_get_function_identity_arguments(
         pg_proc.oid
     ) AS func_identity_arguments,
-    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def
+    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def,
+    (
+        -- Find composite types of a table or a view used by this function
+        SELECT
+            ARRAY_AGG(DISTINCT JSONB_BUILD_OBJECT(
+                'schema', depend_namespace.nspname::TEXT,
+                'name', depend_class.relname::TEXT,
+                'columns', ARRAY[]::TEXT[]
+            ))
+        FROM pg_catalog.pg_depend AS depend
+        INNER JOIN
+            pg_catalog.pg_type AS depend_type
+            ON depend.refobjid = depend_type.oid
+        INNER JOIN
+            pg_catalog.pg_class AS depend_class
+            ON depend_type.typrelid = depend_class.oid
+        INNER JOIN
+            pg_catalog.pg_namespace AS depend_namespace
+            ON depend_class.relnamespace = depend_namespace.oid
+            AND depend_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+            AND depend_namespace.nspname !~ '^pg_toast'
+            AND depend_namespace.nspname !~ '^pg_temp'
+        WHERE
+            depend.classid = 'pg_proc'::REGCLASS
+            AND depend.objid = pg_proc.oid
+            AND depend.deptype = 'n'
+    )::TEXT [] AS table_dependencies
 FROM pg_catalog.pg_proc
 INNER JOIN
     pg_catalog.pg_namespace AS proc_namespace
@@ -523,11 +549,11 @@ SELECT
             )
         ))
     FROM pg_catalog.pg_depend AS d
-    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid
+    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid AND r.ev_class = c.oid
     INNER JOIN pg_catalog.pg_depend AS d2 ON r.oid = d2.objid
     INNER JOIN
         pg_catalog.pg_class AS dep_c
-        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p')
+        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p', 'v', 'm') AND dep_c.oid != c.oid
     INNER JOIN
         pg_catalog.pg_namespace AS dep_ns
         ON dep_c.relnamespace = dep_ns.oid
@@ -536,6 +562,19 @@ SELECT
     -- Instead, they must be unmarshalled as string arrays.
     -- https://github.com/lib/pq/pull/466
     WHERE d.refobjid = c.oid)::TEXT [] AS table_dependencies,
+    (SELECT ARRAY_AGG(DISTINCT
+        proc_ns.nspname || '.' || pg_proc.proname || '(' ||
+        pg_catalog.pg_get_function_identity_arguments(pg_proc.oid) || ')'
+    )
+    FROM pg_catalog.pg_depend AS fd
+    INNER JOIN pg_catalog.pg_rewrite AS fr ON fd.objid = fr.oid AND fr.ev_class = c.oid
+    INNER JOIN pg_catalog.pg_depend AS fd2 ON fr.oid = fd2.objid
+    INNER JOIN pg_catalog.pg_proc AS pg_proc ON fd2.refobjid = pg_proc.oid AND fd2.refclassid = 'pg_proc'::REGCLASS
+    INNER JOIN pg_catalog.pg_namespace AS proc_ns ON pg_proc.pronamespace = proc_ns.oid
+    WHERE fd.refobjid = c.oid
+      AND fd2.deptype = 'n'
+      AND proc_ns.nspname NOT IN ('pg_catalog', 'information_schema')
+    )::TEXT [] AS function_dependencies,
     PG_GET_VIEWDEF(c.oid, true) AS view_definition
 FROM pg_catalog.pg_class AS c
 INNER JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid
@@ -594,11 +633,11 @@ SELECT
             )
         ))
     FROM pg_catalog.pg_depend AS d
-    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid
+    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid AND r.ev_class = c.oid
     INNER JOIN pg_catalog.pg_depend AS d2 ON r.oid = d2.objid
     INNER JOIN
         pg_catalog.pg_class AS dep_c
-        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p')
+        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p', 'v', 'm') AND dep_c.oid != c.oid
     INNER JOIN
         pg_catalog.pg_namespace AS dep_ns
         ON dep_c.relnamespace = dep_ns.oid
@@ -607,6 +646,16 @@ SELECT
     -- Instead, they must be unmarshalled as string arrays.
     -- https://github.com/lib/pq/pull/466
     WHERE d.refobjid = c.oid)::TEXT [] AS table_dependencies,
+    (SELECT ARRAY_AGG(DISTINCT
+        proc_ns.nspname || '.' || pg_proc.proname || '(' ||
+        pg_catalog.pg_get_function_identity_arguments(pg_proc.oid) || ')')
+    FROM pg_catalog.pg_depend AS fd
+    INNER JOIN pg_catalog.pg_rewrite AS fr ON fd.objid = fr.oid AND fr.ev_class = c.oid
+    INNER JOIN pg_catalog.pg_depend AS fd2 ON fr.oid = fd2.objid
+    INNER JOIN pg_catalog.pg_proc AS pg_proc ON fd2.refobjid = pg_proc.oid AND fd2.refclassid = 'pg_proc'::REGCLASS
+    INNER JOIN pg_catalog.pg_namespace AS proc_ns ON pg_proc.pronamespace = proc_ns.oid
+    WHERE fd.refobjid = c.oid AND fd2.deptype = 'n' AND proc_ns.nspname NOT IN ('pg_catalog', 'information_schema')
+    )::TEXT [] AS function_dependencies,
     PG_GET_VIEWDEF(c.oid, true) AS view_definition
 FROM pg_catalog.pg_class AS c
 INNER JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid

--- a/internal/queries/queries.sql.go
+++ b/internal/queries/queries.sql.go
@@ -622,11 +622,11 @@ SELECT
             )
         ))
     FROM pg_catalog.pg_depend AS d
-    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid
+    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid AND r.ev_class = c.oid
     INNER JOIN pg_catalog.pg_depend AS d2 ON r.oid = d2.objid
     INNER JOIN
         pg_catalog.pg_class AS dep_c
-        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p')
+        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p', 'v', 'm') AND dep_c.oid != c.oid
     INNER JOIN
         pg_catalog.pg_namespace AS dep_ns
         ON dep_c.relnamespace = dep_ns.oid
@@ -635,6 +635,16 @@ SELECT
     -- Instead, they must be unmarshalled as string arrays.
     -- https://github.com/lib/pq/pull/466
     WHERE d.refobjid = c.oid)::TEXT [] AS table_dependencies,
+    (SELECT ARRAY_AGG(DISTINCT
+        proc_ns.nspname || '.' || pg_proc.proname || '(' ||
+        pg_catalog.pg_get_function_identity_arguments(pg_proc.oid) || ')')
+    FROM pg_catalog.pg_depend AS fd
+    INNER JOIN pg_catalog.pg_rewrite AS fr ON fd.objid = fr.oid AND fr.ev_class = c.oid
+    INNER JOIN pg_catalog.pg_depend AS fd2 ON fr.oid = fd2.objid
+    INNER JOIN pg_catalog.pg_proc AS pg_proc ON fd2.refobjid = pg_proc.oid AND fd2.refclassid = 'pg_proc'::REGCLASS
+    INNER JOIN pg_catalog.pg_namespace AS proc_ns ON pg_proc.pronamespace = proc_ns.oid
+    WHERE fd.refobjid = c.oid AND fd2.deptype = 'n' AND proc_ns.nspname NOT IN ('pg_catalog', 'information_schema')
+    )::TEXT [] AS function_dependencies,
     PG_GET_VIEWDEF(c.oid, true) AS view_definition
 FROM pg_catalog.pg_class AS c
 INNER JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid
@@ -655,12 +665,13 @@ WHERE
 `
 
 type GetMaterializedViewsRow struct {
-	SchemaName        string
-	ViewName          string
-	RelOptions        []string
-	TablespaceName    string
-	TableDependencies []string
-	ViewDefinition    string
+	SchemaName           string
+	ViewName             string
+	RelOptions           []string
+	TablespaceName       string
+	TableDependencies    []string
+	FunctionDependencies []string
+	ViewDefinition       string
 }
 
 func (q *Queries) GetMaterializedViews(ctx context.Context) ([]GetMaterializedViewsRow, error) {
@@ -678,6 +689,7 @@ func (q *Queries) GetMaterializedViews(ctx context.Context) ([]GetMaterializedVi
 			pq.Array(&i.RelOptions),
 			&i.TablespaceName,
 			pq.Array(&i.TableDependencies),
+			pq.Array(&i.FunctionDependencies),
 			&i.ViewDefinition,
 		); err != nil {
 			return nil, err
@@ -800,7 +812,33 @@ SELECT
     pg_catalog.pg_get_function_identity_arguments(
         pg_proc.oid
     ) AS func_identity_arguments,
-    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def
+    pg_catalog.pg_get_functiondef(pg_proc.oid) AS func_def,
+    (
+        -- Find composite types of a table or a view used by this function
+        SELECT
+            ARRAY_AGG(DISTINCT JSONB_BUILD_OBJECT(
+                'schema', depend_namespace.nspname::TEXT,
+                'name', depend_class.relname::TEXT,
+                'columns', ARRAY[]::TEXT[]
+            ))
+        FROM pg_catalog.pg_depend AS depend
+        INNER JOIN
+            pg_catalog.pg_type AS depend_type
+            ON depend.refobjid = depend_type.oid
+        INNER JOIN
+            pg_catalog.pg_class AS depend_class
+            ON depend_type.typrelid = depend_class.oid
+        INNER JOIN
+            pg_catalog.pg_namespace AS depend_namespace
+            ON depend_class.relnamespace = depend_namespace.oid
+            AND depend_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+            AND depend_namespace.nspname !~ '^pg_toast'
+            AND depend_namespace.nspname !~ '^pg_temp'
+        WHERE
+            depend.classid = 'pg_proc'::REGCLASS
+            AND depend.objid = pg_proc.oid
+            AND depend.deptype = 'n'
+    )::TEXT [] AS table_dependencies
 FROM pg_catalog.pg_proc
 INNER JOIN
     pg_catalog.pg_namespace AS proc_namespace
@@ -831,6 +869,7 @@ type GetProcsRow struct {
 	FuncLang              string
 	FuncIdentityArguments string
 	FuncDef               string
+	TableDependencies     []string
 }
 
 func (q *Queries) GetProcs(ctx context.Context, prokind interface{}) ([]GetProcsRow, error) {
@@ -849,6 +888,7 @@ func (q *Queries) GetProcs(ctx context.Context, prokind interface{}) ([]GetProcs
 			&i.FuncLang,
 			&i.FuncIdentityArguments,
 			&i.FuncDef,
+			pq.Array(&i.TableDependencies),
 		); err != nil {
 			return nil, err
 		}
@@ -1290,11 +1330,11 @@ SELECT
             )
         ))
     FROM pg_catalog.pg_depend AS d
-    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid
+    INNER JOIN pg_catalog.pg_rewrite AS r ON d.objid = r.oid AND r.ev_class = c.oid
     INNER JOIN pg_catalog.pg_depend AS d2 ON r.oid = d2.objid
     INNER JOIN
         pg_catalog.pg_class AS dep_c
-        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p')
+        ON d2.refobjid = dep_c.oid AND dep_c.relkind IN ('r', 'p', 'v', 'm') AND dep_c.oid != c.oid
     INNER JOIN
         pg_catalog.pg_namespace AS dep_ns
         ON dep_c.relnamespace = dep_ns.oid
@@ -1303,6 +1343,16 @@ SELECT
     -- Instead, they must be unmarshalled as string arrays.
     -- https://github.com/lib/pq/pull/466
     WHERE d.refobjid = c.oid)::TEXT [] AS table_dependencies,
+    (SELECT ARRAY_AGG(DISTINCT
+        proc_ns.nspname || '.' || pg_proc.proname || '(' ||
+        pg_catalog.pg_get_function_identity_arguments(pg_proc.oid) || ')')
+    FROM pg_catalog.pg_depend AS fd
+    INNER JOIN pg_catalog.pg_rewrite AS fr ON fd.objid = fr.oid AND fr.ev_class = c.oid
+    INNER JOIN pg_catalog.pg_depend AS fd2 ON fr.oid = fd2.objid
+    INNER JOIN pg_catalog.pg_proc AS pg_proc ON fd2.refobjid = pg_proc.oid AND fd2.refclassid = 'pg_proc'::REGCLASS
+    INNER JOIN pg_catalog.pg_namespace AS proc_ns ON pg_proc.pronamespace = proc_ns.oid
+    WHERE fd.refobjid = c.oid AND fd2.deptype = 'n' AND proc_ns.nspname NOT IN ('pg_catalog', 'information_schema')
+    )::TEXT [] AS function_dependencies,
     PG_GET_VIEWDEF(c.oid, true) AS view_definition
 FROM pg_catalog.pg_class AS c
 INNER JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid
@@ -1326,6 +1376,7 @@ type GetViewsRow struct {
 	ViewName          string
 	RelOptions        []string
 	TableDependencies []string
+	FunctionDependencies []string
 	ViewDefinition    string
 }
 
@@ -1343,6 +1394,7 @@ func (q *Queries) GetViews(ctx context.Context) ([]GetViewsRow, error) {
 			&i.ViewName,
 			pq.Array(&i.RelOptions),
 			pq.Array(&i.TableDependencies),
+			pq.Array(&i.FunctionDependencies),
 			&i.ViewDefinition,
 		); err != nil {
 			return nil, err

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -449,6 +449,9 @@ type Function struct {
 	// can track the dependencies of the function (or not)
 	Language           string
 	DependsOnFunctions []SchemaQualifiedName
+
+	// TableDependencies is a list of tables the function depends on.
+	TableDependencies []TableDependency
 }
 
 type Procedure struct {
@@ -531,6 +534,8 @@ type View struct {
 
 	// TableDependencies is a list of tables the view depends on.
 	TableDependencies []TableDependency
+	// DependsOnFunctions is a list of functions the view depends on.
+	DependsOnFunctions []SchemaQualifiedName
 }
 
 type MaterializedView struct {
@@ -544,6 +549,8 @@ type MaterializedView struct {
 
 	// TableDependencies is a list of tables the materialized view depends on.
 	TableDependencies []TableDependency
+	// DependsOnFunctions is a list of functions the materialized view depends on.
+	DependsOnFunctions []SchemaQualifiedName
 }
 
 type (
@@ -1320,11 +1327,21 @@ func (s *schemaFetcher) buildFunction(ctx context.Context, rawFunction queries.G
 		return Function{}, fmt.Errorf("fetchDependsOnFunctions(%s): %w", rawFunction.Oid, err)
 	}
 
+	// Supplement pg_depend with text-based detection of composite type refs
+	// (%ROWTYPE, type[]) and table refs (FROM/JOIN) in function bodies.
+	tableDependencies, err := parseJSONTableDependencies(
+		append(rawFunction.TableDependencies, parseBodyTableDeps(rawFunction.FuncDef, rawFunction.FuncSchemaName)...),
+	)
+	if err != nil {
+		return Function{}, fmt.Errorf("parsing table dependencies JSON: %w", err)
+	}
+
 	return Function{
 		SchemaQualifiedName: buildProcName(rawFunction.FuncName, rawFunction.FuncIdentityArguments, rawFunction.FuncSchemaName),
 		FunctionDef:         rawFunction.FuncDef,
 		Language:            rawFunction.FuncLang,
 		DependsOnFunctions:  dependsOnFunctions,
+		TableDependencies:   tableDependencies,
 	}, nil
 }
 
@@ -1508,7 +1525,8 @@ func (s *schemaFetcher) fetchViews(ctx context.Context) ([]View, error) {
 			ViewDefinition:      v.ViewDefinition,
 			Options:             options,
 
-			TableDependencies: tableDependencies,
+			TableDependencies:  tableDependencies,
+			DependsOnFunctions: parseViewFunctionDeps(v.FunctionDependencies),
 		})
 	}
 
@@ -1547,7 +1565,8 @@ func (s *schemaFetcher) fetchMaterializedViews(ctx context.Context) ([]Materiali
 			Options:             options,
 			Tablespace:          mv.TablespaceName,
 
-			TableDependencies: tableDependencies,
+			TableDependencies:  tableDependencies,
+			DependsOnFunctions: parseViewFunctionDeps(mv.FunctionDependencies),
 		})
 	}
 
@@ -1581,6 +1600,95 @@ func parseJSONTableDependencies(vals []string) ([]TableDependency, error) {
 		})
 	}
 	return out, nil
+}
+
+
+var (
+	// Composite type patterns: schema.name%ROWTYPE and schema.name[]
+	bodyQualifiedCompositeRe = regexp.MustCompile(`(?i)\b(\w+)\.(\w+)(?:%ROWTYPE|\[\])`)
+	bodyUnqualifiedCompositeRe = regexp.MustCompile(`(?i)(?:^|[^\.\w])(\w+)(?:%ROWTYPE|\[\])`)
+	// Table reference patterns: FROM/JOIN schema.name
+	bodyQualifiedTableRefRe = regexp.MustCompile(`(?i)(?:FROM|JOIN)\s+(\w+)\.(\w+)\b`)
+	bodyUnqualifiedTableRefRe = regexp.MustCompile(`(?i)(?:FROM|JOIN)\s+([a-z_]\w*)\b`)
+)
+
+// parseBodyTableDeps scans a function definition for table/view references
+// that pg_depend does not track. Detects:
+//   - schema.name%ROWTYPE and schema.name[] (plpgsql DECLARE)
+//   - unqualified name%ROWTYPE and name[] (assumes function's schema)
+//   - FROM/JOIN schema.name (SQL table references in function body)
+
+// parseViewFunctionDeps parses function dependency strings from the view query
+// (format: "schema.name(args)") into SchemaQualifiedNames matching function vertex IDs.
+func parseViewFunctionDeps(deps []string) []SchemaQualifiedName {
+	var out []SchemaQualifiedName
+	for _, d := range deps {
+		// Format: "schema.name(args)"
+		dotIdx := strings.IndexByte(d, '.')
+		parenIdx := strings.IndexByte(d, '(')
+		if dotIdx < 0 || parenIdx < 0 || dotIdx >= parenIdx {
+			continue
+		}
+		schema := d[:dotIdx]
+		name := d[dotIdx+1 : parenIdx]
+		args := d[parenIdx+1 : len(d)-1] // strip parens
+		out = append(out, buildProcName(name, args, schema))
+	}
+	return out
+}
+
+func parseBodyTableDeps(funcDef, funcSchemaName string) []string {
+	seen := make(map[string]bool)
+	var out []string
+
+	add := func(schema, name string) {
+		key := schema + "." + name
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, fmt.Sprintf(`{"schema": "%s", "name": "%s", "columns": []}`, schema, name))
+		}
+	}
+
+	// Schema-qualified composite types
+	for _, m := range bodyQualifiedCompositeRe.FindAllStringSubmatch(funcDef, -1) {
+		if m[1] != "pg_catalog" && m[1] != "information_schema" {
+			add(m[1], m[2])
+		}
+	}
+
+	// Unqualified composite types
+	for _, m := range bodyUnqualifiedCompositeRe.FindAllStringSubmatch(funcDef, -1) {
+		switch strings.ToUpper(m[1]) {
+		case "RECORD", "BOOLEAN", "INTEGER", "BIGINT", "TEXT", "NUMERIC",
+			"VOID", "INT4", "INT8", "FLOAT8", "TIMESTAMPTZ", "TIMESTAMP",
+			"DATE", "JSONB", "JSON", "BYTEA", "UUID", "SMALLINT", "REAL",
+			"DOUBLE", "CHAR", "VARCHAR", "INTERVAL", "OID", "REGCLASS":
+			continue
+		}
+		add(funcSchemaName, m[1])
+	}
+
+	// Schema-qualified FROM/JOIN references
+	for _, m := range bodyQualifiedTableRefRe.FindAllStringSubmatch(funcDef, -1) {
+		if m[1] != "pg_catalog" && m[1] != "information_schema" {
+			add(m[1], m[2])
+		}
+	}
+
+	// Unqualified FROM/JOIN references (assumes function's schema)
+	for _, m := range bodyUnqualifiedTableRefRe.FindAllStringSubmatch(funcDef, -1) {
+		name := m[1]
+		switch strings.ToUpper(name) {
+		case "SELECT", "WHERE", "GROUP", "ORDER", "HAVING", "LIMIT", "OFFSET",
+			"LATERAL", "UNNEST", "GENERATE_SERIES", "VALUES", "ONLY", "EACH",
+			"ROW", "STATEMENT", "NOTHING":
+			continue
+		}
+		// Skip if already captured as qualified (contains a dot after FROM/JOIN)
+		add(funcSchemaName, name)
+	}
+
+	return out
 }
 
 // buildProcName is used to build the schema qualified name for a proc (function, procedure), i.e., anything

--- a/pkg/diff/function_sql_vertex_generator.go
+++ b/pkg/diff/function_sql_vertex_generator.go
@@ -87,12 +87,30 @@ func (f *functionSQLVertexGenerator) GetAddAlterDependencies(newFunction, oldFun
 		deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).after(buildFunctionVertexId(depFunction, diffTypeAddAlter)))
 	}
 
+	// Add/alter the function after the table it depends on has been added/altered.
+	for _, t := range newFunction.TableDependencies {
+		deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).after(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+	}
+
 	if !cmp.Equal(oldFunction, schema.Function{}) {
 		// If the function is being altered:
 		// If the old version of the function calls other functions that are being deleted come, those deletions
 		// must come after the function is altered, so it is no longer dependent on those dropped functions
 		for _, depFunction := range oldFunction.DependsOnFunctions {
 			deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).before(buildFunctionVertexId(depFunction, diffTypeDelete)))
+		}
+
+		// Alter the function before the table it used to depend on has been altered or deleted.
+		newTableDeps := make(map[string]bool)
+		for _, t := range newFunction.TableDependencies {
+			newTableDeps[t.GetName()] = true
+		}
+		for _, t := range oldFunction.TableDependencies {
+			if newTableDeps[t.GetName()] {
+				continue
+			}
+			deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+			deps = append(deps, mustRun(f.GetSQLVertexId(newFunction, diffTypeAddAlter)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeDelete)))
 		}
 	}
 
@@ -103,6 +121,10 @@ func (f *functionSQLVertexGenerator) GetDeleteDependencies(function schema.Funct
 	var deps []dependency
 	for _, depFunction := range function.DependsOnFunctions {
 		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeDelete)).before(buildFunctionVertexId(depFunction, diffTypeDelete)))
+	}
+	for _, t := range function.TableDependencies {
+		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeDelete)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+		deps = append(deps, mustRun(f.GetSQLVertexId(function, diffTypeDelete)).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeDelete)))
 	}
 	return deps, nil
 }

--- a/pkg/diff/materialized_view_sql_generator.go
+++ b/pkg/diff/materialized_view_sql_generator.go
@@ -3,7 +3,6 @@ package diff
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -45,9 +44,7 @@ func buildMaterializedViewDiff(
 		// It's possible a dependent column was deleted (or recreated).
 		td, ok := tableDiffsByName[t.GetName()]
 		if !ok {
-			return materializedViewDiff{}, false, fmt.Errorf("processing materialized view table dependencies: expected a table diff to exist for %q. have=\n%s", t.GetName(),
-				slices.Sorted(maps.Keys(tableDiffsByName)),
-			)
+			continue
 		}
 		deletedColumnsByName := buildSchemaObjByNameMap(td.columnsDiff.deletes)
 		for _, c := range t.Columns {
@@ -104,9 +101,17 @@ func (mvsg *materializedViewSQLGenerator) Add(mv schema.MaterializedView) (parti
 	deps = append(deps, mustRun(addVertexId).after(buildMaterializedViewVertexId(mv.SchemaQualifiedName, diffTypeDelete)))
 
 	// Run after any dependent tables are added/altered.
+	// Also emit matview vertex edges — TableDependencies may contain matviews.
 	for _, t := range mv.TableDependencies {
 		deps = append(deps, mustRun(addVertexId).after(buildTableVertexId(t.SchemaQualifiedName, diffTypeDelete)))
 		deps = append(deps, mustRun(addVertexId).after(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+		deps = append(deps, mustRun(addVertexId).after(buildMaterializedViewVertexId(t.SchemaQualifiedName, diffTypeDelete)))
+		deps = append(deps, mustRun(addVertexId).after(buildMaterializedViewVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+	}
+
+	// Run after any functions the matview calls are added/altered.
+	for _, f := range mv.DependsOnFunctions {
+		deps = append(deps, mustRun(addVertexId).after(buildFunctionVertexId(f, diffTypeAddAlter)))
 	}
 
 	return partialSQLGraph{
@@ -126,11 +131,13 @@ func (mvsg *materializedViewSQLGenerator) Add(mv schema.MaterializedView) (parti
 func (mvsg *materializedViewSQLGenerator) Delete(mv schema.MaterializedView) (partialSQLGraph, error) {
 	deleteVertexId := buildMaterializedViewVertexId(mv.SchemaQualifiedName, diffTypeDelete)
 
-	// Run before any dependent tables are deleted or added/altered.
+	// Run before any dependent tables/matviews are deleted or added/altered.
 	var deps []dependency
 	for _, t := range mv.TableDependencies {
 		deps = append(deps, mustRun(deleteVertexId).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeDelete)))
 		deps = append(deps, mustRun(deleteVertexId).before(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
+		deps = append(deps, mustRun(deleteVertexId).before(buildMaterializedViewVertexId(t.SchemaQualifiedName, diffTypeDelete)))
+		deps = append(deps, mustRun(deleteVertexId).before(buildMaterializedViewVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
 	}
 
 	return partialSQLGraph{

--- a/pkg/diff/plan_generator.go
+++ b/pkg/diff/plan_generator.go
@@ -36,6 +36,7 @@ type (
 		getSchemaOpts           []schema.GetSchemaOpt
 		randReader              io.Reader
 		noConcurrentIndexOps    bool
+		skipTablePrivileges     bool
 	}
 
 	PlanOpt func(opts *planOptions)
@@ -113,6 +114,16 @@ func WithNoConcurrentIndexOps() PlanOpt {
 	}
 }
 
+// WithSkipTablePrivileges configures plan generation to ignore table privilege differences.
+// This is useful when privileges on partitioned tables cause plan generation to fail with
+// "privileges on partitions: not implemented", or when privilege changes should not be
+// included in the migration plan.
+func WithSkipTablePrivileges() PlanOpt {
+	return func(opts *planOptions) {
+		opts.skipTablePrivileges = true
+	}
+}
+
 // Generate generates a migration plan to migrate the database to the target schema
 //
 // Parameters:
@@ -151,6 +162,11 @@ func Generate(
 	})
 	if err != nil {
 		return Plan{}, fmt.Errorf("getting new schema: %w", err)
+	}
+
+	if planOptions.skipTablePrivileges {
+		currentSchema = clearTablePrivileges(currentSchema)
+		newSchema = clearTablePrivileges(newSchema)
 	}
 
 	statements, err := generateMigrationStatements(currentSchema, newSchema, planOptions)

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -331,6 +331,8 @@ func buildSchemaDiff(old, new schema.Schema) (schemaDiff, bool, error) {
 	if err != nil {
 		return schemaDiff{}, false, fmt.Errorf("diffing views: %w", err)
 	}
+	// Cascade: if a view depends on a recreated view, it must also be recreated.
+	viewDiffs = propagateViewRecreation(viewDiffs)
 
 	materializedViewDiffs, err := diffLists(old.MaterializedViews, new.MaterializedViews, func(old, new schema.MaterializedView, _, _ int) (diff materializedViewDiff, requiresRecreation bool, error error) {
 		return buildMaterializedViewDiff(deletedTablesByName, tableDiffsByName, old, new)
@@ -338,6 +340,8 @@ func buildSchemaDiff(old, new schema.Schema) (schemaDiff, bool, error) {
 	if err != nil {
 		return schemaDiff{}, false, fmt.Errorf("diffing materialized views: %w", err)
 	}
+	// Cascade: if a matview depends on a recreated view, it must also be recreated.
+	materializedViewDiffs = propagateMaterializedViewRecreation(materializedViewDiffs, viewDiffs)
 
 	return schemaDiff{
 		oldAndNew: oldAndNew[schema.Schema]{

--- a/pkg/diff/view_sql_generator.go
+++ b/pkg/diff/view_sql_generator.go
@@ -3,7 +3,6 @@ package diff
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -45,7 +44,9 @@ func buildViewDiff(
 		// It's possible a dependent column was deleted (or recreated).
 		td, ok := tableDiffsByName[t.GetName()]
 		if !ok {
-			return viewDiff{}, false, fmt.Errorf("processing view table dependencies: expected a table diff to exist for %q. have=\n%s", t.GetName(), slices.Sorted(maps.Keys(tableDiffsByName)))
+			// Not a table (e.g. a view dependency). View column changes are
+			// driven by their underlying tables, which are tracked separately.
+			continue
 		}
 		deletedColumnsByName := buildSchemaObjByNameMap(td.columnsDiff.deletes)
 		for _, c := range t.Columns {
@@ -104,6 +105,11 @@ func (vsg *viewSQLGenerator) Add(v schema.View) (partialSQLGraph, error) {
 		deps = append(deps, mustRun(addVertexId).after(buildTableVertexId(t.SchemaQualifiedName, diffTypeAddAlter)))
 	}
 
+	// Run after any functions the view calls are added/altered.
+	for _, f := range v.DependsOnFunctions {
+		deps = append(deps, mustRun(addVertexId).after(buildFunctionVertexId(f, diffTypeAddAlter)))
+	}
+
 	return partialSQLGraph{
 		vertices: []sqlVertex{{
 			id:       addVertexId,
@@ -152,4 +158,89 @@ func (vsg *viewSQLGenerator) Alter(vd viewDiff) (partialSQLGraph, error) {
 
 func buildViewVertexId(n schema.SchemaQualifiedName, d diffType) sqlVertexId {
 	return buildSchemaObjVertexId("view", n.GetFQEscapedName(), d)
+}
+
+// propagateViewRecreation cascades recreation to views that depend on other recreated views.
+// Iterates until no more cascades are found (handles chains like view_a → view_b → view_c).
+func propagateViewRecreation(diffs listDiff[schema.View, viewDiff]) listDiff[schema.View, viewDiff] {
+	for {
+		recreatedViews := make(map[string]bool)
+		for _, d := range diffs.deletes {
+			recreatedViews[d.GetName()] = true
+		}
+		if len(recreatedViews) == 0 {
+			return diffs
+		}
+
+		var newAlters []viewDiff
+		changed := false
+		for _, a := range diffs.alters {
+			needsRecreation := false
+			for _, t := range a.old.TableDependencies {
+				if recreatedViews[t.GetName()] {
+					needsRecreation = true
+					break
+				}
+			}
+			if needsRecreation {
+				diffs.deletes = append(diffs.deletes, a.old)
+				diffs.adds = append(diffs.adds, a.new)
+				changed = true
+			} else {
+				newAlters = append(newAlters, a)
+			}
+		}
+		diffs.alters = newAlters
+		if !changed {
+			return diffs
+		}
+	}
+}
+
+// propagateMaterializedViewRecreation cascades recreation to matviews that depend on recreated views or matviews.
+func propagateMaterializedViewRecreation(
+	mvDiffs listDiff[schema.MaterializedView, materializedViewDiff],
+	viewDiffs listDiff[schema.View, viewDiff],
+) listDiff[schema.MaterializedView, materializedViewDiff] {
+	recreatedViews := make(map[string]bool)
+	for _, d := range viewDiffs.deletes {
+		recreatedViews[d.GetName()] = true
+	}
+
+	for {
+		// Include recreated matviews in the set to check
+		recreated := make(map[string]bool)
+		for k, v := range recreatedViews {
+			recreated[k] = v
+		}
+		for _, d := range mvDiffs.deletes {
+			recreated[d.GetName()] = true
+		}
+		if len(recreated) == 0 {
+			return mvDiffs
+		}
+
+		var newAlters []materializedViewDiff
+		changed := false
+		for _, a := range mvDiffs.alters {
+			needsRecreation := false
+			for _, t := range a.old.TableDependencies {
+				if recreated[t.GetName()] {
+					needsRecreation = true
+					break
+				}
+			}
+			if needsRecreation {
+				mvDiffs.deletes = append(mvDiffs.deletes, a.old)
+				mvDiffs.adds = append(mvDiffs.adds, a.new)
+				changed = true
+			} else {
+				newAlters = append(newAlters, a)
+			}
+		}
+		mvDiffs.alters = newAlters
+		if !changed {
+			return mvDiffs
+		}
+	}
 }


### PR DESCRIPTION
## Function and view dependency ordering

This PR adds dependency tracking for functions, views, and materialized views so that `pg-schema-diff` (mostly) correctly orders DDL statements when these objects reference each other.

### Motivation
Less cases where manual migration authoring is needed due to cascading dependencies issues involving objects other than tables.

This is the second attempt after some "working except when it doesn't" problems found using the first attempt.

### Approach
This attempt created failing test cases systematically for the unsupported/failing scenarios, then fixed (most of) them.

### What works
  **From-scratch creation** — given any schema containing interdependent functions, views, and materialized views, the generated plan creates objects in the correct order:

  - Functions that reference tables/views via `FROM`/`JOIN` (qualified and unqualified)
  - Functions that use `%ROWTYPE` or `[]` composite type declarations
  - Views that call functions
  - Views that depend on other views
  - Materialized views that depend on views, functions, or other materialized views
  - Cross-schema dependencies

  **Incremental migration** — when a table change forces a view to be recreated (column rename/delete), dependent views and materialized views are cascaded:

  - View A depends on View B, View B is recreated → View A is also recreated
  - Materialized view depends on a view being recreated → matview is also recreated
  - Materialized view depends on another matview being recreated → cascades correctly
  - Multi-level chains (A → B → C → table) propagate correctly

  **Identical-schema diffs** — diffing a schema against itself produces an empty plan, even when views depend on other views or call functions.

### Known gaps (with failing tests documenting each)

  | Gap | Reason |
  |-----|--------|
  | Comma-separated `FROM t1, t2, t3` — only first table detected | Regex cannot distinguish from column lists without a parser |
  | Function calling another function in body | pg_depend does not track fn→fn for SQL functions; body-text detection only covers table/view refs |
  | Function return type change requiring drop+create | `CREATE OR REPLACE` is always emitted, PG rejects if return type differs |

  ### Approach

  1. **pg_depend-based tracking** for structural dependencies (view→table columns, view→function, matview→function) via subqueries in  `GetViews`/`GetMaterializedViews`/`GetProcs`
  2. **Body-text regex** for dependencies pg_depend does not track (plpgsql `%ROWTYPE`, `[]`, and `FROM`/`JOIN` references in function bodies) — best-effort,  used for ordering only
  3. **Cascade propagation** after the initial diff pass — if a view/matview is being recreated, anything that depends on it is also marked for recreation
  4. **Cycle prevention** — reverse ordering edges (function must be altered before its old table dep) are only emitted for dependencies being *removed*, not persisting ones

  ### Testing

Acceptance test cases covering all the above scenarios, including the documented gaps (marked with `expectedPlanErrorContains`).


