### PR TITLE
fix: escape policy role names and function/procedure names in generated SQL

### DIFF
--- a/internal/migration_acceptance_tests/function_cases_test.go
+++ b/internal/migration_acceptance_tests/function_cases_test.go
@@ -573,6 +573,50 @@ var functionAcceptanceTestCases = []acceptanceTestCase{
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{diff.MigrationHazardTypeHasUntrackableDependencies},
 	},
+	{
+		name:         "Create function with name containing double quote",
+		oldSchemaDDL: nil,
+		newSchemaDDL: []string{
+			`
+            CREATE FUNCTION "evil""func"(a integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + 1;
+			`,
+		},
+	},
+	{
+		name: "Drop function with name containing double quote",
+		oldSchemaDDL: []string{
+			`
+            CREATE FUNCTION "evil""func"(a integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a + 1;
+			`,
+		},
+		newSchemaDDL: nil,
+	},
+	{
+		name: "Create function with SQL injection in name",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE foo(id integer);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE foo(id integer);
+            CREATE FUNCTION "x""; DROP TABLE foo; --"(a integer) RETURNS integer
+                LANGUAGE SQL
+                IMMUTABLE
+                RETURNS NULL ON NULL INPUT
+                RETURN a;
+			`,
+		},
+	},
 }
 
 func TestFunctionTestCases(t *testing.T) {

--- a/internal/migration_acceptance_tests/policy_cases_test.go
+++ b/internal/migration_acceptance_tests/policy_cases_test.go
@@ -658,6 +658,84 @@ var policyAcceptanceTestCases = []acceptanceTestCase{
 
 		expectedPlanErrorIs: diff.ErrNotImplemented,
 	},
+	{
+		name: "Create policy with role containing double quote",
+		roles: []string{
+			`"evil""role"`,
+		},
+		oldSchemaDDL: []string{
+			`
+                CREATE TABLE foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar
+                    AS PERMISSIVE
+                    FOR ALL
+                    TO "evil""role"
+                    USING (true)
+                    WITH CHECK (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Alter policy with role containing SQL injection payload",
+		roles: []string{
+			`"x""; DROP TABLE foobar; --"`,
+		},
+		oldSchemaDDL: []string{
+			`
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar
+                    AS PERMISSIVE
+                    FOR ALL
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar
+                    AS PERMISSIVE
+                    FOR ALL
+                    TO "x""; DROP TABLE foobar; --"
+                    USING (true)
+                    WITH CHECK (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
+	{
+		name: "Create policy with PUBLIC keyword unquoted",
+		oldSchemaDDL: []string{
+			`
+                CREATE TABLE foobar();
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+                CREATE TABLE foobar();
+                CREATE POLICY foobar_policy ON foobar
+                    AS PERMISSIVE
+                    FOR ALL
+                    TO PUBLIC
+                    USING (true)
+                    WITH CHECK (true);
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAuthzUpdate,
+		},
+	},
 }
 
 func TestPolicyCases(t *testing.T) {

--- a/internal/schema/escape_test.go
+++ b/internal/schema/escape_test.go
@@ -58,3 +58,41 @@ func TestEscapeLiteral(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildProcName(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		procName        string
+		identityArgs    string
+		schemaName      string
+		expectedEscaped string
+	}{
+		{
+			name:            "simple function",
+			procName:        "add",
+			identityArgs:    "integer, integer",
+			schemaName:      "public",
+			expectedEscaped: `"add"(integer, integer)`,
+		},
+		{
+			name:            "function name with embedded double quote",
+			procName:        `evil"func`,
+			identityArgs:    "integer",
+			schemaName:      "public",
+			expectedEscaped: `"evil""func"(integer)`,
+		},
+		{
+			name:            "injection attempt via double quote",
+			procName:        `x"; DROP TABLE foo; --`,
+			identityArgs:    "",
+			schemaName:      "public",
+			expectedEscaped: `"x""; DROP TABLE foo; --"()`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildProcName(tc.procName, tc.identityArgs, tc.schemaName)
+			assert.Equal(t, tc.schemaName, result.SchemaName)
+			assert.Equal(t, tc.expectedEscaped, result.EscapedName)
+		})
+	}
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1588,7 +1588,7 @@ func parseJSONTableDependencies(vals []string) ([]TableDependency, error) {
 func buildProcName(name, identityArguments, schemaName string) SchemaQualifiedName {
 	return SchemaQualifiedName{
 		SchemaName:  schemaName,
-		EscapedName: fmt.Sprintf("\"%s\"(%s)", name, identityArguments),
+		EscapedName: fmt.Sprintf("%s(%s)", EscapeIdentifier(name), identityArguments),
 	}
 }
 

--- a/pkg/diff/policy_sql_generator.go
+++ b/pkg/diff/policy_sql_generator.go
@@ -100,6 +100,20 @@ func unforceRLSForTable(t schema.Table) Statement {
 	}
 }
 
+// escapeRoleNames escapes role names for use in SQL policy statements.
+// PUBLIC is a SQL keyword (not an identifier) and must not be quoted.
+func escapeRoleNames(roles []string) []string {
+	escaped := make([]string, len(roles))
+	for i, role := range roles {
+		if role == "PUBLIC" {
+			escaped[i] = role
+		} else {
+			escaped[i] = schema.EscapeIdentifier(role)
+		}
+	}
+	return escaped
+}
+
 type policyDiff struct {
 	oldAndNew[schema.Policy]
 }
@@ -164,7 +178,7 @@ func (psg *policySQLVertexGenerator) Add(p schema.Policy) ([]Statement, error) {
 	}
 	sb.WriteString(fmt.Sprintf("\n\tFOR %s", cmdSQL))
 
-	sb.WriteString(fmt.Sprintf("\n\tTO %s", strings.Join(p.AppliesTo, ", ")))
+	sb.WriteString(fmt.Sprintf("\n\tTO %s", strings.Join(escapeRoleNames(p.AppliesTo), ", ")))
 
 	if p.UsingExpression != "" {
 		sb.WriteString(fmt.Sprintf("\n\tUSING (%s)", p.UsingExpression))
@@ -223,7 +237,7 @@ func (psg *policySQLVertexGenerator) Alter(diff policyDiff) ([]Statement, error)
 	var alterPolicyParts []string
 
 	if !cmp.Equal(oldCopy.AppliesTo, diff.new.AppliesTo) {
-		alterPolicyParts = append(alterPolicyParts, fmt.Sprintf("TO %s", strings.Join(diff.new.AppliesTo, ", ")))
+		alterPolicyParts = append(alterPolicyParts, fmt.Sprintf("TO %s", strings.Join(escapeRoleNames(diff.new.AppliesTo), ", ")))
 		oldCopy.AppliesTo = diff.new.AppliesTo
 	}
 

--- a/pkg/diff/policy_sql_generator_test.go
+++ b/pkg/diff/policy_sql_generator_test.go
@@ -1,0 +1,94 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/pg-schema-diff/internal/schema"
+)
+
+func TestEscapeRoleNames(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "PUBLIC is not escaped",
+			input:    []string{"PUBLIC"},
+			expected: []string{"PUBLIC"},
+		},
+		{
+			name:     "simple role is escaped",
+			input:    []string{"my_role"},
+			expected: []string{`"my_role"`},
+		},
+		{
+			name:     "mixed PUBLIC and regular roles",
+			input:    []string{"PUBLIC", "role_1", "role_2"},
+			expected: []string{"PUBLIC", `"role_1"`, `"role_2"`},
+		},
+		{
+			name:     "role with embedded double quote",
+			input:    []string{`evil"role`},
+			expected: []string{`"evil""role"`},
+		},
+		{
+			name:     "injection attempt via role name",
+			input:    []string{`x"; DROP TABLE foo; --`},
+			expected: []string{`"x""; DROP TABLE foo; --"`},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, escapeRoleNames(tc.input))
+		})
+	}
+}
+
+func TestPolicySQLGenerator_Add_EscapesRoleNames(t *testing.T) {
+	table := schema.Table{
+		SchemaQualifiedName: schema.SchemaQualifiedName{
+			SchemaName:  "public",
+			EscapedName: `"foo"`,
+		},
+	}
+	psg, err := newPolicySQLVertexGenerator(nil, table)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name        string
+		appliesTo   []string
+		expectedSub string
+	}{
+		{
+			name:        "PUBLIC unquoted",
+			appliesTo:   []string{"PUBLIC"},
+			expectedSub: "\n\tTO PUBLIC",
+		},
+		{
+			name:        "regular role quoted",
+			appliesTo:   []string{"my_role"},
+			expectedSub: "\n\tTO \"my_role\"",
+		},
+		{
+			name:        "role with embedded double quote",
+			appliesTo:   []string{`evil"role`},
+			expectedSub: "\n\tTO \"evil\"\"role\"",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			graph, err := psg.Add(schema.Policy{
+				EscapedName:  `"test_policy"`,
+				IsPermissive: true,
+				AppliesTo:    tc.appliesTo,
+				Cmd:          schema.AllPolicyCmd,
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, graph.vertices)
+			require.NotEmpty(t, graph.vertices[0].statements)
+			ddl := graph.vertices[0].statements[0].DDL
+			assert.Contains(t, ddl, tc.expectedSub)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two additional SQL injection sinks identified via the same root cause as #295 (enum labels). Schema-derived values were re-emitted into generated DDL without proper escaping.

### 1. Policy role names (`policy_sql_generator.go`)

`AppliesTo` role names (sourced from `pg_roles.rolname`) were interpolated raw into `CREATE POLICY ... TO` and `ALTER POLICY ... TO` statements. A user with `CREATEROLE` privilege could plant a role whose name contains an embedded double-quote to inject arbitrary SQL during plan execution.

**Fix**: Added `escapeRoleNames()` helper that applies `EscapeIdentifier` to each role name, preserving `PUBLIC` as an unquoted SQL keyword (matching the existing pattern in `privilege_sql_generator.go`).

### 2. Function/procedure names (`schema.go` `buildProcName`)

The function used hand-rolled quoting (`fmt.Sprintf("\"%s\"(%s)", name, ...)`) that did not double embedded double-quotes. A user with `CREATE FUNCTION` privilege could create a function with `"` in its name to inject SQL when `DROP FUNCTION`/`DROP PROCEDURE` statements are generated.

**Fix**: Replaced the hand-rolled quoting with `EscapeIdentifier(name)`.

## Evidence of vulnerability without fix

### buildProcName (function names)

When the fix is reverted, `buildProcName` produces broken/injectable identifiers:

```
=== RUN   TestBuildProcName/function_name_with_embedded_double_quote
    expected: "evil""func"(integer)
    actual  : "evil"func"(integer)      <-- unescaped, invalid SQL

=== RUN   TestBuildProcName/injection_attempt_via_double_quote
    expected: "x""; DROP TABLE foo; --"()
    actual  : "x"; DROP TABLE foo; --"()   <-- SQL injection!
```

### Policy role names

When the fix is reverted, role names are emitted raw:

```
=== RUN   TestPolicySQLGenerator_Add_EscapesRoleNames/regular_role_quoted
    TO my_role           <-- unescaped (should be TO "my_role")

=== RUN   TestPolicySQLGenerator_Add_EscapesRoleNames/role_with_embedded_double_quote
    TO evil"role         <-- SQL injection! (should be TO "evil""role")
```

## Evidence of all acceptance tests passing with fix

All 50 policy and function acceptance tests pass against a live PostgreSQL 14 instance (Docker, with `-race`):

```
--- PASS: TestPolicyCases (0.01s)
    --- PASS: TestPolicyCases/Alter_policy_check (3.53s)
    --- PASS: TestPolicyCases/Add_policy_on_existing_partition_(not_implemented) (1.15s)
    --- PASS: TestPolicyCases/Policy_on_new_partition_(not_implemented) (1.21s)
    --- PASS: TestPolicyCases/no-op (5.42s)
    --- PASS: TestPolicyCases/Create_policy_with_PUBLIC_keyword_unquoted (4.14s)
    --- PASS: TestPolicyCases/Alter_policy_(table_is_re-created) (3.27s)
    --- PASS: TestPolicyCases/Remove_check_for_ALL_policy (3.31s)
    --- PASS: TestPolicyCases/Remove_using_check_for_ALL_policy (3.30s)
    --- PASS: TestPolicyCases/Alter_policy_that_references_deleted_columns_and_new_columns_(non-public_schema) (3.31s)
    --- PASS: TestPolicyCases/Re-create_policy_that_references_deleted_columns_and_new_columns_(non-public_schema) (3.33s)
    --- PASS: TestPolicyCases/Alter_policy_using (2.87s)
    --- PASS: TestPolicyCases/Add_policy_on_new_table (3.45s)
    --- PASS: TestPolicyCases/Alter_policy_with_role_containing_SQL_injection_payload (5.89s)
    --- PASS: TestPolicyCases/Create_policy_with_role_containing_double_quote (6.02s)
    --- PASS: TestPolicyCases/Alter_all_alterable_attributes_on_non-public_schema (6.02s)
    --- PASS: TestPolicyCases/Alter_policy_target (3.71s)
    --- PASS: TestPolicyCases/Drop_policy_and_columns (3.63s)
    --- PASS: TestPolicyCases/Alter_policy_applies_to (5.84s)
    --- PASS: TestPolicyCases/Disable_RLS_then_drop_policy (3.90s)
    --- PASS: TestPolicyCases/Drop_policy_and_table (3.90s)
    --- PASS: TestPolicyCases/Drop_non-public_schema_policy (3.91s)
    --- PASS: TestPolicyCases/Add_policy_then_enable_RLS (3.91s)
    --- PASS: TestPolicyCases/Create_INSERT_policy (3.83s)
    --- PASS: TestPolicyCases/Create_DELETE_policy (3.15s)
    --- PASS: TestPolicyCases/Restrictive_to_permissive_policy (3.04s)
    --- PASS: TestPolicyCases/Create_SELECT_policy (2.77s)
    --- PASS: TestPolicyCases/Create_UPDATE_policy (2.49s)
    --- PASS: TestPolicyCases/Add_permissive_ALL_policy_target_on_non-public_schema (3.71s)
    --- PASS: TestPolicyCases/Create_INSERT_policy (4.13s)
    --- PASS: TestPolicyCases/Create_UPDATE_policy (4.14s)
--- PASS: TestFunctionTestCases (0.01s)
    --- PASS: TestFunctionTestCases/No-op (4.05s)
    --- PASS: TestFunctionTestCases/Alter_functions_(with_conflicting_names) (4.21s)
    --- PASS: TestFunctionTestCases/Drop_function_with_name_containing_double_quote (4.03s)
    --- PASS: TestFunctionTestCases/Create_function_with_name_containing_double_quote (3.99s)
    --- PASS: TestFunctionTestCases/Alter_a_dependent_function (3.98s)
    --- PASS: TestFunctionTestCases/Create_function_with_SQL_injection_in_name (3.98s)
    --- PASS: TestFunctionTestCases/Alter_a_function_to_no_longer_depend_on_a_function_and_drop_that_function (3.16s)
    --- PASS: TestFunctionTestCases/Alter_non-sql_function_to_be_sql_function_(no_dependency_tracking_error) (3.49s)
    --- PASS: TestFunctionTestCases/Alter_a_function's_dependencies (3.98s)
    --- PASS: TestFunctionTestCases/Alter_non-sql_function (3.53s)
    --- PASS: TestFunctionTestCases/Alter_functions_with_quoted_names_(with_conflicting_names) (3.55s)
    --- PASS: TestFunctionTestCases/Drop_non-sql_function (3.52s)
    --- PASS: TestFunctionTestCases/Create_functions_with_quoted_names_(with_conflicting_names) (3.54s)
    --- PASS: TestFunctionTestCases/Create_non-sql_function (3.58s)
    --- PASS: TestFunctionTestCases/Drop_function_with_dependencies (3.59s)
    --- PASS: TestFunctionTestCases/Alter_sql_function_to_be_non-sql_function (3.61s)
    --- PASS: TestFunctionTestCases/Drop_functions_with_quoted_names_(with_conflicting_names) (4.01s)
    --- PASS: TestFunctionTestCases/Drop_functions_(with_conflicting_names) (4.02s)
    --- PASS: TestFunctionTestCases/Create_function_with_an_extension_that_also_creates_functions_installed (3.07s)
    --- PASS: TestFunctionTestCases/Create_function_with_dependencies (3.87s)
    --- PASS: TestFunctionTestCases/Add_and_drop_functions_with_dependencies_(conflicting_schemas) (3.98s)
    --- PASS: TestFunctionTestCases/Create_functions_(with_conflicting_names) (3.04s)
ok  	github.com/stripe/pg-schema-diff/internal/migration_acceptance_tests	19.901s
```

## Test plan

- [x] Unit tests for `buildProcName` with normal, double-quote, and injection payloads
- [x] Unit tests for `escapeRoleNames` including PUBLIC keyword handling
- [x] Unit tests for `policySQLGenerator.Add` verifying escaped role output
- [x] Acceptance tests for policy creation/alteration with double-quote roles and injection payloads (live PostgreSQL)
- [x] Acceptance tests for function create/drop with double-quote names and injection payloads (live PostgreSQL)
- [x] All existing policy and function acceptance tests pass (no regressions)
- [x] Verified test failures when fix is reverted (evidence above)