### PR TITLE
fix: qualify pg_catalog.to_timestamp in bigint-to-timestamp migrations

### DIFF
--- a/internal/migration_acceptance_tests/column_cases_test.go
+++ b/internal/migration_acceptance_tests/column_cases_test.go
@@ -327,8 +327,44 @@ var columnAcceptanceTestCases = []acceptanceTestCase{
 			`,
 		},
 		expectedPlanDDL: []string{
-			"ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using to_timestamp(\"some_time_col\" / 1000)",
+			"ALTER TABLE \"public\".\"Foobar\" ALTER COLUMN \"some_time_col\" SET DATA TYPE timestamp without time zone using pg_catalog.to_timestamp(\"some_time_col\"::pg_catalog.float8 OPERATOR(pg_catalog./) 1000.0::pg_catalog.float8)",
 			"ANALYZE \"public\".\"Foobar\" (\"some_time_col\")",
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,
+			diff.MigrationHazardTypeImpactsDatabasePerformance,
+		},
+	},
+	{
+		name: "Change BIGINT to TIMESTAMP (ignores shadowed to_timestamp in USING)",
+		oldSchemaDDL: []string{
+			`
+            CREATE FUNCTION public.to_timestamp(double precision)
+            RETURNS timestamp without time zone LANGUAGE plpgsql AS $$
+            BEGIN
+              RAISE EXCEPTION 'pwnd';
+            END $$;
+
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col BIGINT NOT NULL
+            );
+            INSERT INTO "Foobar" VALUES (1, 1700000000000);
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE FUNCTION public.to_timestamp(double precision)
+            RETURNS timestamp without time zone LANGUAGE plpgsql AS $$
+            BEGIN
+              RAISE EXCEPTION 'pwnd';
+            END $$;
+
+            CREATE TABLE "Foobar"(
+                id INT PRIMARY KEY,
+                some_time_col TIMESTAMP NOT NULL
+            );
+			`,
 		},
 		expectedHazardTypes: []diff.MigrationHazardType{
 			diff.MigrationHazardTypeAcquiresAccessExclusiveLock,

--- a/pkg/diff/sql_generator.go
+++ b/pkg/diff/sql_generator.go
@@ -1399,7 +1399,7 @@ func (csg *columnSQLVertexGenerator) generateTypeTransformationStatement(
 	if strings.EqualFold(oldType, "bigint") &&
 		strings.EqualFold(newType, "timestamp without time zone") {
 		return Statement{
-			DDL: fmt.Sprintf("%s SET DATA TYPE %s using to_timestamp(%s / 1000)",
+			DDL: fmt.Sprintf("%s SET DATA TYPE %s using pg_catalog.to_timestamp(%s::pg_catalog.float8 OPERATOR(pg_catalog./) 1000.0::pg_catalog.float8)",
 				csg.alterColumnPrefix(col),
 				newType,
 				schema.EscapeIdentifier(col.Name),


### PR DESCRIPTION
## Summary

When migrating a `bigint` column to `timestamp without time zone`, pg-schema-diff emits a `to_timestamp()` call in the `ALTER COLUMN ... USING` clause. An unqualified call resolves via `search_path`, so a user with `CREATE` on a schema can plant shadow functions that run during apply instead of the built-ins (CVE-2018-1058). On a default Postgres install, `search_path` is `"$user", public, pg_catalog` — `public` is already searched before `pg_catalog`.

**Fix:** emit a fully qualified expression:

```sql
pg_catalog.to_timestamp(
  col::pg_catalog.float8 OPERATOR(pg_catalog./) 1000.0::pg_catalog.float8
)
```

The shadow acceptance case plants `public.to_timestamp(double precision)` because the fixed emission passes **float8** to `to_timestamp` (not bigint). That matches the overload that would win if `pg_catalog.` qualification were removed while keeping the float8 casts. The original pre-fix emission `to_timestamp(col / 1000)` uses bigint division and is covered by the "without fix" evidence below.

## Evidence of vulnerability without fix

Reverted `generateTypeTransformationStatement` to pre-fix emission (`to_timestamp(col / 1000)`) and ran the shadow acceptance test locally (PostgreSQL 14.15 via pgengine, default `search_path`).

```
ERROR:  pwnd
STATEMENT:  ... using to_timestamp("some_time_col" / 1000);

    acceptance_test.go:182: ERROR: pwnd (SQLSTATE P0001)
--- FAIL: TestColumnTestCases/Change_BIGINT_to_TIMESTAMP_(ignores_shadowed_to_timestamp_in_USING)
```

Unqualified `to_timestamp()` in the emitted `USING` clause invokes the planted shadow during apply.

The validate case asserts qualified DDL in `expectedPlanDDL`; without the fix the generator emits `using to_timestamp("some_time_col" / 1000)`.

## Evidence of tests passing with fix

Restored the fix and re-ran both acceptance tests locally (PostgreSQL 14.23 via pgengine, `pg_dump` 14.23 with `--restrict-key`, default `search_path`):

```bash
export PATH="/opt/homebrew/opt/postgresql@14/bin:$PATH"
go test ./internal/migration_acceptance_tests/... \
  -run 'TestColumnTestCases/Change_BIGINT_to_TIMESTAMP' -count=1 -v
```

```
=== RUN   TestColumnTestCases/Change_BIGINT_to_TIMESTAMP_(validate_conversion_and_ANALYZE)
=== RUN   TestColumnTestCases/Change_BIGINT_to_TIMESTAMP_(ignores_shadowed_to_timestamp_in_USING)
--- PASS: TestColumnTestCases (0.00s)
    --- PASS: TestColumnTestCases/Change_BIGINT_to_TIMESTAMP_(validate_conversion_and_ANALYZE) (1.92s)
    --- PASS: TestColumnTestCases/Change_BIGINT_to_TIMESTAMP_(ignores_shadowed_to_timestamp_in_USING) (1.92s)
PASS
ok  	github.com/stripe/pg-schema-diff/internal/migration_acceptance_tests	4.943s
```

Both cases pass the full acceptance harness: **plan → apply → pg_dump schema compare**. Apply succeeds with no `ERROR: pwnd` in Postgres logs (the shadow is not invoked).

CI `run_tests` (PG 14, 15, 16, 17) passed on `490295f` and `794276a`.

## Tests

- **Change BIGINT to TIMESTAMP (validate conversion and ANALYZE)** — `expectedPlanDDL` for qualified emission + ANALYZE
- **Change BIGINT to TIMESTAMP (ignores shadowed to_timestamp in USING)** — planted `public.to_timestamp(double precision)` + row data; apply succeeds only with the fix

```bash
go test ./internal/migration_acceptance_tests/... \
  -run 'TestColumnTestCases/Change_BIGINT_to_TIMESTAMP' -count=1
```

## Test plan

- [x] Standard bigint→timestamp case asserts plan DDL + ANALYZE
- [x] Shadow case verifies apply succeeds against planted `public.to_timestamp(double precision)` on default search_path
- [x] Verified shadow case fails with `pwnd` when fix is reverted to `to_timestamp(col / 1000)`
- [x] Local acceptance tests pass end-to-end on PG 14.23 (plan/apply/pgdump)
- [x] CI green on PG 14–17