### PR TITLE
Fix multiline expression index handling

### DIFF
--- a/internal/migration_acceptance_tests/index_cases_test.go
+++ b/internal/migration_acceptance_tests/index_cases_test.go
@@ -133,6 +133,33 @@ var indexAcceptanceTestCases = []acceptanceTestCase{
 		},
 	},
 	{
+		name: "Add a multiline expression index",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE index_test (
+                flag BOOLEAN,
+                value1 TEXT,
+                value2 TEXT
+            );
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE index_test (
+                flag BOOLEAN,
+                value1 TEXT,
+                value2 TEXT
+            );
+            CREATE INDEX ix_test ON index_test ((
+                CASE WHEN flag THEN value1 ELSE value2 END
+            ));
+			`,
+		},
+		expectedHazardTypes: []diff.MigrationHazardType{
+			diff.MigrationHazardTypeIndexBuild,
+		},
+	},
+	{
 		name: "Add a unique index",
 		oldSchemaDDL: []string{
 			`

--- a/internal/migration_acceptance_tests/index_no_concurrent_cases_test.go
+++ b/internal/migration_acceptance_tests/index_no_concurrent_cases_test.go
@@ -56,6 +56,35 @@ var indexNoConcurrentAcceptanceTestCases = []acceptanceTestCase{
 		},
 		planOpts: []diff.PlanOpt{diff.WithNoConcurrentIndexOps()},
 	},
+	{
+		name: "Alter table with existing multiline expression index",
+		oldSchemaDDL: []string{
+			`
+            CREATE TABLE index_test (
+                flag BOOLEAN,
+                value1 TEXT,
+                value2 TEXT
+            );
+            CREATE INDEX ix_test ON index_test ((
+                CASE WHEN flag THEN value1 ELSE value2 END
+            ));
+			`,
+		},
+		newSchemaDDL: []string{
+			`
+            CREATE TABLE index_test (
+                flag BOOLEAN,
+                value1 TEXT,
+                value2 TEXT,
+                value3 TEXT
+            );
+            CREATE INDEX ix_test ON index_test ((
+                CASE WHEN flag THEN value1 ELSE value2 END
+            ));
+			`,
+		},
+		planOpts: []diff.PlanOpt{diff.WithNoConcurrentIndexOps()},
+	},
 }
 
 func TestIndexNoConcurrentTestCases(t *testing.T) {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -319,7 +319,7 @@ var (
 	// because only UNIQUE indices will have the UNIQUE keyword in their pg_get_indexdef statement
 	//
 	// The third matching group is the rest of the statement
-	idxToConcurrentlyRegex = regexp.MustCompile("^(CREATE (UNIQUE )?INDEX )(.*)$")
+	idxToConcurrentlyRegex = regexp.MustCompile("(?s)^(CREATE (UNIQUE )?INDEX )(.*)$")
 )
 
 // GetIndexDefStatement is the output of pg_getindexdef. It is a `CREATE INDEX` statement that will re-create

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -1382,6 +1382,15 @@ func TestIdxDefStmtToCreateIdxConcurrently(t *testing.T) {
 			out:     `CREATE UNIQUE INDEX CONCURRENTLY "CREATE INDEX ON" ON public.foobar USING btree (foo)`,
 		},
 		{
+			name: "multiline expression index",
+			defStmt: `CREATE INDEX ix_test ON public.index_test USING btree ((
+    CASE WHEN flag THEN value1 ELSE value2 END
+))`,
+			out: `CREATE INDEX CONCURRENTLY ix_test ON public.index_test USING btree ((
+    CASE WHEN flag THEN value1 ELSE value2 END
+))`,
+		},
+		{
 			name:      "case sensitive",
 			defStmt:   `CREATE uNIQUE INDEX foobar ON public.foobar USING btree (foo)`,
 			expectErr: true,


### PR DESCRIPTION
### Description

`pg_get_indexdef` can preserve newlines inside expression index definitions. The existing anchored rewrite uses `.*`, which does not match newlines in Go, so converting a valid definition to `CREATE INDEX CONCURRENTLY` fails. The same conversion is also used while validating plans with concurrent index operations disabled.

This change enables dot-all matching only for the existing regex, preserving its anchors, case sensitivity, and exact `CREATE [UNIQUE] INDEX ` prefix. It adds regression coverage for:

- the direct statement conversion;
- adding a multiline expression index through the default concurrent path;
- validating a migration with an existing multiline expression index under `WithNoConcurrentIndexOps()`.

### Testing

- `GOTOOLCHAIN=go1.25.5 go test -race ./... -timeout 30m`
- focused conversion test, 100 repetitions
- both PostgreSQL 17.10 acceptance scenarios, 10 repetitions
- `golangci-lint v2.7.0 run`
- `go vet ./...`
- `sqlfluff 3.3.0 lint`
- `gofmt`, `go mod tidy -diff`, and `git diff --check`

The commit is GitHub Verified.

Fixes #253