### PR TITLE
Removed "early stages" note from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,5 +214,5 @@ An abridged list of unsupported migrations:
 an object, it will be treated as a drop and an add
 
 # Contributing
-This project is in its early stages. We appreciate all the feature/bug requests we receive, but we have limited cycles
+We appreciate all the feature/bug requests we receive, but we have limited cycles
 to review direct code contributions at this time. See [Contributing](CONTRIBUTING.md) to learn more.


### PR DESCRIPTION

<!-- README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed -->

### Description
After nearly a year in Github, and having hit the 1.x milestone, it seems reasonable to remove the "early stages" note. It seems to be running smoothly and largely as described.

### Motivation
The software seems to be at a relatively mature stage; it runs as expected and has not had any major changes in usage/functionality. Removing "early stages" seems more correct, and also may serve to avoid raising incorrect concerns about instability, etc.

### Testing
N/A