### PR TITLE
Track table LOGGED/UNLOGGED persistence

### DIFF
--- a/internal/migration_acceptance_tests/table_cases_test.go
+++ b/internal/migration_acceptance_tests/table_cases_test.go
@@ -99,6 +99,52 @@ var tableAcceptanceTestCases = []acceptanceTestCase{
 		},
 	},
 	{
+		name: "Set table unlogged",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE UNLOGGED TABLE foobar(
+                id INT PRIMARY KEY
+            );
+			`,
+		},
+		expectedPlanDDL: []string{
+			`ALTER TABLE "public"."foobar" SET UNLOGGED`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
+		name: "Set table logged",
+		oldSchemaDDL: []string{
+			`
+            CREATE UNLOGGED TABLE foobar(
+                id INT PRIMARY KEY
+            );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foobar(
+                id INT PRIMARY KEY
+            );
+			`,
+		},
+		expectedPlanDDL: []string{
+			`ALTER TABLE "public"."foobar" SET LOGGED`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+		},
+	},
+	{
 		name:         "Create table with RLS enabled",
 		oldSchemaDDL: nil,
 		newSchemaDDL: []string{

--- a/internal/queries/queries.sql
+++ b/internal/queries/queries.sql
@@ -20,6 +20,7 @@ SELECT
     c.oid,
     c.relname::TEXT AS table_name,
     table_namespace.nspname::TEXT AS table_schema_name,
+    c.relpersistence = 'u' AS is_unlogged,
     c.relreplident::TEXT AS replica_identity,
     c.relrowsecurity AS rls_enabled,
     c.relforcerowsecurity AS rls_forced,

--- a/internal/queries/queries.sql.go
+++ b/internal/queries/queries.sql.go
@@ -1089,6 +1089,7 @@ SELECT
     c.oid,
     c.relname::TEXT AS table_name,
     table_namespace.nspname::TEXT AS table_schema_name,
+    c.relpersistence = 'u' AS is_unlogged,
     c.relreplident::TEXT AS replica_identity,
     c.relrowsecurity AS rls_enabled,
     c.relforcerowsecurity AS rls_forced,
@@ -1136,6 +1137,7 @@ type GetTablesRow struct {
 	Oid                   interface{}
 	TableName             string
 	TableSchemaName       string
+	IsUnlogged            bool
 	ReplicaIdentity       string
 	RlsEnabled            bool
 	RlsForced             bool
@@ -1158,6 +1160,7 @@ func (q *Queries) GetTables(ctx context.Context) ([]GetTablesRow, error) {
 			&i.Oid,
 			&i.TableName,
 			&i.TableSchemaName,
+			&i.IsUnlogged,
 			&i.ReplicaIdentity,
 			&i.RlsEnabled,
 			&i.RlsForced,

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -218,6 +218,7 @@ type Table struct {
 	CheckConstraints []CheckConstraint
 	Policies         []Policy
 	Privileges       []TablePrivilege
+	IsUnlogged       bool
 	ReplicaIdentity  ReplicaIdentity
 	RLSEnabled       bool
 	RLSForced        bool
@@ -1056,6 +1057,7 @@ func (s *schemaFetcher) buildTable(
 		CheckConstraints:    checkConsByTable[schemaQualifiedName.GetFQEscapedName()],
 		Policies:            policiesByTable[schemaQualifiedName.GetFQEscapedName()],
 		Privileges:          privilegesByTable[schemaQualifiedName.GetFQEscapedName()],
+		IsUnlogged:          table.IsUnlogged,
 		ReplicaIdentity:     ReplicaIdentity(table.ReplicaIdentity),
 		RLSEnabled:          table.RlsEnabled,
 		RLSForced:           table.RlsForced,

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -239,7 +239,7 @@ var (
 			GRANT SELECT ON schema_2.foo TO some_role_1;
 			GRANT INSERT ON schema_2.foo TO some_role_2 WITH GRANT OPTION;
 		`},
-			expectedHash: "4c2174e2cac3956b",
+			expectedHash: "63bdda1e60bbc81",
 			expectedSchema: Schema{
 				NamedSchemas: []NamedSchema{
 					{Name: "public"},
@@ -591,7 +591,7 @@ var (
 			ALTER TABLE foo_fk_1 ADD CONSTRAINT foo_fk_1_fk FOREIGN KEY (author, content) REFERENCES foo_1 (author, content)
 				NOT VALID;
 		`},
-			expectedHash: "32c5a9c52dcfb15e",
+			expectedHash: "528eed3f5ac35bd1",
 			expectedSchema: Schema{
 				NamedSchemas: []NamedSchema{
 					{Name: "public"},

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -828,7 +828,12 @@ func (t *tableSQLVertexGenerator) Add(table schema.Table) ([]Statement, error) {
 		columnDefs = append(columnDefs, "\t"+columnDef)
 	}
 	createTableSb := strings.Builder{}
-	createTableSb.WriteString(fmt.Sprintf("CREATE TABLE %s (\n%s\n)",
+	tableKind := "TABLE"
+	if table.IsUnlogged {
+		tableKind = "UNLOGGED TABLE"
+	}
+	createTableSb.WriteString(fmt.Sprintf("CREATE %s %s (\n%s\n)",
+		tableKind,
 		table.GetFQEscapedName(),
 		strings.Join(columnDefs, ",\n"),
 	))
@@ -954,6 +959,10 @@ func (t *tableSQLVertexGenerator) Alter(diff tableDiff) ([]Statement, error) {
 		stmts = append(stmts, alterBaseTableStmts...)
 	}
 
+	if diff.old.IsUnlogged != diff.new.IsUnlogged {
+		stmts = append(stmts, alterTablePersistenceStatement(diff.new.SchemaQualifiedName, diff.new.IsUnlogged))
+	}
+
 	if diff.old.ReplicaIdentity != diff.new.ReplicaIdentity {
 		alterReplicaIdentityStmt, err := alterReplicaIdentityStatement(diff.new.SchemaQualifiedName, diff.new.ReplicaIdentity)
 		if err != nil {
@@ -1058,6 +1067,22 @@ func (t *tableSQLVertexGenerator) alterBaseTable(diff tableDiff) ([]Statement, e
 	stmts = append(stmts, dropTempCCs...)
 
 	return stmts, nil
+}
+
+func alterTablePersistenceStatement(table schema.SchemaQualifiedName, isUnlogged bool) Statement {
+	persistence := "LOGGED"
+	if isUnlogged {
+		persistence = "UNLOGGED"
+	}
+	return Statement{
+		DDL:         fmt.Sprintf("%s SET %s", alterTablePrefix(table), persistence),
+		Timeout:     statementTimeoutDefault,
+		LockTimeout: lockTimeoutDefault,
+		Hazards: []MigrationHazard{{
+			Type:    MigrationHazardTypeAcquiresAccessExclusiveLock,
+			Message: "Changing table persistence requires an ACCESS EXCLUSIVE lock and rewrites the table",
+		}},
+	}
 }
 
 func (t *tableSQLVertexGenerator) alterPartition(diff tableDiff) ([]Statement, error) {


### PR DESCRIPTION
## Summary

- track table persistence from `pg_class.relpersistence` in schema extraction
- emit `CREATE UNLOGGED TABLE` for new unlogged tables
- emit `ALTER TABLE ... SET LOGGED/UNLOGGED` when an existing table changes persistence

## Root Cause

`pg-schema-diff` did not include table persistence in its table model, so a declarative `CREATE UNLOGGED TABLE` target could differ from an existing logged table while the generated migration plan stayed empty.

## Tests

- `PATH="/Applications/Postgres.app/Contents/Versions/16/bin:$PATH" go test ./internal/schema -run TestSchemaTestCases/'Simple schema|Partition test' -count=1`
- `PATH="/Applications/Postgres.app/Contents/Versions/16/bin:$PATH" go test ./internal/migration_acceptance_tests -run TestTableTestCases/'Set table' -count=1`
- `PATH="/Applications/Postgres.app/Contents/Versions/16/bin:$PATH" go test ./...`
