### PR TITLE
Fix typo in prohibited hazards error message

### DIFF
--- a/cmd/pg-schema-diff/apply_cmd.go
+++ b/cmd/pg-schema-diff/apply_cmd.go
@@ -111,7 +111,7 @@ func failIfHazardsNotAllowed(plan diff.Plan, allowedHazardsTypesStrs []string) e
 
 	}
 	if len(disallowedHazardMsgs) > 0 {
-		return fmt.Errorf("prohited hazards found\n"+
+		return fmt.Errorf("prohibited hazards found\n"+
 			"These hazards must be allowed via the allow-hazards flag, e.g., --allow-hazards %s\n"+
 			"Prohibited hazards in the following statements:\n%s",
 			strings.Join(getHazardTypes(plan), ","),


### PR DESCRIPTION
<!-- README: Ensure you've read the CONTRIBUTING.MD and that your commits are signed -->

### Description
Fixes the misspelling `prohited` to `prohibited` in the apply command hazard error text in `cmd/pg-schema-diff/apply_cmd.go`.

### Motivation
The error message currently reads "prohited hazards found", which is a typo for "prohibited".

Fixes #302

### Testing
Confirmed the misspelling only appears in that error string; this is a one-word message change.